### PR TITLE
Add native clipboard history clear actions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { ClipList } from './components/ClipList';
 import { ContentFilter, FlyoutHeader } from './components/FlyoutHeader';
 import { ContextMenu } from './components/ContextMenu';
 import { FolderModal } from './components/FolderModal';
+import { ConfirmDialog } from './components/ConfirmDialog';
 import { useKeyboard } from './hooks/useKeyboard';
 import { useTheme } from './hooks/useTheme';
 import { useLanguage } from './hooks/useLanguage';
@@ -52,6 +53,14 @@ function App() {
   const [theme, setTheme] = useState('system');
   const [settings, setSettings] = useState<Settings | null>(null);
   const [pasteContext, setPasteContext] = useState<PasteContext | null>(null);
+  const [contextMenu, setContextMenu] = useState<{
+    type: 'card' | 'folder' | 'history';
+    x: number;
+    y: number;
+    itemId: string;
+  } | null>(null);
+  const [clearRequest, setClearRequest] = useState<'unpinned' | 'all' | null>(null);
+  const [isClearing, setIsClearing] = useState(false);
 
   // Add Folder Modal State
   const [showAddFolderModal, setShowAddFolderModal] = useState(false);
@@ -440,6 +449,7 @@ function App() {
 
   useEffect(() => {
     const focusSearchOnTyping = (event: KeyboardEvent) => {
+      if (contextMenu || clearRequest || showAddFolderModal) return;
       const target = event.target as HTMLElement | null;
       const isEditing =
         target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || target?.isContentEditable;
@@ -456,7 +466,7 @@ function App() {
 
     document.addEventListener('keydown', focusSearchOnTyping);
     return () => document.removeEventListener('keydown', focusSearchOnTyping);
-  }, []);
+  }, [clearRequest, contextMenu, showAddFolderModal]);
 
   const handleNavigateUp = useCallback(() => {
     if (visibleClips.length === 0) return;
@@ -506,6 +516,7 @@ function App() {
   }, [selectedClipId, handleCopy]);
 
   useKeyboard({
+    disabled: Boolean(contextMenu || clearRequest || showAddFolderModal),
     onClose: () => {
       if (searchQuery) {
         setSearchQuery('');
@@ -564,14 +575,6 @@ function App() {
     }
   }, [hasMore, isLoading, selectedFolder, loadClips, searchQuery]);
 
-  // Context Menu State
-  const [contextMenu, setContextMenu] = useState<{
-    type: 'card' | 'folder';
-    x: number;
-    y: number;
-    itemId: string;
-  } | null>(null);
-
   // New Folder Modal Rename Mode
   const [folderModalMode, setFolderModalMode] = useState<'create' | 'rename'>('create');
   const [editingFolderId, setEditingFolderId] = useState<string | null>(null);
@@ -588,6 +591,16 @@ function App() {
     },
     []
   );
+
+  const handleHistoryMenu = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    setContextMenu({
+      type: 'history',
+      x: rect.right,
+      y: rect.bottom + 4,
+      itemId: '',
+    });
+  }, []);
 
   const handleCloseContextMenu = useCallback(() => {
     setContextMenu(null);
@@ -630,6 +643,36 @@ function App() {
     }
   };
 
+  const handleClearClips = async (mode: 'unpinned' | 'all') => {
+    if (isClearing) return;
+    setIsClearing(true);
+    try {
+      const deleted =
+        mode === 'unpinned'
+          ? await invoke<number>('clear_unpinned_clips')
+          : (await invoke('clear_all_clips'), totalClipCount);
+
+      setSelectedClipId(null);
+      setClipListResetToken((token) => token + 1);
+      await Promise.all([
+        loadClips(selectedFolder, false, searchQuery),
+        loadFolders(),
+        refreshTotalCount(),
+      ]);
+      toast.success(
+        mode === 'unpinned'
+          ? t('notifications.clearUnpinnedSuccess', { count: deleted })
+          : t('notifications.clearAllSuccess')
+      );
+      setClearRequest(null);
+    } catch (error) {
+      console.error('Failed to clear clipboard history:', error);
+      toast.error(t('notifications.clearFailed'));
+    } finally {
+      setIsClearing(false);
+    }
+  };
+
   return (
     <div
       data-el="app-root"
@@ -646,72 +689,110 @@ function App() {
               y={contextMenu.y}
               onClose={handleCloseContextMenu}
               options={
-                contextMenu.type === 'card'
-                  ? (() => {
-                      const clip = clips.find((item) => item.id === contextMenu.itemId);
-                      return [
+                contextMenu.type === 'history'
+                  ? [
+                      {
+                        label: t('contextMenu.clearUnpinned'),
+                        disabled: totalClipCount === 0,
+                        onClick: () => setClearRequest('unpinned'),
+                      },
+                      {
+                        label: t('contextMenu.clearAll'),
+                        danger: true,
+                        disabled: totalClipCount === 0,
+                        onClick: () => setClearRequest('all'),
+                      },
+                    ]
+                  : contextMenu.type === 'card'
+                    ? (() => {
+                        const clip = clips.find((item) => item.id === contextMenu.itemId);
+                        return [
+                          {
+                            label: clip?.is_pinned ? 'Unpin' : 'Pin',
+                            onClick: () => handleTogglePin(contextMenu.itemId),
+                          },
+                          {
+                            label: t('contextMenu.paste'),
+                            onClick: () => handlePaste(contextMenu.itemId),
+                          },
+                          {
+                            label: t('contextMenu.pastePlainText'),
+                            disabled: clip?.clip_type === 'image',
+                            onClick: () => handlePaste(contextMenu.itemId, true),
+                          },
+                          {
+                            label: t('contextMenu.copy'),
+                            onClick: () => handleCopy(contextMenu.itemId),
+                          },
+                          {
+                            label: t('contextMenu.copyPlainText'),
+                            disabled: clip?.clip_type === 'image',
+                            onClick: () => handleCopy(contextMenu.itemId, true),
+                          },
+                          ...(clip?.folder_id
+                            ? [
+                                {
+                                  label: 'Remove from folder',
+                                  onClick: () => handleMoveClip(contextMenu.itemId, null),
+                                },
+                              ]
+                            : []),
+                          ...folders.map((folder) => ({
+                            label: `Move to ${folder.name}`,
+                            disabled: clip?.folder_id === folder.id,
+                            onClick: () => handleMoveClip(contextMenu.itemId, folder.id),
+                          })),
+                          {
+                            label: t('contextMenu.delete'),
+                            danger: true,
+                            onClick: () => handleDelete(contextMenu.itemId),
+                          },
+                        ];
+                      })()
+                    : [
                         {
-                          label: clip?.is_pinned ? 'Unpin' : 'Pin',
-                          onClick: () => handleTogglePin(contextMenu.itemId),
+                          label: t('contextMenu.rename'),
+                          onClick: () => {
+                            setFolderModalMode('rename');
+                            setEditingFolderId(contextMenu.itemId);
+                            const folder = folders.find((f) => f.id === contextMenu.itemId);
+                            setNewFolderName(folder ? folder.name : '');
+                            setShowAddFolderModal(true);
+                          },
                         },
-                        {
-                          label: t('contextMenu.paste'),
-                          onClick: () => handlePaste(contextMenu.itemId),
-                        },
-                        {
-                          label: t('contextMenu.pastePlainText'),
-                          disabled: clip?.clip_type === 'image',
-                          onClick: () => handlePaste(contextMenu.itemId, true),
-                        },
-                        {
-                          label: t('contextMenu.copy'),
-                          onClick: () => handleCopy(contextMenu.itemId),
-                        },
-                        {
-                          label: t('contextMenu.copyPlainText'),
-                          disabled: clip?.clip_type === 'image',
-                          onClick: () => handleCopy(contextMenu.itemId, true),
-                        },
-                        ...(clip?.folder_id
-                          ? [
-                              {
-                                label: 'Remove from folder',
-                                onClick: () => handleMoveClip(contextMenu.itemId, null),
-                              },
-                            ]
-                          : []),
-                        ...folders.map((folder) => ({
-                          label: `Move to ${folder.name}`,
-                          disabled: clip?.folder_id === folder.id,
-                          onClick: () => handleMoveClip(contextMenu.itemId, folder.id),
-                        })),
                         {
                           label: t('contextMenu.delete'),
                           danger: true,
-                          onClick: () => handleDelete(contextMenu.itemId),
+                          onClick: () => handleDeleteFolder(contextMenu.itemId),
                         },
-                      ];
-                    })()
-                  : [
-                      {
-                        label: t('contextMenu.rename'),
-                        onClick: () => {
-                          setFolderModalMode('rename');
-                          setEditingFolderId(contextMenu.itemId);
-                          const folder = folders.find((f) => f.id === contextMenu.itemId);
-                          setNewFolderName(folder ? folder.name : '');
-                          setShowAddFolderModal(true);
-                        },
-                      },
-                      {
-                        label: t('contextMenu.delete'),
-                        danger: true,
-                        onClick: () => handleDeleteFolder(contextMenu.itemId),
-                      },
-                    ]
+                      ]
               }
             />
           )}
+
+          <ConfirmDialog
+            isOpen={clearRequest !== null}
+            title={
+              clearRequest === 'all' ? t('clearHistory.allTitle') : t('clearHistory.unpinnedTitle')
+            }
+            message={
+              clearRequest === 'all'
+                ? t('clearHistory.allMessage')
+                : t('clearHistory.unpinnedMessage')
+            }
+            confirmText={
+              isClearing
+                ? t('clearHistory.clearing')
+                : clearRequest === 'all'
+                  ? t('clearHistory.confirmAll')
+                  : t('clearHistory.confirmUnpinned')
+            }
+            isBusy={isClearing}
+            onConfirm={() => {
+              if (clearRequest) void handleClearClips(clearRequest);
+            }}
+            onCancel={() => setClearRequest(null)}
+          />
 
           <FlyoutHeader
             searchQuery={searchQuery}
@@ -730,6 +811,7 @@ function App() {
               setNewFolderName('');
               setShowAddFolderModal(true);
             }}
+            onOpenHistoryMenu={handleHistoryMenu}
             onOpenSettings={openSettings}
           />
 

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -11,6 +11,7 @@ interface ConfirmDialogProps {
   onConfirm: () => void;
   onCancel: () => void;
   variant?: 'danger' | 'warning' | 'info';
+  isBusy?: boolean;
 }
 
 export function ConfirmDialog({
@@ -22,18 +23,19 @@ export function ConfirmDialog({
   onConfirm,
   onCancel,
   variant = 'danger',
+  isBusy = false,
 }: ConfirmDialogProps) {
   const { t } = useTranslation();
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onCancel();
+      if (e.key === 'Escape' && !isBusy) onCancel();
     };
     if (isOpen) {
       window.addEventListener('keydown', handleEscape);
     }
     return () => window.removeEventListener('keydown', handleEscape);
-  }, [isOpen, onCancel]);
+  }, [isOpen, isBusy, onCancel]);
 
   if (!isOpen) return null;
 
