### PR TITLE
Correct website comparison claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ The current upstream baseline has no meaningful automated tests. Adding a Window
 
 Remote-session capture is a first-class reliability target. Cubby must be tested with Windows Remote Desktop and representative third-party remote-control tools, including rapid sequential copies, delayed-rendered content, reconnects, and text, image, HTML, RTF, and file-list formats.
 
-Cubby includes a remote-session trigger and a Ninja Remote workflow optimized
-for large clipboard items. See [Remote-session behavior](docs/REMOTE_SESSIONS.md).
+Cubby includes a remote-session trigger and workflows optimized for remote
+desktop and remote support tools, including large clipboard items. See
+[Remote-session behavior](docs/REMOTE_SESSIONS.md).
 
 ## Repository layout
 

--- a/product_pages/index.html
+++ b/product_pages/index.html
@@ -129,7 +129,7 @@
         <div class="remote-copy">
           <p class="eyebrow">Remote work is real work</p>
           <h2>Built for the sessions Windows forgets.</h2>
-          <p>RDP and remote-control tools can make clipboard history unpredictable. Cubby treats those workflows as a core reliability target, with a remote-session mode designed for tools such as Ninja Remote and large clipboard items.</p>
+          <p>Remote desktop and remote support tools can make clipboard history unpredictable. Cubby treats those workflows as a core reliability target, with a remote-session mode designed for dependable clipboard sync and large items.</p>
           <ul class="check-list">
             <li><span aria-hidden="true">✓</span> Capture text and screenshots from remote sessions</li>
             <li><span aria-hidden="true">✓</span> Avoid slow character-by-character typing for large logs</li>
@@ -150,7 +150,7 @@
         <div class="comparison-row" role="row"><strong role="rowheader">Long local history</strong><span>Limited</span><span class="cubby-col">Built for it</span></div>
         <div class="comparison-row" role="row"><strong role="rowheader">Instant search</strong><span>—</span><span class="cubby-col">Included</span></div>
         <div class="comparison-row" role="row"><strong role="rowheader">Remote-session workflow</strong><span>Inconsistent</span><span class="cubby-col">First-class target</span></div>
-        <div class="comparison-row" role="row"><strong role="rowheader">Pinned-safe clearing</strong><span>—</span><span class="cubby-col">Included</span></div>
+        <div class="comparison-row" role="row"><strong role="rowheader">Pin important clips</strong><span>Included</span><span class="cubby-col">Included</span></div>
         <div class="comparison-row" role="row"><strong role="rowheader">Open source</strong><span>—</span><span class="cubby-col">GPL-3.0</span></div>
       </div>
       <p class="comparison-note">Cubby focuses on clipboard history. Windows still owns emoji, GIF, kaomoji, and symbol picking through <kbd>Win</kbd> + <kbd>.</kbd></p>


### PR DESCRIPTION
## What changed

- Replaced the named remote-support vendor in public copy with generic remote desktop and remote support language.
- Corrected the comparison table to show that both Windows Clipboard History and Cubby support pinning.
- Aligned the README overview with the vendor-neutral wording.

## Why

The landing page should avoid implying a vendor endorsement and should compare Cubby with Windows Clipboard History accurately.

## Validation

- `node .github/scripts/check-site.mjs`
- `git diff --check`
