### PR TITLE
Remove reachable RSA dependency

### DIFF
--- a/scripts/audit-rust.ps1
+++ b/scripts/audit-rust.ps1
@@ -13,7 +13,7 @@ foreach ($target in $releaseTargets) {
         throw "Failed to inspect the Rust dependency tree for $target."
     }
 
-    if ($tree -match '(?m)(?:^|\s)rsa v0\.9\.10(?:\s|$)') {
+    if ($tree -match '(?m)(?:^|\s)rsa v[^\s]+(?:\s|$)') {
         throw "RUSTSEC-2023-0071 is reachable for $target; remove the waiver."
     }
 }

--- a/scripts/audit-rust.ps1
+++ b/scripts/audit-rust.ps1
@@ -6,7 +6,9 @@ $releaseTargets = @(
 )
 
 foreach ($target in $releaseTargets) {
-    $tree = cargo tree --manifest-path src-tauri/Cargo.toml --target $target 2>&1 | Out-String
+    # Cargo writes download/progress messages to stderr. Keep those out of the
+    # parsed tree so an inert lockfile download cannot look like a reachable node.
+    $tree = cargo tree --manifest-path src-tauri/Cargo.toml --locked --target $target | Out-String
     if ($LASTEXITCODE -ne 0) {
         throw "Failed to inspect the Rust dependency tree for $target."
     }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-global-shortcut = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlx = { version = "0.8", default-features = false, features = ["sqlite", "chrono", "uuid", "runtime-tokio", "derive"] }
+sqlx = { version = "0.8", default-features = false, features = ["sqlite", "chrono", "uuid", "runtime-tokio"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 sha2 = "0.10"

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
+use sqlx::{sqlite::SqliteRow, FromRow, Row};
 use std::sync::OnceLock;
 
 use std::collections::HashSet;
@@ -49,7 +49,7 @@ impl Default for AppSettings {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Clip {
     pub id: i64,
     pub uuid: String,
@@ -68,7 +68,29 @@ pub struct Clip {
     pub last_accessed: chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+impl<'r> FromRow<'r, SqliteRow> for Clip {
+    fn from_row(row: &'r SqliteRow) -> Result<Self, sqlx::Error> {
+        Ok(Self {
+            id: row.try_get("id")?,
+            uuid: row.try_get("uuid")?,
+            clip_type: row.try_get("clip_type")?,
+            content: row.try_get("content")?,
+            text_preview: row.try_get("text_preview")?,
+            content_hash: row.try_get("content_hash")?,
+            folder_id: row.try_get("folder_id")?,
+            is_deleted: row.try_get("is_deleted")?,
+            is_pinned: row.try_get("is_pinned")?,
+            is_thumbnail: row.try_get("is_thumbnail")?,
+            source_app: row.try_get("source_app")?,
+            source_icon: row.try_get("source_icon")?,
+            metadata: row.try_get("metadata")?,
+            created_at: row.try_get("created_at")?,
+            last_accessed: row.try_get("last_accessed")?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Folder {
     pub id: i64,
     pub name: String,
@@ -76,6 +98,19 @@ pub struct Folder {
     pub color: Option<String>,
     pub is_system: bool,
     pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl<'r> FromRow<'r, SqliteRow> for Folder {
+    fn from_row(row: &'r SqliteRow) -> Result<Self, sqlx::Error> {
+        Ok(Self {
+            id: row.try_get("id")?,
+            name: row.try_get("name")?,
+            icon: row.try_get("icon")?,
+            color: row.try_get("color")?,
+            is_system: row.try_get("is_system")?,
+            created_at: row.try_get("created_at")?,
+        })
+    }
 }
 
 static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();


### PR DESCRIPTION
## What changed

- removes SQLx's derive-macro feature from Cubby's SQLite-only build
- replaces the two `FromRow` derives with explicit `SqliteRow` mappings
- eliminates the clean-build path through SQLx MySQL support to `rsa 0.9.10`

## Why

The draft release preflight found `RUSTSEC-2023-0071` reachable on a clean x64 Windows runner. Cached PR runners had masked the SQLx macro dependency path. Cubby does not use MySQL, so the correct fix is to remove that feature rather than waive a reachable advisory.

## Validation

- `cargo tree --locked --target x86_64-pc-windows-msvc -i rsa` returns no path
- `cargo tree --locked --target x86_64-pc-windows-msvc -i sqlx-macros-core` returns no path
- Rust audit passes for x64 and ARM64 release targets
- 53 Rust tests pass
- strict Clippy and rustfmt pass
- release metadata check passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading clips and folders from the local database by fixing SQL-to-model row mapping.
* **Refactor**
  * Updated database row-mapping to explicitly handle SQLite results, improving consistency and reducing mapping errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->