### PR TITLE
Encrypt clipboard history at rest

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,6 +14,8 @@ Cubby release candidates must pass the JavaScript production dependency audit, t
 
 `scripts/audit-rust.ps1` permits this one lockfile-only advisory and fails if RSA becomes reachable on any target. The waiver must be removed if SQLx stops recording the inactive package or if Cubby enables another SQLx database driver.
 
-## Current development-build limitation
+## Clipboard history at rest
 
-Clipboard payloads are not yet encrypted at rest. Development builds must not be represented as suitable for retaining sensitive clipboard data until the encrypted-storage release gate is complete.
+Cubby encrypts clipboard payloads, previews, source attribution, metadata, and image files with AES-256-GCM. Dedupe values use a keyed HMAC rather than a plain content hash. The random storage key is protected for the current Windows user with DPAPI and is never stored in plaintext.
+
+Existing plaintext history is migrated before the clipboard listener starts. Cubby fails closed if the key cannot be unlocked or migration cannot complete, preventing new history from being mixed into an unreadable or partially encrypted store.

--- a/frontend/src/components/ClipCard.tsx
+++ b/frontend/src/components/ClipCard.tsx
@@ -1,7 +1,6 @@
 import { ClipboardItem } from '../types';
 import { clsx } from 'clsx';
 import { memo, useMemo } from 'react';
-import { convertFileSrc } from '@tauri-apps/api/core';
 import { Copy, File, Image as ImageIcon, MoreHorizontal, Pin } from 'lucide-react';
 import { formatDistanceToNowStrict } from 'date-fns';
 import { PREVIEW_CHAR_LIMIT } from '../constants';
@@ -84,9 +83,6 @@ export const ClipCard = memo(function ClipCard({
       value.startsWith('tauri://')
     ) {
       return value;
-    }
-    if (value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value)) {
-      return convertFileSrc(value);
     }
     return `data:image/png;base64,${value}`;
   }, [clip.clip_type, clip.content]);

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 const root = new URL('../', import.meta.url);
 const read = (path) => readFile(new URL(path, root), 'utf8');
 
