### PR TITLE
Polish clipboard history empty and error states

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Cubby began as a fork of [PastePaw](https://github.com/XueshiQiao/PastePaw), whi
 
 The inherited shell is being evaluated against a WinUI 3 prototype. Tauri is not a permanent architecture decision; Cubby will use the option that best meets the Windows focus, accessibility, rendering, performance, and packaging requirements.
 
+## Relationship to Win+V
+
+Cubby is designed as a focused replacement for Windows Clipboard History, not for every panel bundled into the Windows `Win+V` surface.
+
+- Cubby uses `Win+V` by default and can release it in Settings. `Win+Period` remains the Windows shortcut for emoji, GIF, kaomoji, and symbol pickers.
+- Selecting a clip pastes it into the previously focused app. In supported remote-control tools, Cubby may restore the synchronized clipboard and ask for a final `Ctrl+V` so large logs are not typed character by character.
+- Clearing history preserves pinned clips by default. A separate confirmed action clears everything, including pins.
+- History is local, searchable, and intended to extend well beyond Windows Clipboard History's short retention window.
+- Cloud sync is intentionally absent until it can be offered with clear privacy and encryption guarantees.
+
 ## Development
 
 Requirements:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,6 +49,7 @@ function App() {
   const [selectedClipId, setSelectedClipId] = useState<string | null>(null);
   const [clipListResetToken, setClipListResetToken] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const [theme, setTheme] = useState('system');
   const [settings, setSettings] = useState<Settings | null>(null);
@@ -189,6 +190,7 @@ function App() {
 
       try {
         setIsLoading(true);
+        setLoadError(false);
 
         const currentOffset = append ? clips.length : 0;
 
@@ -261,6 +263,8 @@ function App() {
         }
       } catch (error) {
         console.error('Failed to load clips:', error);
+        setLoadError(true);
+        setHasMore(false);
       } finally {
         setIsLoading(false);
       }
@@ -436,6 +440,58 @@ function App() {
       }),
     [clips, contentFilter]
   );
+
+  const emptyState = useMemo(() => {
+    if (searchQuery.trim()) {
+      return {
+        title: t('clipList.noMatches'),
+        description: t('clipList.noMatchesDesc'),
+      };
+    }
+    if (selectedFolder) {
+      return {
+        title: t('clipList.emptyFolder'),
+        description: t('clipList.emptyFolderDesc'),
+      };
+    }
+    if (contentFilter === 'images') {
+      return {
+        title: t('clipList.noImages'),
+        description: t('clipList.noImagesDesc'),
+      };
+    }
+    if (contentFilter === 'text') {
+      return {
+        title: t('clipList.noText'),
+        description: t('clipList.noTextDesc'),
+      };
+    }
+    return {
+      title: t('clipList.empty'),
+      description: t('clipList.emptyDesc'),
+    };
+  }, [contentFilter, searchQuery, selectedFolder, t]);
+
+  useEffect(() => {
+    if (
+      contentFilter !== 'all' &&
+      clips.length > 0 &&
+      visibleClips.length === 0 &&
+      hasMore &&
+      !isLoading
+    ) {
+      loadClips(selectedFolder, true, searchQuery);
+    }
+  }, [
+    clips.length,
+    contentFilter,
+    hasMore,
+    isLoading,
+    loadClips,
+    searchQuery,
+    selectedFolder,
+    visibleClips.length,
+  ]);
 
   useEffect(() => {
     if (visibleClips.length === 0) {
@@ -821,16 +877,20 @@ function App() {
           >
             <ClipList
               clips={visibleClips}
-              isLoading={isLoading}
+              isLoading={isLoading || (visibleClips.length === 0 && hasMore)}
               hasMore={hasMore}
               resetToken={clipListResetToken}
               density={density}
               selectedClipId={selectedClipId}
+              loadError={loadError}
+              emptyTitle={emptyState.title}
+              emptyDescription={emptyState.description}
               onSelectClip={setSelectedClipId}
               onPaste={handlePaste}
               onCopy={handleCopy}
               onTogglePin={handleTogglePin}
               onLoadMore={loadMore}
+              onRetry={refreshCurrentFolder}
               onCardContextMenu={(e, clipId) => handleContextMenu(e, 'card', clipId)}
             />
 

--- a/frontend/src/components/ClipList.tsx
+++ b/frontend/src/components/ClipList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ClipboardItem } from '../types';
 import { ClipCard } from './ClipCard';
+import { AlertCircle, RefreshCw } from 'lucide-react';
 
 interface ClipListProps {
   clips: ClipboardItem[];
@@ -10,11 +11,15 @@ interface ClipListProps {
   resetToken: number;
   density: 'compact' | 'comfortable';
   selectedClipId: string | null;
+  loadError: boolean;
+  emptyTitle: string;
+  emptyDescription: string;
   onSelectClip: (clipId: string) => void;
   onPaste: (clipId: string) => void;
   onCopy: (clipId: string) => void;
   onTogglePin: (clipId: string) => void;
   onLoadMore: () => void;
+  onRetry: () => void;
   onCardContextMenu?: (e: React.MouseEvent, clipId: string) => void;
 }
 
@@ -25,11 +30,15 @@ export function ClipList({
   resetToken,
   density,
   selectedClipId,
+  loadError,
+  emptyTitle,
+  emptyDescription,
   onSelectClip,
   onPaste,
   onCopy,
   onTogglePin,
   onLoadMore,
+  onRetry,
   onCardContextMenu,
 }: ClipListProps) {
   const { t } = useTranslation();
@@ -55,10 +64,29 @@ export function ClipList({
   }
 
   if (clips.length === 0) {
+    if (loadError) {
+      return (
+        <div className="flex h-full flex-col items-center justify-center px-10 text-center">
+          <AlertCircle size={22} className="mb-3 text-destructive" />
+          <p className="text-sm font-medium text-foreground/90">{t('clipList.loadFailed')}</p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            {t('clipList.loadFailedDesc')}
+          </p>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="mt-4 flex items-center gap-1.5 rounded-md border border-white/[0.1] bg-white/[0.05] px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-white/[0.09]"
+          >
+            <RefreshCw size={13} />
+            {t('clipList.retry')}
+          </button>
+        </div>
+      );
+    }
     return (
       <div className="flex h-full flex-col items-center justify-center px-10 text-center">
-        <p className="text-sm font-medium text-foreground/80">{t('clipList.empty')}</p>
-        <p className="mt-1 text-xs leading-5 text-muted-foreground">{t('clipList.emptyDesc')}</p>
+        <p className="text-sm font-medium text-foreground/80">{emptyTitle}</p>
+        <p className="mt-1 text-xs leading-5 text-muted-foreground">{emptyDescription}</p>
       </div>
     );
   }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -15,6 +15,17 @@
   "clipList": {
     "empty": "No clips yet",
     "emptyDesc": "Copy something to your clipboard and it will appear here.",
+    "noMatches": "No matching clips",
+    "noMatchesDesc": "Try a different search or clear the current filters.",
+    "emptyFolder": "This folder is empty",
+    "emptyFolderDesc": "Move a clip here or choose another folder.",
+    "noImages": "No images in this view",
+    "noImagesDesc": "Copy an image or switch back to All.",
+    "noText": "No text in this view",
+    "noTextDesc": "Copy some text or switch back to All.",
+    "loadFailed": "Couldn’t load clipboard history",
+    "loadFailedDesc": "Cubby kept your data. Try loading it again.",
+    "retry": "Try again",
     "loadingClips": "Loading clips...",
     "imageSize": "Image ({{size}}KB)",
     "textLength": "{{count}} characters"


### PR DESCRIPTION
## What changed

- shows contextual empty states for search, folders, image filters, text filters, and genuinely empty history
- shows a visible, retryable history-load error instead of silently rendering an empty list
- continues paginating when a client-side content filter has no match in the first page, avoiding false empty states
- documents Cubby's intentional differences from the broader Windows Win+V surface

## Why

The flyout previously used the same “No clips yet” message for every empty result and only logged data-load failures to the console. That made filters look broken and could make a database error look like lost history.

## Validation

- `npm run format:check`
- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml --all-targets` (39 tests, before this frontend/docs-only commit)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`

Linear: SOU-207