### PR TITLE
Polish website hero and brand mark

### DIFF
--- a/product_pages/brand-mark.svg
+++ b/product_pages/brand-mark.svg
@@ -1,4 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 64" aria-hidden="true">
-  <path fill="#147ee8" d="M11 0h42c6.1 0 11 4.9 11 11s-4.9 11-11 11H34c-6.6 0-12 5.4-12 12v19c0 6.1-4.9 11-11 11S0 59.1 0 53V11C0 4.9 4.9 0 11 0Z"/>
-  <path fill="#32aeb1" d="M39 64c-5.5 0-10-4.5-10-10v-2c0-5.5 4.5-10 10-10h3c2.8 0 5-2.2 5-5v-2c0-5.5 4.5-10 10-10h1c5.5 0 10 4.5 10 10v19c0 5.5-4.5 10-10 10Z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" aria-hidden="true">
+  <!-- Small-size brand mark: a sturdy C-shaped cubby with a stored tile. -->
+  <path fill="#147ee8" d="M14 2h34c7.7 0 14 6.3 14 14v5H32c-6.6 0-12 5.4-12 12s5.4 12 12 12h30v3c0 7.7-6.3 14-14 14H14C6.3 62 0 55.7 0 48V16C0 8.3 6.3 2 14 2Z"/>
+  <rect x="42" y="25" width="20" height="16" rx="8" fill="#32aeb1"/>
 </svg>

--- a/product_pages/index.html
+++ b/product_pages/index.html
@@ -47,7 +47,6 @@
       </div>
 
       <div class="product-stage" aria-label="Preview of the Cubby clipboard history window">
-        <div class="cursor" aria-hidden="true"></div>
         <div class="cubby-window">
           <div class="mock-search"><span aria-hidden="true"></span>Search clipboard history</div>
           <div class="mock-tabs">

--- a/product_pages/styles.css
+++ b/product_pages/styles.css
@@ -33,7 +33,7 @@ a { color: inherit; }
 .site-header { position: relative; z-index: 10; border-bottom: 1px solid rgba(28, 39, 42, .09); }
 .nav-wrap { min-height: 76px; display: flex; align-items: center; justify-content: space-between; }
 .brand { display: inline-flex; align-items: center; gap: 10px; color: var(--ink); font-family: "Segoe UI Variable Display", "Segoe UI", system-ui, sans-serif; font-size: 18px; font-weight: 650; text-decoration: none; letter-spacing: -.025em; }
-.brand-mark { display: block; width: 34px; height: 32px; object-fit: contain; }
+.brand-mark { display: block; width: 32px; height: 32px; object-fit: contain; flex: 0 0 32px; }
 .nav-links { display: flex; align-items: center; gap: 28px; }
 .nav-links a { color: #445054; font-size: 14px; font-weight: 600; text-decoration: none; }
 .nav-links a:hover { color: var(--blue-dark); }
@@ -59,7 +59,6 @@ h1 span { color: #607075; font-weight: 600; }
 .product-stage { position: relative; min-height: 560px; display: grid; align-items: center; }
 .product-stage::before { content: ""; position: absolute; width: 460px; height: 460px; right: -35px; border-radius: 50%; background: #dfe9e8; filter: blur(0); opacity: .65; }
 .cubby-window { position: relative; z-index: 1; width: 100%; max-width: 540px; margin-left: auto; padding: 13px 13px 0; overflow: hidden; border: 1px solid rgba(255,255,255,.17); border-radius: 16px; background: rgba(27,32,34,.96); color: #f4f6f6; box-shadow: var(--shadow); transform: rotate(.35deg); }
-.cursor { position: absolute; z-index: 3; top: 16px; left: 48px; width: 18px; height: 27px; background: #fff; clip-path: polygon(0 0, 0 100%, 27% 75%, 44% 100%, 59% 91%, 42% 68%, 75% 65%); filter: drop-shadow(1px 2px 1px rgba(0,0,0,.5)); }
 .mock-search { height: 48px; display: flex; align-items: center; gap: 10px; padding: 0 14px; border: 1px solid #444b4d; border-radius: 10px; background: #272c2e; color: #aeb5b8; font-size: 13px; }
 .mock-search span { width: 13px; height: 13px; border: 1.7px solid #9ca6aa; border-radius: 50%; position: relative; }
 .mock-search span::after { content: ""; position: absolute; width: 5px; height: 1.5px; right: -4px; bottom: -2px; transform: rotate(45deg); background: #9ca6aa; }
@@ -228,7 +227,6 @@ kbd { padding: 2px 5px; border: 1px solid currentColor; border-radius: 4px; font
   .image-card { min-height: 88px; }
   .thumb { flex-basis: 76px; height: 53px; }
   .mock-footer { height: 28px; }
-  .cursor { top: 21px; left: 23px; }
   .trust-grid { grid-template-columns: 1fr; padding-block: 8px; }
   .trust-grid > div { min-height: 88px; padding: 0 14px; border-right: 0; border-bottom: 1px solid var(--line); }
   .section, .remote-section { padding-block: 82px; }


### PR DESCRIPTION
## What changed

- remove the decorative mouse-pointer shape behind the hero mockup
- refine the compact Cubby brand mark and lock it to a clean 32px square in the header

## Why

The pointer looked like an accidental cursor captured beside the product preview, and the previous header mark rendered unevenly at website size.

## Validation

- `git diff --check`
- confirmed the cursor element and its desktop/mobile CSS are fully removed
- Cloudflare preview will be visually checked before merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the brand mark sizing for a more balanced appearance.
  - Removed an unused decorative cursor element and its responsive styling from the product preview area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->