-const [packageText, tauriText, cargoText, changelog, releaseWorkflow, capabilityText, clipboardSource] = await Promise.all([
+const [packageText, tauriText, cargoText, changelog, releaseWorkflow, capabilityText, clipboardSource, cryptoSource, databaseSource, commandSource, clipCardSource] = await Promise.all([
   read('package.json'),
   read('src-tauri/tauri.conf.json'),
   read('src-tauri/Cargo.toml'),
@@ -11,6 +11,10 @@ const [packageText, tauriText, cargoText, changelog, releaseWorkflow, capability
   read('.github/workflows/release.yml'),
   read('src-tauri/capabilities/default.json'),
   read('src-tauri/src/clipboard.rs'),
+  read('src-tauri/src/crypto.rs'),
+  read('src-tauri/src/database.rs'),
+  read('src-tauri/src/commands.rs'),
+  read('frontend/src/components/ClipCard.tsx'),
 ]);
 
 const packageVersion = JSON.parse(packageText).version;
@@ -61,6 +65,33 @@ if (cargoText.includes('tauri-plugin-notification')) {
 
 if (JSON.parse(packageText).dependencies?.['@tauri-apps/plugin-clipboard-manager']) {
   throw new Error('The unused JavaScript clipboard-manager plugin must not return');
+}
+
+for (const dependency of ['aes-gcm', 'hmac']) {
+  if (!cargoText.includes(`${dependency} =`)) {
+    throw new Error(`Encrypted storage requires the Rust ${dependency} dependency`);
+  }
+}
+
+if (
+  cargoText.includes('protocol-asset') ||
+  clipCardSource.includes('convertFileSrc') ||
+  tauriConfig.app?.security?.assetProtocol?.enable
+) {
+  throw new Error('Release builds must not expose stored image files through the WebView asset protocol');
+}
+
+for (const encryptedStorageGate of [
+  'CryptProtectData',
+  'Aes256Gcm',
+  'keyed_hash',
+  'storage_encryption_version',
+  'migrate_encrypted_storage',
+]) {
+  const sources = `${cryptoSource}\n${databaseSource}\n${commandSource}\n${clipboardSource}`;
+  if (!sources.includes(encryptedStorageGate)) {
+    throw new Error(`Encrypted-storage release gate is missing: ${encryptedStorageGate}`);
+  }
 }
 
 for (const sensitiveLogFragment of ['Detected self-paste for hash', 'full_path: {:?}', 'path match): {}']) {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +665,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clipboard-rs"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,6 +869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -867,9 +913,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cubby"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "base64 0.22.1",
  "chrono",
  "clipboard-rs",
@@ -877,6 +933,8 @@ dependencies = [
  "dark-light",
  "dirs 5.0.1",
  "futures",
+ "getrandom 0.3.4",
+ "hmac",
  "image 0.24.9",
  "log",
  "once_cell",
@@ -1739,6 +1797,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gif"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,12 +2132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,6 +2387,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -3079,6 +3150,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "open"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,6 +3417,18 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -4591,7 +4680,6 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "http-range",
  "image 0.25.10",
  "jni",
  "libc",
@@ -5466,6 +5554,16 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "url"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ default-run = "cubby"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["protocol-asset", "tray-icon", "image-png", "devtools"] }
+tauri = { version = "2", features = ["tray-icon", "image-png", "devtools"] }
 tauri-plugin-global-shortcut = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -19,6 +19,9 @@ sqlx = { version = "0.8", default-features = false, features = ["sqlite", "chron
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 sha2 = "0.10"
+hmac = "0.12"
+aes-gcm = "0.10"
+getrandom = "0.3"
 image = "0.24"
 
 futures = "0.3"
@@ -41,7 +44,7 @@ clipboard-win = "5.4.1"
 
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.62.2", features = ["UI_ViewManagement", "Win32_UI_Accessibility", "Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Win32_System_Threading", "Win32_System_ProcessStatus", "Win32_System_LibraryLoader", "Win32_Security", "Win32_System_DataExchange", "Win32_UI_Shell", "Win32_Graphics_Gdi", "Win32_Graphics_Dwm", "Win32_Storage_FileSystem", "Win32_System_SystemInformation", "Win32_System_Memory", "Win32_UI_Input_KeyboardAndMouse", "Win32_System_Com"] }
+windows = { version = "0.62.2", features = ["UI_ViewManagement", "Win32_UI_Accessibility", "Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Win32_System_Threading", "Win32_System_ProcessStatus", "Win32_System_LibraryLoader", "Win32_Security", "Win32_Security_Cryptography", "Win32_System_DataExchange", "Win32_UI_Shell", "Win32_Graphics_Gdi", "Win32_Graphics_Dwm", "Win32_Storage_FileSystem", "Win32_System_SystemInformation", "Win32_System_Memory", "Win32_UI_Input_KeyboardAndMouse", "Win32_System_Com"] }
 
 
 [features]

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -288,6 +288,7 @@ async fn process_clipboard_snapshot(
                 source_type,
             } => {
                 let size_bytes = png_bytes.len();
+                let preview_bytes = create_image_preview(&png_bytes).unwrap_or_default();
                 log::debug!(
                     "CLIPBOARD: Materialized image sequence={} {}x{} source_type={} png_bytes={} decode_ms={}",
                     sequence,
@@ -299,7 +300,7 @@ async fn process_clipboard_snapshot(
                 );
                 (
                     "image",
-                    Vec::new(),
+                    preview_bytes,
                     "[Image]".to_string(),
                     hash,
                     Some(png_bytes),
@@ -384,11 +385,48 @@ async fn process_clipboard_snapshot(
 
     // DB Logic
     let pool = &db.pool;
+    let hash_source = full_image_content.as_deref().unwrap_or(&clip_content);
+    let storage_hash = db.crypto.keyed_hash(hash_source);
+    let encrypted_content = match db.crypto.encrypt(&clip_content) {
+        Ok(content) => content,
+        Err(error) => {
+            log::error!("CLIPBOARD: Failed to encrypt captured content: {}", error);
+            return;
+        }
+    };
+    let encrypted_preview = match db.crypto.encrypt_text(&clip_preview) {
+        Ok(preview) => preview,
+        Err(error) => {
+            log::error!("CLIPBOARD: Failed to encrypt captured preview: {}", error);
+            return;
+        }
+    };
+    let encrypted_source_app = match db.crypto.encrypt_optional_text(source_app.as_deref()) {
+        Ok(value) => value,
+        Err(error) => {
+            log::error!("CLIPBOARD: Failed to encrypt source attribution: {}", error);
+            return;
+        }
+    };
+    let encrypted_source_icon = match db.crypto.encrypt_optional_text(source_icon.as_deref()) {
+        Ok(value) => value,
+        Err(error) => {
+            log::error!("CLIPBOARD: Failed to encrypt source icon: {}", error);
+            return;
+        }
+    };
+    let encrypted_metadata = match db.crypto.encrypt_optional_text(metadata.as_deref()) {
+        Ok(value) => value,
+        Err(error) => {
+            log::error!("CLIPBOARD: Failed to encrypt content metadata: {}", error);
+            return;
+        }
+    };
 
     let db_lookup_started = std::time::Instant::now();
     let existing_uuid: Option<String> =
         sqlx::query_scalar::<_, String>(r#"SELECT uuid FROM clips WHERE content_hash = ?"#)
-            .bind(&clip_hash)
+            .bind(&storage_hash)
             .fetch_optional(pool)
             .await
             .unwrap_or(None);
@@ -412,11 +450,11 @@ async fn process_clipboard_snapshot(
                 WHERE uuid = ?
                 "#,
             )
-            .bind(&source_app)
-            .bind(&source_icon)
-            .bind(&clip_content)
-            .bind(&clip_preview)
-            .bind(metadata.clone())
+            .bind(&encrypted_source_app)
+            .bind(&encrypted_source_icon)
+            .bind(&encrypted_content)
+            .bind(&encrypted_preview)
+            .bind(encrypted_metadata.clone())
             .bind(&existing_id)
             .execute(pool)
             .await
@@ -430,7 +468,12 @@ async fn process_clipboard_snapshot(
             }
 
             if let Some(full_bytes) = &full_image_content {
-                match persist_full_image_file(&existing_id, full_bytes) {
+                match persist_full_image_file(
+                    &db.crypto,
+                    &db.image_dir,
+                    &existing_id,
+                    full_bytes,
+                ) {
                     Ok(file_path) => {
                         if let Err(error) = sqlx::query(
                             r#"
@@ -463,8 +506,8 @@ async fn process_clipboard_snapshot(
             }
         } else {
             if let Err(error) = sqlx::query(r#"UPDATE clips SET created_at = CURRENT_TIMESTAMP, is_deleted = 0, source_app = ?, source_icon = ? WHERE uuid = ?"#)
-                .bind(&source_app)
-                .bind(&source_icon)
+                .bind(&encrypted_source_app)
+                .bind(&encrypted_source_icon)
                 .bind(&existing_id)
                 .execute(pool)
                 .await
@@ -489,13 +532,13 @@ async fn process_clipboard_snapshot(
         )
         .bind(&clip_uuid)
         .bind(clip_type)
-        .bind(&clip_content)
-        .bind(&clip_preview)
-        .bind(&clip_hash)
+        .bind(&encrypted_content)
+        .bind(&encrypted_preview)
+        .bind(&storage_hash)
         .bind(false)
-        .bind(&source_app)
-        .bind(&source_icon)
-        .bind(metadata)
+        .bind(&encrypted_source_app)
+        .bind(&encrypted_source_icon)
+        .bind(encrypted_metadata)
         .execute(pool)
         .await
         {
@@ -510,7 +553,12 @@ async fn process_clipboard_snapshot(
 
         if clip_type == "image" {
             if let Some(full_bytes) = &full_image_content {
-                match persist_full_image_file(&clip_uuid, full_bytes) {
+                match persist_full_image_file(
+                    &db.crypto,
+                    &db.image_dir,
+                    &clip_uuid,
+                    full_bytes,
+                ) {
                     Ok(file_path) => {
                         if let Err(error) = sqlx::query(
                             r#"
@@ -605,32 +653,42 @@ async fn process_clipboard_snapshot(
         started.elapsed().as_millis()
     );
 }
-fn calculate_hash(content: &[u8]) -> String {
+pub(crate) fn calculate_hash(content: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(content);
     let result = hasher.finalize();
     format!("{:x}", result)
 }
 
-fn get_image_store_dir() -> std::path::PathBuf {
-    let current_dir = std::env::current_dir().unwrap_or(std::path::PathBuf::from("."));
-    let app_data_dir = match dirs::data_dir() {
-        Some(path) => path.join("Cubby Clipboard"),
-        None => current_dir.join("Cubby Clipboard"),
-    };
-    app_data_dir.join("images")
+pub fn create_image_preview(png_bytes: &[u8]) -> Result<Vec<u8>, String> {
+    let image = image::load_from_memory(png_bytes).map_err(|e| e.to_string())?;
+    let preview = image.thumbnail(320, 220);
+    let mut bytes = std::io::Cursor::new(Vec::new());
+    preview
+        .write_to(&mut bytes, image::ImageOutputFormat::Png)
+        .map_err(|e| e.to_string())?;
+    Ok(bytes.into_inner())
 }
 
-pub fn persist_full_image_file(clip_uuid: &str, png_bytes: &[u8]) -> Result<String, String> {
-    let dir = get_image_store_dir();
-    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
-    let file_path = dir.join(format!("{}.png", clip_uuid));
-    std::fs::write(&file_path, png_bytes).map_err(|e| e.to_string())?;
+pub fn persist_full_image_file(
+    crypto: &crate::crypto::CryptoManager,
+    image_dir: &std::path::Path,
+    clip_uuid: &str,
+    png_bytes: &[u8],
+) -> Result<String, String> {
+    std::fs::create_dir_all(image_dir).map_err(|e| e.to_string())?;
+    let file_path = image_dir.join(format!("{}.cubby", clip_uuid));
+    let encrypted = crypto.encrypt(png_bytes)?;
+    std::fs::write(&file_path, encrypted).map_err(|e| e.to_string())?;
     Ok(file_path.to_string_lossy().to_string())
 }
 
-pub fn read_full_image_file(file_path: &str) -> Result<Vec<u8>, String> {
-    std::fs::read(file_path).map_err(|e| e.to_string())
+pub fn read_full_image_file(
+    crypto: &crate::crypto::CryptoManager,
+    file_path: &str,
+) -> Result<Vec<u8>, String> {
+    let encrypted = std::fs::read(file_path).map_err(|e| e.to_string())?;
+    crypto.decrypt(&encrypted)
 }
 
 pub fn remove_full_image_file(file_path: &str) {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9,9 +9,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
-fn clip_to_list_item(clip: &Clip, image_path: Option<&str>) -> ClipboardItem {
+fn clip_to_list_item(clip: &Clip) -> ClipboardItem {
     let content_str = if clip.clip_type == "image" {
-        image_path.unwrap_or_default().to_string()
+        BASE64.encode(&clip.content)
     } else {
         String::from_utf8_lossy(&clip.content).to_string()
     };
@@ -28,6 +28,15 @@ fn clip_to_list_item(clip: &Clip, image_path: Option<&str>) -> ClipboardItem {
         source_icon: clip.source_icon.clone(),
         metadata: clip.metadata.clone(),
     }
+}
+
+fn decrypt_clip_fields(db: &Database, clip: &mut Clip) -> Result<(), String> {
+    clip.content = db.crypto.decrypt(&clip.content)?;
+    clip.text_preview = db.crypto.decrypt_text(&clip.text_preview)?;
+    db.crypto.decrypt_optional_text(&mut clip.source_app)?;
+    db.crypto.decrypt_optional_text(&mut clip.source_icon)?;
+    db.crypto.decrypt_optional_text(&mut clip.metadata)?;
+    Ok(())
 }
 
 fn clip_to_detail_item(clip: &Clip, full_image_content: Option<&[u8]>) -> ClipboardItem {
@@ -94,81 +103,169 @@ async fn cleanup_orphan_clip_image_files(pool: &SqlitePool) -> Result<(), String
     Ok(())
 }
 
-pub async fn migrate_images_to_files(pool: &SqlitePool) -> Result<(), String> {
-    log::info!("Starting background image migration...");
+fn encrypt_existing_text(
+    crypto: &crate::crypto::CryptoManager,
+    value: &str,
+) -> Result<String, String> {
+    if crate::crypto::CryptoManager::is_encrypted_text(value) {
+        Ok(value.to_string())
+    } else {
+        crypto.encrypt_text(value)
+    }
+}
 
-    // 1. Migrate legacy clips (content in 'clips' table)
-    let legacy_clips: Vec<Clip> =
-        sqlx::query_as(r#"SELECT * FROM clips WHERE clip_type = 'image' AND length(content) > 0"#)
-            .fetch_all(pool)
+fn encrypt_existing_optional_text(
+    crypto: &crate::crypto::CryptoManager,
+    value: Option<&str>,
+) -> Result<Option<String>, String> {
+    value
+        .map(|value| encrypt_existing_text(crypto, value))
+        .transpose()
+}
+
+async fn image_bytes_for_encryption_migration(
+    db: &Database,
+    clip: &Clip,
+) -> Result<(Vec<u8>, Option<String>), String> {
+    let row: Option<(Option<String>, Vec<u8>)> =
+        sqlx::query_as("SELECT file_path, full_content FROM clip_images WHERE clip_uuid = ?")
+            .bind(&clip.uuid)
+            .fetch_optional(&db.pool)
             .await
             .map_err(|e| e.to_string())?;
 
-    for clip in legacy_clips {
-        log::info!("Migrating legacy clip {}...", clip.uuid);
-        let full_bytes = clip.content.clone();
-        match crate::clipboard::persist_full_image_file(&clip.uuid, &full_bytes) {
-            Ok(file_path) => {
-                let _ = sqlx::query(
-                    r#"
-                    INSERT OR REPLACE INTO clip_images (clip_uuid, full_content, file_path, file_size, storage_kind, mime_type, created_at)
-                    VALUES (?, x'', ?, ?, 'file', 'image/png', CURRENT_TIMESTAMP)
-                    "#,
-                )
-                .bind(&clip.uuid)
-                .bind(&file_path)
-                .bind(full_bytes.len() as i64)
-                .execute(pool)
-                .await;
-
-                let _ = sqlx::query(
-                    r#"UPDATE clips SET content = x'', is_thumbnail = 0 WHERE uuid = ?"#,
-                )
-                .bind(&clip.uuid)
-                .execute(pool)
-                .await;
+    if let Some((file_path, full_content)) = row {
+        if let Some(path) = file_path.as_deref().filter(|path| !path.is_empty()) {
+            if let Ok(stored) = std::fs::read(path) {
+                let plaintext = if crate::crypto::CryptoManager::is_encrypted(&stored) {
+                    db.crypto.decrypt(&stored)?
+                } else {
+                    stored
+                };
+                return Ok((plaintext, file_path));
             }
-            Err(e) => {
-                log::error!("Failed to migrate legacy clip {}: {}", clip.uuid, e);
-            }
+        }
+        if !full_content.is_empty() {
+            let plaintext = if crate::crypto::CryptoManager::is_encrypted(&full_content) {
+                db.crypto.decrypt(&full_content)?
+            } else {
+                full_content
+            };
+            return Ok((plaintext, file_path));
         }
     }
 
-    // 2. Migrate DB-stored images in 'clip_images'
-    let db_images: Vec<(String, Vec<u8>)> = sqlx::query_as(
-        r#"SELECT clip_uuid, full_content FROM clip_images WHERE storage_kind = 'db' AND length(full_content) > 0"#,
-    )
-    .fetch_all(pool)
-    .await
-    .map_err(|e| e.to_string())?;
-
-    for (uuid, content) in db_images {
-        log::info!("Migrating DB-stored image for clip {}...", uuid);
-        match crate::clipboard::persist_full_image_file(&uuid, &content) {
-            Ok(file_path) => {
-                let _ = sqlx::query(
-                    r#"
-                    UPDATE clip_images
-                    SET full_content = x'', file_path = ?, storage_kind = 'file'
-                    WHERE clip_uuid = ?
-                    "#,
-                )
-                .bind(&file_path)
-                .bind(&uuid)
-                .execute(pool)
-                .await;
-            }
-            Err(e) => {
-                log::error!("Failed to migrate DB image for clip {}: {}", uuid, e);
-            }
-        }
+    if !clip.content.is_empty() && !crate::crypto::CryptoManager::is_encrypted(&clip.content) {
+        return Ok((clip.content.clone(), None));
     }
-
-    log::info!("Background image migration completed.");
-    Ok(())
+    Err(format!("image payload is missing for clip {}", clip.uuid))
 }
 
-async fn load_full_image_content(pool: &SqlitePool, clip: &mut Clip) -> Result<Vec<u8>, String> {
+pub async fn migrate_encrypted_storage(db: &Database) -> Result<u64, String> {
+    let version: Option<String> =
+        sqlx::query_scalar("SELECT value FROM settings WHERE key = 'storage_encryption_version'")
+            .fetch_optional(&db.pool)
+            .await
+            .map_err(|e| e.to_string())?;
+    if version.as_deref() == Some("1") {
+        return Ok(0);
+    }
+
+    let clips: Vec<Clip> = sqlx::query_as("SELECT * FROM clips ORDER BY id")
+        .fetch_all(&db.pool)
+        .await
+        .map_err(|e| e.to_string())?;
+    let mut migrated = 0_u64;
+
+    for clip in clips {
+        let (plaintext, new_image_path, old_image_path) = if clip.clip_type == "image" {
+            let (full_image, old_path) = image_bytes_for_encryption_migration(db, &clip).await?;
+            let preview = crate::clipboard::create_image_preview(&full_image)?;
+            let new_path = crate::clipboard::persist_full_image_file(
+                &db.crypto,
+                &db.image_dir,
+                &clip.uuid,
+                &full_image,
+            )?;
+            (preview, Some((new_path, full_image)), old_path)
+        } else {
+            let plaintext = if crate::crypto::CryptoManager::is_encrypted(&clip.content) {
+                db.crypto.decrypt(&clip.content)?
+            } else {
+                clip.content.clone()
+            };
+            (plaintext, None, None)
+        };
+
+        let hash_source = new_image_path
+            .as_ref()
+            .map(|(_, full_image)| full_image.as_slice())
+            .unwrap_or(plaintext.as_slice());
+        let encrypted_content = db.crypto.encrypt(&plaintext)?;
+        let encrypted_preview = encrypt_existing_text(&db.crypto, &clip.text_preview)?;
+        let encrypted_source_app =
+            encrypt_existing_optional_text(&db.crypto, clip.source_app.as_deref())?;
+        let encrypted_source_icon =
+            encrypt_existing_optional_text(&db.crypto, clip.source_icon.as_deref())?;
+        let encrypted_metadata =
+            encrypt_existing_optional_text(&db.crypto, clip.metadata.as_deref())?;
+
+        let mut transaction = db.pool.begin().await.map_err(|e| e.to_string())?;
+        sqlx::query(
+            r#"
+            UPDATE clips
+            SET content = ?, text_preview = ?, content_hash = ?, source_app = ?, source_icon = ?, metadata = ?, is_thumbnail = ?
+            WHERE uuid = ?
+            "#,
+        )
+        .bind(encrypted_content)
+        .bind(encrypted_preview)
+        .bind(db.crypto.keyed_hash(hash_source))
+        .bind(encrypted_source_app)
+        .bind(encrypted_source_icon)
+        .bind(encrypted_metadata)
+        .bind(clip.clip_type == "image")
+        .bind(&clip.uuid)
+        .execute(&mut *transaction)
+        .await
+        .map_err(|e| e.to_string())?;
+
+        if let Some((path, full_image)) = &new_image_path {
+            sqlx::query(
+                r#"
+                INSERT OR REPLACE INTO clip_images
+                    (clip_uuid, full_content, file_path, file_size, storage_kind, mime_type, created_at)
+                VALUES (?, x'', ?, ?, 'encrypted_file', 'image/png', CURRENT_TIMESTAMP)
+                "#,
+            )
+            .bind(&clip.uuid)
+            .bind(path)
+            .bind(full_image.len() as i64)
+            .execute(&mut *transaction)
+            .await
+            .map_err(|e| e.to_string())?;
+        }
+        transaction.commit().await.map_err(|e| e.to_string())?;
+
+        if let (Some(old_path), Some((new_path, _))) = (old_image_path, &new_image_path) {
+            if old_path != *new_path {
+                crate::clipboard::remove_full_image_file(&old_path);
+            }
+        }
+        migrated += 1;
+    }
+
+    sqlx::query(
+        "INSERT OR REPLACE INTO settings (key, value) VALUES ('storage_encryption_version', '1')",
+    )
+    .execute(&db.pool)
+    .await
+    .map_err(|e| e.to_string())?;
+    Ok(migrated)
+}
+
+async fn load_full_image_content(db: &Database, clip: &mut Clip) -> Result<Vec<u8>, String> {
+    let pool = &db.pool;
     if clip.clip_type != "image" {
         return Err("Clip is not an image".to_string());
     }
@@ -184,11 +281,11 @@ async fn load_full_image_content(pool: &SqlitePool, clip: &mut Clip) -> Result<V
     if let Some(path) = file_path {
         if !path.is_empty() {
             // If file exists, return it
-            if let Ok(bytes) = crate::clipboard::read_full_image_file(&path) {
+            if let Ok(bytes) = crate::clipboard::read_full_image_file(&db.crypto, &path) {
                 return Ok(bytes);
             }
             // If file missing, try fallbacks below
-            log::warn!("Image file missing at {}, checking DB backups...", path);
+            log::warn!("Stored image file is missing; checking database fallbacks");
         }
     }
 
@@ -202,13 +299,21 @@ async fn load_full_image_content(pool: &SqlitePool, clip: &mut Clip) -> Result<V
 
     if let Some(content) = full_content {
         if !content.is_empty() {
-            return Ok(content);
+            return if crate::crypto::CryptoManager::is_encrypted(&content) {
+                db.crypto.decrypt(&content)
+            } else {
+                Ok(content)
+            };
         }
     }
 
     // 3. Legacy content in clips table
     if !clip.content.is_empty() {
-        return Ok(clip.content.clone());
+        return if crate::crypto::CryptoManager::is_encrypted(&clip.content) {
+            db.crypto.decrypt(&clip.content)
+        } else {
+            Ok(clip.content.clone())
+        };
     }
 
     Err("Image content missing".to_string())
@@ -233,7 +338,7 @@ pub async fn get_clips(
     );
 
     let sql_started = Instant::now();
-    let clips: Vec<Clip> = match filter_id.as_deref() {
+    let mut clips: Vec<Clip> = match filter_id.as_deref() {
         Some(id) => {
             let folder_id_num = id.parse::<i64>().ok();
             if let Some(numeric_id) = folder_id_num {
@@ -273,49 +378,21 @@ pub async fn get_clips(
     let sql_ms = sql_started.elapsed().as_millis();
 
     log::info!("DB: Found {} clips", clips.len());
-
-    // Batch fetch image paths
-    let mut image_path_map: HashMap<String, String> = HashMap::new();
-    let image_uuids: Vec<String> = clips
-        .iter()
-        .filter(|c| c.clip_type == "image")
-        .map(|c| c.uuid.clone())
-        .collect();
-
-    if !image_uuids.is_empty() {
-        // Construct query: SELECT clip_uuid, file_path FROM clip_images WHERE clip_uuid IN (?, ?, ...)
-        let placeholders: Vec<String> = image_uuids.iter().map(|_| "?".to_string()).collect();
-        let query = format!(
-            "SELECT clip_uuid, file_path FROM clip_images WHERE clip_uuid IN ({})",
-            placeholders.join(",")
-        );
-
-        let mut query_builder = sqlx::query_as::<_, (String, Option<String>)>(&query);
-        for uuid in &image_uuids {
-            query_builder = query_builder.bind(uuid);
-        }
-
-        let results = query_builder
-            .fetch_all(pool)
-            .await
-            .map_err(|e| e.to_string())?;
-        for (uuid, path) in results {
-            if let Some(p) = path {
-                if !p.is_empty() {
-                    image_path_map.insert(uuid, p);
-                }
-            }
-        }
+    for clip in &mut clips {
+        decrypt_clip_fields(&db, clip)?;
     }
 
-    let image_rows = image_uuids.len();
+    let image_rows = clips
+        .iter()
+        .filter(|clip| clip.clip_type == "image")
+        .count();
     let raw_bytes: usize = clips.iter().map(|clip| clip.content.len()).sum();
     let map_started = Instant::now();
     let items: Vec<ClipboardItem> = clips
         .iter()
         .enumerate()
         .map(|(idx, clip)| {
-            let item = clip_to_list_item(clip, image_path_map.get(&clip.uuid).map(|s| s.as_str()));
+            let item = clip_to_list_item(clip);
             // Only log first 10 clips to reduce noise
             if idx < 10 {
                 log::trace!(
@@ -364,9 +441,11 @@ pub async fn get_clip(
     match clip {
         Some(mut clip) => {
             if clip.clip_type == "image" {
-                let full = load_full_image_content(pool, &mut clip).await?;
+                let full = load_full_image_content(&db, &mut clip).await?;
+                decrypt_clip_fields(&db, &mut clip)?;
                 Ok(clip_to_detail_item(&clip, Some(&full)))
             } else {
+                decrypt_clip_fields(&db, &mut clip)?;
                 Ok(clip_to_detail_item(&clip, None))
             }
         }
@@ -399,7 +478,8 @@ async fn restore_clip(
         .map_err(|e| e.to_string())?;
 
     match clip {
-        Some(clip) => {
+        Some(mut clip) => {
+            decrypt_clip_fields(db, &mut clip)?;
             if plain_text && clip.clip_type == "image" {
                 return Err("Plain text is not available for image clips".to_string());
             }
@@ -407,7 +487,12 @@ async fn restore_clip(
             // Synchronize clipboard access across the app
             let _guard = crate::clipboard::CLIPBOARD_SYNC.lock().await;
 
-            let content_hash = clip.content_hash.clone();
+            let content_hash = if clip.clip_type == "image" {
+                let full_image = load_full_image_content(db, &mut clip).await?;
+                crate::clipboard::calculate_hash(&full_image)
+            } else {
+                crate::clipboard::calculate_hash(&clip.content)
+            };
             let uuid = clip.uuid.clone();
 
             let mut final_res = Ok(());
@@ -700,83 +785,58 @@ pub async fn search_clips(
     let pool = &db.pool;
     let started = Instant::now();
 
-    let search_pattern = format!("%{}%", query);
-
     let sql_started = Instant::now();
-    let clips: Vec<Clip> = match filter_id.as_deref() {
+    let mut clips: Vec<Clip> = match filter_id.as_deref() {
         Some(id) => {
             let folder_id_num = id.parse::<i64>().ok();
             if let Some(numeric_id) = folder_id_num {
-                sqlx::query_as(r#"
-                    SELECT * FROM clips WHERE is_deleted = 0 AND folder_id = ? AND (text_preview LIKE ? OR content LIKE ?)
-                    ORDER BY is_pinned DESC, created_at DESC LIMIT ? OFFSET ?
-                "#)
+                sqlx::query_as(
+                    r#"
+                    SELECT * FROM clips WHERE is_deleted = 0 AND folder_id = ?
+                    ORDER BY is_pinned DESC, created_at DESC
+                "#,
+                )
                 .bind(numeric_id)
-                .bind(&search_pattern)
-                .bind(&search_pattern)
-                .bind(limit)
-                .bind(offset)
-                .fetch_all(pool).await.map_err(|e| e.to_string())?
+                .fetch_all(pool)
+                .await
+                .map_err(|e| e.to_string())?
             } else {
                 Vec::new()
             }
         }
         None => sqlx::query_as(
             r#"
-                SELECT * FROM clips WHERE is_deleted = 0 AND (text_preview LIKE ? OR content LIKE ?)
-                ORDER BY is_pinned DESC, created_at DESC LIMIT ? OFFSET ?
+                SELECT * FROM clips WHERE is_deleted = 0
+                ORDER BY is_pinned DESC, created_at DESC
             "#,
         )
-        .bind(&search_pattern)
-        .bind(&search_pattern)
-        .bind(limit)
-        .bind(offset)
         .fetch_all(pool)
         .await
         .map_err(|e| e.to_string())?,
     };
     let sql_ms = sql_started.elapsed().as_millis();
-
-    // Batch fetch image paths
-    let mut image_path_map: HashMap<String, String> = HashMap::new();
-    let image_uuids: Vec<String> = clips
-        .iter()
-        .filter(|c| c.clip_type == "image")
-        .map(|c| c.uuid.clone())
-        .collect();
-
-    if !image_uuids.is_empty() {
-        let placeholders: Vec<String> = image_uuids.iter().map(|_| "?".to_string()).collect();
-        let query = format!(
-            "SELECT clip_uuid, file_path FROM clip_images WHERE clip_uuid IN ({})",
-            placeholders.join(",")
-        );
-
-        let mut query_builder = sqlx::query_as::<_, (String, Option<String>)>(&query);
-        for uuid in &image_uuids {
-            query_builder = query_builder.bind(uuid);
-        }
-
-        let results = query_builder
-            .fetch_all(pool)
-            .await
-            .map_err(|e| e.to_string())?;
-        for (uuid, path) in results {
-            if let Some(p) = path {
-                if !p.is_empty() {
-                    image_path_map.insert(uuid, p);
-                }
-            }
-        }
+    for clip in &mut clips {
+        decrypt_clip_fields(&db, clip)?;
     }
 
-    let image_rows = image_uuids.len();
+    let normalized_query = query.to_lowercase();
+    let offset = offset.max(0) as usize;
+    let limit = limit.max(0) as usize;
+    clips.retain(|clip| {
+        String::from_utf8_lossy(&clip.content)
+            .to_lowercase()
+            .contains(&normalized_query)
+            || clip.text_preview.to_lowercase().contains(&normalized_query)
+    });
+    let clips: Vec<Clip> = clips.into_iter().skip(offset).take(limit).collect();
+
+    let image_rows = clips
+        .iter()
+        .filter(|clip| clip.clip_type == "image")
+        .count();
     let raw_bytes: usize = clips.iter().map(|clip| clip.content.len()).sum();
     let map_started = Instant::now();
-    let items: Vec<ClipboardItem> = clips
-        .iter()
-        .map(|clip| clip_to_list_item(clip, image_path_map.get(&clip.uuid).map(|s| s.as_str())))
-        .collect();
+    let items: Vec<ClipboardItem> = clips.iter().map(clip_to_list_item).collect();
     let map_ms = map_started.elapsed().as_millis();
     let total_ms = started.elapsed().as_millis();
     log::info!(
@@ -1156,9 +1216,15 @@ pub fn get_system_accent_color() -> Result<serde_json::Value, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{clear_clips_in_pool, enforce_retention_in_pool, toggle_clip_pin_in_pool};
+    use super::{
+        clear_clips_in_pool, enforce_retention_in_pool, migrate_encrypted_storage,
+        toggle_clip_pin_in_pool,
+    };
+    use crate::crypto::CryptoManager;
     use crate::database::Database;
+    use crate::models::Clip;
     use sqlx::sqlite::SqlitePoolOptions;
+    use std::sync::Arc;
 
     async fn test_database() -> Database {
         let pool = SqlitePoolOptions::new()
@@ -1166,7 +1232,11 @@ mod tests {
             .connect("sqlite::memory:")
             .await
             .expect("in-memory database should open");
-        let database = Database { pool };
+        let database = Database {
+            pool,
+            crypto: Arc::new(crate::crypto::CryptoManager::ephemeral()),
+            image_dir: std::env::temp_dir().join(format!("cubby-test-{}", uuid::Uuid::new_v4())),
+        };
         database.migrate().await.expect("migration should succeed");
         database
     }
@@ -1194,6 +1264,102 @@ mod tests {
             toggle_clip_pin_in_pool(&database.pool, "missing").await,
             Err("Clipboard item not found".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn storage_migration_encrypts_plaintext_history_and_is_idempotent() {
+        let database = test_database().await;
+        sqlx::query(
+            r#"
+            INSERT INTO clips
+                (uuid, clip_type, content, text_preview, content_hash, source_app, metadata)
+            VALUES
+                ('legacy-text', 'text', ?, 'private preview', 'legacy-sha', 'Editor.exe', '{"kind":"text"}')
+            "#,
+        )
+        .bind(b"private clipboard payload".as_slice())
+        .execute(&database.pool)
+        .await
+        .expect("legacy clip should be inserted");
+
+        assert_eq!(migrate_encrypted_storage(&database).await.unwrap(), 1);
+        assert_eq!(migrate_encrypted_storage(&database).await.unwrap(), 0);
+
+        let mut stored: Clip = sqlx::query_as("SELECT * FROM clips WHERE uuid = 'legacy-text'")
+            .fetch_one(&database.pool)
+            .await
+            .expect("migrated clip should load");
+        assert!(CryptoManager::is_encrypted(&stored.content));
+        assert!(CryptoManager::is_encrypted_text(&stored.text_preview));
+        assert!(CryptoManager::is_encrypted_text(
+            stored.source_app.as_deref().unwrap()
+        ));
+        assert_ne!(stored.content_hash, "legacy-sha");
+
+        super::decrypt_clip_fields(&database, &mut stored).unwrap();
+        assert_eq!(stored.content, b"private clipboard payload");
+        assert_eq!(stored.text_preview, "private preview");
+        assert_eq!(stored.source_app.as_deref(), Some("Editor.exe"));
+        assert_eq!(stored.metadata.as_deref(), Some("{\"kind\":\"text\"}"));
+    }
+
+    #[tokio::test]
+    async fn storage_migration_replaces_plaintext_images_with_encrypted_files_and_previews() {
+        let database = test_database().await;
+        std::fs::create_dir_all(&database.image_dir).unwrap();
+        let old_path = database.image_dir.join("legacy-image.png");
+        let mut png = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::new_rgba8(4, 3)
+            .write_to(&mut png, image::ImageOutputFormat::Png)
+            .unwrap();
+        let png = png.into_inner();
+        std::fs::write(&old_path, &png).unwrap();
+
+        sqlx::query(
+            r#"
+            INSERT INTO clips (uuid, clip_type, content, text_preview, content_hash, metadata)
+            VALUES ('legacy-image', 'image', x'', '[Image]', 'legacy-image-sha', '{"width":4,"height":3}')
+            "#,
+        )
+        .execute(&database.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r#"
+            INSERT INTO clip_images (clip_uuid, full_content, file_path, file_size, storage_kind)
+            VALUES ('legacy-image', x'', ?, ?, 'file')
+            "#,
+        )
+        .bind(old_path.to_string_lossy().to_string())
+        .bind(png.len() as i64)
+        .execute(&database.pool)
+        .await
+        .unwrap();
+
+        assert_eq!(migrate_encrypted_storage(&database).await.unwrap(), 1);
+        let mut stored: Clip = sqlx::query_as("SELECT * FROM clips WHERE uuid = 'legacy-image'")
+            .fetch_one(&database.pool)
+            .await
+            .unwrap();
+        let (new_path, storage_kind): (String, String) = sqlx::query_as(
+            "SELECT file_path, storage_kind FROM clip_images WHERE clip_uuid = 'legacy-image'",
+        )
+        .fetch_one(&database.pool)
+        .await
+        .unwrap();
+
+        assert!(CryptoManager::is_encrypted(&stored.content));
+        assert_eq!(storage_kind, "encrypted_file");
+        assert!(new_path.ends_with("legacy-image.cubby"));
+        assert!(!old_path.exists());
+        let encrypted_file = std::fs::read(&new_path).unwrap();
+        assert!(CryptoManager::is_encrypted(&encrypted_file));
+        assert_eq!(database.crypto.decrypt(&encrypted_file).unwrap(), png);
+        super::decrypt_clip_fields(&database, &mut stored).unwrap();
+        assert!(!stored.content.is_empty());
+        image::load_from_memory(&stored.content).expect("decrypted preview should be a PNG");
+
+        std::fs::remove_dir_all(&database.image_dir).unwrap();
     }
 
     #[tokio::test]

--- a/src-tauri/src/crypto.rs
+++ b/src-tauri/src/crypto.rs
@@ -1,0 +1,273 @@
+use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::{Aes256Gcm, Nonce};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::path::Path;
+
+const ENVELOPE_MAGIC: &[u8; 4] = b"CUB1";
+const NONCE_LEN: usize = 12;
+const KEY_LEN: usize = 32;
+const TEXT_PREFIX: &str = "CUB1:";
+
+#[derive(Clone)]
+pub struct CryptoManager {
+    key: [u8; KEY_LEN],
+}
+
+impl CryptoManager {
+    pub fn load_or_create(db_path: &Path, allow_create: bool) -> Result<Self, String> {
+        let key_path = db_path.with_file_name("storage.key");
+        let key = if key_path.exists() {
+            let protected = std::fs::read(&key_path)
+                .map_err(|e| format!("failed to read protected storage key: {e}"))?;
+            let plaintext = unprotect_for_current_user(&protected)?;
+            plaintext
+                .try_into()
+                .map_err(|_| "protected storage key has an invalid length".to_string())?
+        } else {
+            if !allow_create {
+                return Err(
+                    "encrypted clipboard history exists, but its protected storage key is missing"
+                        .to_string(),
+                );
+            }
+            let mut key = [0_u8; KEY_LEN];
+            getrandom::fill(&mut key)
+                .map_err(|e| format!("failed to generate storage key: {e}"))?;
+            let protected = protect_for_current_user(&key)?;
+            if let Some(parent) = key_path.parent() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| format!("failed to create storage directory: {e}"))?;
+            }
+            let temporary_path = key_path.with_extension("key.tmp");
+            std::fs::write(&temporary_path, protected)
+                .map_err(|e| format!("failed to persist protected storage key: {e}"))?;
+            std::fs::rename(&temporary_path, &key_path)
+                .map_err(|e| format!("failed to install protected storage key: {e}"))?;
+            key
+        };
+
+        Ok(Self { key })
+    }
+
+    #[cfg(test)]
+    pub fn ephemeral() -> Self {
+        let mut key = [0_u8; KEY_LEN];
+        getrandom::fill(&mut key).expect("test encryption key should be generated");
+        Self { key }
+    }
+
+    pub fn is_encrypted(value: &[u8]) -> bool {
+        value.starts_with(ENVELOPE_MAGIC)
+    }
+
+    pub fn encrypt(&self, plaintext: &[u8]) -> Result<Vec<u8>, String> {
+        let cipher = Aes256Gcm::new_from_slice(&self.key)
+            .map_err(|_| "failed to initialize storage encryption".to_string())?;
+        let mut nonce = [0_u8; NONCE_LEN];
+        getrandom::fill(&mut nonce).map_err(|e| format!("failed to generate nonce: {e}"))?;
+        let ciphertext = cipher
+            .encrypt(Nonce::from_slice(&nonce), plaintext)
+            .map_err(|_| "failed to encrypt clipboard content".to_string())?;
+
+        let mut envelope = Vec::with_capacity(ENVELOPE_MAGIC.len() + NONCE_LEN + ciphertext.len());
+        envelope.extend_from_slice(ENVELOPE_MAGIC);
+        envelope.extend_from_slice(&nonce);
+        envelope.extend_from_slice(&ciphertext);
+        Ok(envelope)
+    }
+
+    pub fn decrypt(&self, envelope: &[u8]) -> Result<Vec<u8>, String> {
+        if !Self::is_encrypted(envelope) {
+            return Err("clipboard payload is not encrypted".to_string());
+        }
+        if envelope.len() < ENVELOPE_MAGIC.len() + NONCE_LEN + 16 {
+            return Err("encrypted clipboard payload is truncated".to_string());
+        }
+        let nonce_start = ENVELOPE_MAGIC.len();
+        let ciphertext_start = nonce_start + NONCE_LEN;
+        let cipher = Aes256Gcm::new_from_slice(&self.key)
+            .map_err(|_| "failed to initialize storage encryption".to_string())?;
+        cipher
+            .decrypt(
+                Nonce::from_slice(&envelope[nonce_start..ciphertext_start]),
+                &envelope[ciphertext_start..],
+            )
+            .map_err(|_| "clipboard content failed authentication".to_string())
+    }
+
+    pub fn keyed_hash(&self, content: &[u8]) -> String {
+        let mut mac =
+            <Hmac<Sha256> as Mac>::new_from_slice(&self.key).expect("HMAC accepts a 256-bit key");
+        mac.update(content);
+        mac.finalize()
+            .into_bytes()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
+    }
+
+    pub fn encrypt_text(&self, plaintext: &str) -> Result<String, String> {
+        Ok(format!(
+            "{TEXT_PREFIX}{}",
+            BASE64.encode(self.encrypt(plaintext.as_bytes())?)
+        ))
+    }
+
+    pub fn decrypt_text(&self, value: &str) -> Result<String, String> {
+        if !value.starts_with(TEXT_PREFIX) {
+            return Err("clipboard text field is not encrypted".to_string());
+        }
+        let envelope = BASE64
+            .decode(&value[TEXT_PREFIX.len()..])
+            .map_err(|_| "encrypted clipboard text is invalid".to_string())?;
+        String::from_utf8(self.decrypt(&envelope)?)
+            .map_err(|_| "decrypted clipboard text is not UTF-8".to_string())
+    }
+
+    pub fn is_encrypted_text(value: &str) -> bool {
+        value.starts_with(TEXT_PREFIX)
+    }
+
+    pub fn encrypt_optional_text(&self, value: Option<&str>) -> Result<Option<String>, String> {
+        value.map(|value| self.encrypt_text(value)).transpose()
+    }
+
+    pub fn decrypt_optional_text(&self, value: &mut Option<String>) -> Result<(), String> {
+        if let Some(ciphertext) = value {
+            *ciphertext = self.decrypt_text(ciphertext)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn protect_for_current_user(plaintext: &[u8]) -> Result<Vec<u8>, String> {
+    use windows::Win32::Foundation::{LocalFree, HLOCAL};
+    use windows::Win32::Security::Cryptography::{
+        CryptProtectData, CRYPTPROTECT_UI_FORBIDDEN, CRYPT_INTEGER_BLOB,
+    };
+
+    let input = CRYPT_INTEGER_BLOB {
+        cbData: plaintext.len() as u32,
+        pbData: plaintext.as_ptr() as *mut u8,
+    };
+    let mut output = CRYPT_INTEGER_BLOB::default();
+    unsafe {
+        CryptProtectData(
+            &input,
+            windows::core::w!("Cubby clipboard storage key"),
+            None,
+            None,
+            None,
+            CRYPTPROTECT_UI_FORBIDDEN,
+            &mut output,
+        )
+        .map_err(|e| format!("Windows could not protect the storage key: {e}"))?;
+        let protected = std::slice::from_raw_parts(output.pbData, output.cbData as usize).to_vec();
+        let _ = LocalFree(Some(HLOCAL(output.pbData.cast())));
+        Ok(protected)
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn unprotect_for_current_user(protected: &[u8]) -> Result<Vec<u8>, String> {
+    use windows::Win32::Foundation::{LocalFree, HLOCAL};
+    use windows::Win32::Security::Cryptography::{
+        CryptUnprotectData, CRYPTPROTECT_UI_FORBIDDEN, CRYPT_INTEGER_BLOB,
+    };
+
+    let input = CRYPT_INTEGER_BLOB {
+        cbData: protected.len() as u32,
+        pbData: protected.as_ptr() as *mut u8,
+    };
+    let mut output = CRYPT_INTEGER_BLOB::default();
+    unsafe {
+        CryptUnprotectData(
+            &input,
+            None,
+            None,
+            None,
+            None,
+            CRYPTPROTECT_UI_FORBIDDEN,
+            &mut output,
+        )
+        .map_err(|e| format!("Windows could not unlock the storage key: {e}"))?;
+        let plaintext = std::slice::from_raw_parts(output.pbData, output.cbData as usize).to_vec();
+        let _ = LocalFree(Some(HLOCAL(output.pbData.cast())));
+        Ok(plaintext)
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn protect_for_current_user(_plaintext: &[u8]) -> Result<Vec<u8>, String> {
+    Err("Cubby encrypted storage currently requires Windows".to_string())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn unprotect_for_current_user(_protected: &[u8]) -> Result<Vec<u8>, String> {
+    Err("Cubby encrypted storage currently requires Windows".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CryptoManager, KEY_LEN};
+
+    #[test]
+    fn encrypted_payloads_round_trip_and_detect_tampering() {
+        let crypto = CryptoManager::ephemeral();
+        let encrypted = crypto.encrypt(b"private clipboard text").unwrap();
+        assert!(CryptoManager::is_encrypted(&encrypted));
+        assert_eq!(
+            crypto.decrypt(&encrypted).unwrap(),
+            b"private clipboard text"
+        );
+
+        let mut tampered = encrypted;
+        *tampered.last_mut().unwrap() ^= 1;
+        assert!(crypto.decrypt(&tampered).is_err());
+    }
+
+    #[test]
+    fn keyed_hash_is_stable_without_exposing_plain_sha256() {
+        let crypto = CryptoManager::ephemeral();
+        assert_eq!(crypto.keyed_hash(b"same"), crypto.keyed_hash(b"same"));
+        assert_ne!(crypto.keyed_hash(b"same"), crypto.keyed_hash(b"different"));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn persisted_key_is_dpapi_protected_and_reopens_for_the_same_user() {
+        let directory =
+            std::env::temp_dir().join(format!("cubby-key-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&directory).unwrap();
+        let database_path = directory.join("cubby.db");
+
+        let first = CryptoManager::load_or_create(&database_path, true).unwrap();
+        let protected_key = std::fs::read(directory.join("storage.key")).unwrap();
+        assert_ne!(protected_key.len(), KEY_LEN);
+
+        let second = CryptoManager::load_or_create(&database_path, false).unwrap();
+        assert_eq!(
+            first.keyed_hash(b"clipboard payload"),
+            second.keyed_hash(b"clipboard payload")
+        );
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn missing_key_fails_closed_once_encrypted_storage_exists() {
+        let directory =
+            std::env::temp_dir().join(format!("cubby-key-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&directory).unwrap();
+        let database_path = directory.join("cubby.db");
+        let error = CryptoManager::load_or_create(&database_path, false)
+            .err()
+            .expect("missing protected key should fail");
+        assert!(error.contains("storage key is missing"));
+        assert!(!directory.join("storage.key").exists());
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+}

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -1,19 +1,59 @@
 use sqlx::SqlitePool;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use crate::crypto::CryptoManager;
 
 #[derive(Clone)]
 pub struct Database {
     pub pool: SqlitePool,
+    pub crypto: Arc<CryptoManager>,
+    pub image_dir: PathBuf,
 }
 
 impl Database {
-    pub async fn new(db_path: &str) -> Self {
+    pub async fn new(db_path: &str) -> Result<Self, String> {
+        let image_dir = Path::new(db_path)
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join("images");
         let options = sqlx::sqlite::SqliteConnectOptions::new()
             .filename(db_path)
             .create_if_missing(true);
 
-        let pool = SqlitePool::connect_with(options).await.unwrap();
+        let pool = SqlitePool::connect_with(options)
+            .await
+            .map_err(|e| format!("failed to open clipboard database: {e}"))?;
+        let settings_table_exists: bool = sqlx::query_scalar(
+            r#"
+            SELECT EXISTS(
+                SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'settings'
+            )
+            "#,
+        )
+        .fetch_one(&pool)
+        .await
+        .map_err(|e| format!("failed to inspect clipboard database: {e}"))?;
+        let encryption_version = if settings_table_exists {
+            sqlx::query_scalar::<_, String>(
+                "SELECT value FROM settings WHERE key = 'storage_encryption_version'",
+            )
+            .fetch_optional(&pool)
+            .await
+            .map_err(|e| format!("failed to inspect clipboard encryption state: {e}"))?
+        } else {
+            None
+        };
+        let crypto = Arc::new(CryptoManager::load_or_create(
+            Path::new(db_path),
+            encryption_version.as_deref() != Some("1"),
+        )?);
 
-        Self { pool }
+        Ok(Self {
+            pool,
+            crypto,
+            image_dir,
+        })
     }
 
     pub async fn migrate(&self) -> Result<(), sqlx::Error> {
@@ -160,7 +200,9 @@ async fn add_column_if_missing(pool: &SqlitePool, sql: &str) -> Result<(), sqlx:
 #[cfg(test)]
 mod tests {
     use super::Database;
+    use crate::crypto::CryptoManager;
     use sqlx::sqlite::SqlitePoolOptions;
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn migration_adds_pin_state_to_existing_clip_tables() {
@@ -190,7 +232,11 @@ mod tests {
         .await
         .expect("legacy clips table should be created");
 
-        let database = Database { pool };
+        let database = Database {
+            pool,
+            crypto: Arc::new(CryptoManager::ephemeral()),
+            image_dir: std::env::temp_dir().join(format!("cubby-test-{}", uuid::Uuid::new_v4())),
+        };
         database.migrate().await.expect("migration should succeed");
 
         let pin_default: i64 = sqlx::query_scalar(
@@ -205,5 +251,40 @@ mod tests {
         .expect("is_pinned column should exist");
 
         assert_eq!(pin_default, 0);
+    }
+
+    #[tokio::test]
+    async fn encrypted_database_without_its_key_fails_closed() {
+        let directory =
+            std::env::temp_dir().join(format!("cubby-db-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&directory).unwrap();
+        let database_path = directory.join("cubby.db");
+        let options = sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&database_path)
+            .create_if_missing(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO settings (key, value) VALUES ('storage_encryption_version', '1')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        pool.close().await;
+
+        let error = Database::new(database_path.to_str().unwrap())
+            .await
+            .err()
+            .expect("missing protected key should stop startup");
+        assert!(error.contains("storage key is missing"));
+        assert!(!directory.join("storage.key").exists());
+        // SQLx may release the failed constructor's SQLite handle just after the
+        // error is returned on Windows, so cleanup is deliberately best effort.
+        let _ = std::fs::remove_dir_all(directory);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ static SHOW_GENERATION: AtomicU64 = AtomicU64::new(0);
 mod clipboard;
 mod commands;
 mod constants;
+mod crypto;
 mod database;
 mod models;
 pub mod paste_engine;
@@ -38,10 +39,18 @@ pub fn run_app() {
     let rt = get_runtime().expect("Failed to get global tokio runtime");
     let _guard = rt.enter();
 
-    let db = rt.block_on(async { Database::new(&db_path_str).await });
+    let db = rt
+        .block_on(async { Database::new(&db_path_str).await })
+        .unwrap_or_else(|error| panic!("Cubby storage initialization failed: {error}"));
 
     rt.block_on(async {
-        db.migrate().await.ok();
+        db.migrate().await.expect("Cubby database migration failed");
+        let migrated = commands::migrate_encrypted_storage(&db)
+            .await
+            .unwrap_or_else(|error| panic!("Cubby encrypted storage migration failed: {error}"));
+        if migrated > 0 {
+            log::info!("STORAGE: Encrypted {} existing clipboard items", migrated);
+        }
     });
 
     let db_arc = Arc::new(db);
@@ -337,13 +346,10 @@ pub fn run_app() {
             let db_for_clip = db_for_clipboard.clone();
             clipboard::init(&handle_for_clip, db_for_clip);
 
-            // Start background image migration
+            // Start background retention maintenance after encrypted storage is ready.
             let db_for_migration = db_for_clipboard.clone();
             let retention_settings = manager.get();
             tauri::async_runtime::spawn(async move {
-                if let Err(e) = commands::migrate_images_to_files(&db_for_migration.pool).await {
-                    log::error!("Background image migration failed: {}", e);
-                }
                 match commands::enforce_retention_in_pool(
                     &db_for_migration.pool,
                     retention_settings.max_items,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,14 +29,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost; img-src 'self' asset: http://asset.localhost data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; base-uri 'none'; frame-src 'none'",
-      "assetProtocol": {
-        "enable": true,
-        "scope": [
-          "$DATA/Cubby Clipboard/images/**",
-          "$LOCALDATA/Cubby Clipboard/images/**"
-        ]
-      },
+      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; base-uri 'none'; frame-src 'none'",
       "capabilities": [
         "default"
       ]


### PR DESCRIPTION
## Summary
- protect a random 256-bit storage key with Windows DPAPI and fail closed if an encrypted history loses that key
- encrypt clipboard payloads, previews, source attribution, metadata, thumbnails, and image files with AES-256-GCM
- replace plain SHA-256 dedupe values with keyed HMAC-SHA256
- migrate existing plaintext history before the clipboard listener starts, with resumable/idempotent handling
- remove WebView filesystem asset access and return decrypted image previews only from memory
- search encrypted history by decrypting/filtering in the Rust process instead of persisting a plaintext search index

## Verification
- 27 Rust library tests, including DPAPI persistence, key-loss failure, text migration, image migration, tamper detection, and idempotence
- all helper/bin tests
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- pnpm run format:check
- pnpm run release:check
- pnpm run build
- pnpm audit --prod
- ./scripts/audit-rust.ps1
- pnpm tauri build --no-bundle

## Review note
This PR is stacked on #12. Merge #12 first, then retarget/merge this PR.

Completes the encryption-at-rest portion of SOU-213.