@@ -53,7 +55,11 @@ export function ConfirmDialog({
             </div>
             <h3 className="text-lg font-semibold">{title}</h3>
           </div>
-          <button onClick={onCancel} className="text-muted-foreground hover:text-foreground">
+          <button
+            onClick={onCancel}
+            disabled={isBusy}
+            className="text-muted-foreground hover:text-foreground disabled:opacity-40"
+          >
             <X size={18} />
           </button>
         </div>
@@ -63,13 +69,15 @@ export function ConfirmDialog({
         <div className="flex justify-end gap-3">
           <button
             onClick={onCancel}
-            className="rounded-md border border-input bg-transparent px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground"
+            disabled={isBusy}
+            className="rounded-md border border-input bg-transparent px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground disabled:opacity-40"
           >
             {cancelText || t('common.cancel')}
           </button>
           <button
             onClick={onConfirm}
-            className={`rounded-md px-4 py-2 text-sm font-medium text-white transition-colors ${
+            disabled={isBusy}
+            className={`rounded-md px-4 py-2 text-sm font-medium text-white transition-colors disabled:opacity-60 ${
               variant === 'danger'
                 ? 'bg-destructive hover:bg-destructive/90'
                 : 'bg-primary hover:bg-primary/90'

--- a/frontend/src/components/FlyoutHeader.tsx
+++ b/frontend/src/components/FlyoutHeader.tsx
@@ -1,5 +1,5 @@
 import { FolderItem } from '../types';
-import { ChevronDown, Filter, Plus, Search, Settings2, X } from 'lucide-react';
+import { ChevronDown, Filter, MoreHorizontal, Plus, Search, Settings2, X } from 'lucide-react';
 
 export type ContentFilter = 'all' | 'text' | 'images';
 
@@ -12,6 +12,7 @@ interface FlyoutHeaderProps {
   selectedFolder: string | null;
   onSelectFolder: (folderId: string | null) => void;
   onAddFolder: () => void;
+  onOpenHistoryMenu: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onOpenSettings: () => void;
 }
 
@@ -24,6 +25,7 @@ export function FlyoutHeader({
   selectedFolder,
   onSelectFolder,
   onAddFolder,
+  onOpenHistoryMenu,
   onOpenSettings,
 }: FlyoutHeaderProps) {
   return (
@@ -106,6 +108,15 @@ export function FlyoutHeader({
             title="New folder"
           >
             <Plus size={15} />
+          </button>
+          <button
+            type="button"
+            onClick={onOpenHistoryMenu}
+            className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-white/[0.07] hover:text-foreground"
+            title="Clipboard history actions"
+            aria-label="Clipboard history actions"
+          >
+            <MoreHorizontal size={15} />
           </button>
           <button
             type="button"

--- a/frontend/src/hooks/useKeyboard.ts
+++ b/frontend/src/hooks/useKeyboard.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 interface KeyboardOptions {
+  disabled?: boolean;
   onClose?: () => void;
   onSearch?: () => void;
   onDelete?: () => void;
@@ -24,6 +25,7 @@ export function useKeyboard(options: KeyboardOptions) {
       if (e.isComposing) return;
 
       const current = optionsRef.current;
+      if (current.disabled) return;
       const target = e.target as HTMLElement | null;
       const isEditing =
         target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || target?.isContentEditable;

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -42,6 +42,8 @@
     "copyPlainText": "Copy as plain text",
     "pastePlainText": "Paste as plain text",
     "delete": "Delete",
+    "clearUnpinned": "Clear unpinned items…",
+    "clearAll": "Clear everything…",
     "rename": "Rename",
     "moveToFolder": "Move to Folder",
     "summarize": "Summarize (AI)",
@@ -147,6 +149,19 @@
     "clipDeleteFailed": "Failed to delete clip",
     "folderDeleteFailed": "Failed to delete folder",
     "folderRenameFailed": "Failed to rename folder",
-    "copyFailed": "Failed to copy"
+    "copyFailed": "Failed to copy",
+    "clearUnpinnedSuccess_one": "Cleared {{count}} unpinned item",
+    "clearUnpinnedSuccess_other": "Cleared {{count}} unpinned items",
+    "clearAllSuccess": "Clipboard history cleared",
+    "clearFailed": "Failed to clear clipboard history"
+  },
+  "clearHistory": {
+    "unpinnedTitle": "Clear unpinned items?",
+    "unpinnedMessage": "Remove every unpinned item from Cubby? Your pinned items will stay.",
+    "allTitle": "Clear everything?",
+    "allMessage": "Remove every item from Cubby, including pinned items? This cannot be undone.",
+    "confirmUnpinned": "Clear unpinned",
+    "confirmAll": "Clear everything",
+    "clearing": "Clearing…"
   }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -94,21 +94,6 @@ async fn cleanup_orphan_clip_image_files(pool: &SqlitePool) -> Result<(), String
     Ok(())
 }
 
-async fn cleanup_all_clip_image_files(pool: &SqlitePool) -> Result<(), String> {
-    let all_paths: Vec<Option<String>> = sqlx::query_scalar(r#"SELECT file_path FROM clip_images"#)
-        .fetch_all(pool)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    for path in all_paths.into_iter().flatten() {
-        if !path.is_empty() {
-            crate::clipboard::remove_full_image_file(&path);
-        }
-    }
-
-    Ok(())
-}
-
 pub async fn migrate_images_to_files(pool: &SqlitePool) -> Result<(), String> {
     log::info!("Starting background image migration...");
 
@@ -898,20 +883,72 @@ pub async fn clear_clipboard_history(db: tauri::State<'_, Arc<Database>>) -> Res
     Ok(())
 }
 
+async fn clear_clips_in_pool(
+    pool: &SqlitePool,
+    preserve_pinned: bool,
+) -> Result<(u64, Vec<String>), String> {
+    let clip_filter = if preserve_pinned {
+        "is_pinned = 0 OR is_deleted = 1"
+    } else {
+        "1 = 1"
+    };
+    let image_filter = if preserve_pinned {
+        "clip_uuid NOT IN (SELECT uuid FROM clips WHERE is_pinned = 1 AND is_deleted = 0)"
+    } else {
+        "1 = 1"
+    };
+    let image_paths_sql = format!("SELECT file_path FROM clip_images WHERE {image_filter}");
+    let delete_images_sql = format!("DELETE FROM clip_images WHERE {image_filter}");
+    let delete_clips_sql = format!("DELETE FROM clips WHERE {clip_filter}");
+
+    let mut transaction = pool.begin().await.map_err(|error| error.to_string())?;
+    let image_paths: Vec<Option<String>> = sqlx::query_scalar(&image_paths_sql)
+        .fetch_all(&mut *transaction)
+        .await
+        .map_err(|error| error.to_string())?;
+
+    sqlx::query(&delete_images_sql)
+        .execute(&mut *transaction)
+        .await
+        .map_err(|error| error.to_string())?;
+    let deleted = sqlx::query(&delete_clips_sql)
+        .execute(&mut *transaction)
+        .await
+        .map_err(|error| error.to_string())?
+        .rows_affected();
+
+    transaction
+        .commit()
+        .await
+        .map_err(|error| error.to_string())?;
+
+    Ok((
+        deleted,
+        image_paths
+            .into_iter()
+            .flatten()
+            .filter(|path| !path.is_empty())
+            .collect(),
+    ))
+}
+
+fn remove_clip_image_files(image_paths: Vec<String>) {
+    for path in image_paths {
+        crate::clipboard::remove_full_image_file(&path);
+    }
+}
+
+#[tauri::command]
+pub async fn clear_unpinned_clips(db: tauri::State<'_, Arc<Database>>) -> Result<u64, String> {
+    let (deleted, image_paths) = clear_clips_in_pool(&db.pool, true).await?;
+    remove_clip_image_files(image_paths);
+    Ok(deleted)
+}
+
 #[tauri::command]
 pub async fn clear_all_clips(db: tauri::State<'_, Arc<Database>>) -> Result<(), String> {
-    let pool = &db.pool;
-
-    cleanup_all_clip_image_files(pool).await?;
-
-    sqlx::query(r#"DELETE FROM clip_images"#)
-        .execute(pool)
-        .await
-        .map_err(|e| e.to_string())?;
-    sqlx::query(r#"DELETE FROM clips"#)
-        .execute(pool)
-        .await
-        .map_err(|e| e.to_string())?;
+    let (_, image_paths) = clear_clips_in_pool(&db.pool, false).await?;
+    remove_clip_image_files(image_paths);
     Ok(())
 }
 
@@ -1042,7 +1079,7 @@ pub fn get_system_accent_color() -> Result<serde_json::Value, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::toggle_clip_pin_in_pool;
+    use super::{clear_clips_in_pool, toggle_clip_pin_in_pool};
     use crate::database::Database;
     use sqlx::sqlite::SqlitePoolOptions;
 
@@ -1080,5 +1117,71 @@ mod tests {
             toggle_clip_pin_in_pool(&database.pool, "missing").await,
             Err("Clipboard item not found".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn bulk_clear_preserves_only_active_pinned_clips() {
+        let database = test_database().await;
+        for (uuid, pinned, deleted) in [
+            ("pinned", 1, 0),
+            ("ordinary", 0, 0),
+            ("deleted-pinned", 1, 1),
+        ] {
+            sqlx::query(
+                r#"
+                INSERT INTO clips
+                    (uuid, clip_type, content, text_preview, content_hash, is_pinned, is_deleted)
+                VALUES (?, 'image', X'', ?, ?, ?, ?)
+                "#,
+            )
+            .bind(uuid)
+            .bind(uuid)
+            .bind(format!("hash-{uuid}"))
+            .bind(pinned)
+            .bind(deleted)
+            .execute(&database.pool)
+            .await
+            .expect("clip should be inserted");
+
+            sqlx::query(
+                r#"
+                INSERT INTO clip_images (clip_uuid, full_content, file_path)
+                VALUES (?, X'', ?)
+                "#,
+            )
+            .bind(uuid)
+            .bind(format!("{uuid}.png"))
+            .execute(&database.pool)
+            .await
+            .expect("image metadata should be inserted");
+        }
+        let (deleted, image_paths) = clear_clips_in_pool(&database.pool, true)
+            .await
+            .expect("clear should succeed");
+        assert_eq!(deleted, 2);
+        assert_eq!(image_paths.len(), 2);
+
+        let remaining_clips: Vec<String> =
+            sqlx::query_scalar("SELECT uuid FROM clips ORDER BY uuid")
+                .fetch_all(&database.pool)
+                .await
+                .expect("remaining clips should load");
+        let remaining_images: Vec<String> =
+            sqlx::query_scalar("SELECT clip_uuid FROM clip_images ORDER BY clip_uuid")
+                .fetch_all(&database.pool)
+                .await
+                .expect("remaining image metadata should load");
+        assert_eq!(remaining_clips, vec!["pinned"]);
+        assert_eq!(remaining_images, vec!["pinned"]);
+
+        let (deleted, _) = clear_clips_in_pool(&database.pool, false)
+            .await
+            .expect("full clear should succeed");
+        assert_eq!(deleted, 1);
+        let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM clips")
+            .fetch_one(&database.pool)
+            .await
+            .expect("clip count should load");
+        assert_eq!(remaining, 0);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -373,6 +373,7 @@ pub fn run_app() {
             commands::hide_window,
             commands::get_clipboard_history_size,
             commands::clear_clipboard_history,
+            commands::clear_unpinned_clips,
             commands::clear_all_clips,
             commands::remove_duplicate_clips,
             commands::register_global_shortcut,


### PR DESCRIPTION
## What changed

- adds a compact clipboard-history overflow menu to the flyout
- adds **Clear unpinned items** (the native-style default) and an explicit **Clear everything** action
- confirms both irreversible bulk actions and pauses global flyout shortcuts while menus or dialogs are open
- clears clip rows and image metadata transactionally, then removes persisted image files after commit
- keeps active pinned clips while removing unpinned and previously deleted items

## Why

Cubby already exposed a settings-only full-history delete, but it did not preserve pinned items and was not available from the clipboard flyout. This closes the main Windows clipboard-history parity gap without making accidental data loss easy.

## Validation

- `npm run format:check`
- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml --all-targets` (39 tests)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`

Linear: SOU-207