### PR TITLE
Keep website downloads on the latest release

### DIFF
--- a/product_pages/index.html
+++ b/product_pages/index.html
@@ -173,12 +173,12 @@
 
     <section class="section shell release-section">
       <div>
-        <p class="eyebrow">The beta is ready</p>
-        <h2>Download the latest Cubby beta.</h2>
-        <p>Cubby already handles the clipboard formats you use most, with encrypted local history and workflows built for everyday Windows use. It is still a beta, so your feedback helps us polish compatibility before the stable release.</p>
+        <p class="eyebrow">Ready when you are</p>
+        <h2>Download the latest Cubby release.</h2>
+        <p>Cubby handles the clipboard formats you use most, with encrypted local history and workflows built for everyday Windows use. Your feedback helps us keep polishing compatibility and the details that make it feel at home on Windows.</p>
       </div>
       <div class="release-actions">
-        <a class="button button-primary" data-latest-release href="https://github.com/tsouth89/cubby-clipboard/releases">Download the latest beta</a>
+        <a class="button button-primary" data-latest-release href="https://github.com/tsouth89/cubby-clipboard/releases">Download the latest release</a>
         <a class="text-link" href="https://github.com/tsouth89/cubby-clipboard/issues">Report an issue <span aria-hidden="true">→</span></a>
       </div>
     </section>

--- a/product_pages/index.html
+++ b/product_pages/index.html
@@ -40,10 +40,10 @@
         <h1>Keep what you copy.<br><span>Find it when you need it.</span></h1>
         <p class="hero-lede">Cubby is the clipboard history Windows should have shipped: fast to open, easy to search, and dependable enough for the work you do all day.</p>
         <div class="cta-row">
-          <a class="button button-primary" href="https://github.com/tsouth89/cubby-clipboard/releases">Download for Windows <span aria-hidden="true">↓</span></a>
+          <a class="button button-primary" data-latest-release href="https://github.com/tsouth89/cubby-clipboard/releases">Download for Windows <span aria-hidden="true">↓</span></a>
           <a class="button button-secondary" href="https://github.com/tsouth89/cubby-clipboard">View on GitHub <span aria-hidden="true">↗</span></a>
         </div>
-        <p class="release-note">Early release · Windows 11 · Free and open source</p>
+        <p class="release-note"><span data-release-version>Latest beta · v0.1.0-beta.1</span> · Windows 11 · Free and open source</p>
       </div>
 
       <div class="product-stage" aria-label="Preview of the Cubby clipboard history window">
@@ -173,12 +173,12 @@
 
     <section class="section shell release-section">
       <div>
-        <p class="eyebrow">Early, useful, and improving</p>
-        <h2>Help shape Cubby’s first release.</h2>
-        <p>Cubby is under active development. The essentials work, but packaging, compatibility, and richer Windows clipboard formats are still being hardened before a broad release.</p>
+        <p class="eyebrow">The beta is ready</p>
+        <h2>Download the latest Cubby beta.</h2>
+        <p>Cubby already handles the clipboard formats you use most, with encrypted local history and workflows built for everyday Windows use. It is still a beta, so your feedback helps us polish compatibility before the stable release.</p>
       </div>
       <div class="release-actions">
-        <a class="button button-primary" href="https://github.com/tsouth89/cubby-clipboard/releases">Check available downloads</a>
+        <a class="button button-primary" data-latest-release href="https://github.com/tsouth89/cubby-clipboard/releases">Download the latest beta</a>
         <a class="text-link" href="https://github.com/tsouth89/cubby-clipboard/issues">Report an issue <span aria-hidden="true">→</span></a>
       </div>
     </section>
@@ -191,5 +191,6 @@
     </div>
     <div class="shell footer-bottom"><span>© 2026 SouthForge AI</span><span>Free and open source · GPL-3.0</span></div>
   </footer>
+  <script src="release-links.js" defer></script>
 </body>
 </html>

--- a/product_pages/privacy.html
+++ b/product_pages/privacy.html
@@ -23,14 +23,14 @@
       <p class="eyebrow">Privacy</p>
       <h1>Your clipboard stays yours.</h1>
       <p>Cubby is built to keep clipboard history useful without turning it into a cloud service.</p>
-      <div class="legal-meta">Last updated July 16, 2026</div>
+      <div class="legal-meta">Last updated July 17, 2026</div>
     </header>
     <article class="legal-content">
       <div class="legal-callout"><p><strong>The short version:</strong> Cubby stores clipboard history locally on your Windows PC. It does not require an account and does not include telemetry, advertising, cloud sync, or network-backed AI features.</p></div>
 
       <h2>What Cubby stores</h2>
-      <p>To provide clipboard history, Cubby records supported content you copy while it is running. That currently includes text and images, along with useful context such as the source application, content type, timestamps, and whether an item is pinned.</p>
-      <p>History is stored in Cubby’s local application-data directory. Images may be stored as local files and history metadata is stored in a local SQLite database.</p>
+      <p>To provide clipboard history, Cubby records supported content you copy while it is running. That currently includes plain text, HTML, RTF, images, and file lists, along with useful context such as the source application, content type, timestamps, and whether an item is pinned.</p>
+      <p>History is stored in Cubby’s local application-data directory. Clipboard payloads are kept in a local SQLite database, and image data is kept in local application files.</p>
 
       <h2>What Cubby does not collect</h2>
       <ul>
@@ -47,7 +47,7 @@
 
       <h2>Sensitive information</h2>
       <p>Clipboard history can contain passwords, access tokens, personal messages, customer information, and other sensitive content. Cubby provides ignored-application controls so selected apps can be excluded from capture, but no exclusion system should be treated as a substitute for careful handling of secrets.</p>
-      <div class="legal-callout"><p><strong>Important early-release limitation:</strong> Cubby’s local clipboard database and stored images are not encrypted yet. Anyone or any software with access to your Windows account and Cubby’s application-data files may be able to read that history.</p></div>
+      <div class="legal-callout"><p><strong>Local encryption:</strong> Cubby encrypts stored clipboard payloads and image data with AES-256-GCM. Its encryption key is protected by Windows for the current user. This protects copied content in Cubby’s application-data files at rest, but it cannot protect content from software running as you while Cubby is able to unlock your history.</p></div>
 
       <h2>Your controls</h2>
       <p>You can delete individual clips, clear unpinned history while preserving pinned clips, or use the confirmed clear-everything action. Uninstalling Cubby may not automatically remove every application-data file; those files can be removed manually if you want to erase all remaining local history.</p>

--- a/product_pages/release-links.js
+++ b/product_pages/release-links.js
@@ -10,7 +10,20 @@
     !release.draft &&
     typeof release.tag_name === "string" &&
     typeof release.html_url === "string" &&
+    typeof release.published_at === "string" &&
+    Number.isFinite(Date.parse(release.published_at)) &&
     release.html_url.startsWith(`${releasesUrl}/tag/`);
+
+  const selectLatestRelease = (releases) =>
+    releases
+      .filter(isCubbyRelease)
+      .reduce(
+        (latest, release) =>
+          !latest || Date.parse(release.published_at) > Date.parse(latest.published_at)
+            ? release
+            : latest,
+        null,
+      );
 
   const applyRelease = (release) => {
     if (!isCubbyRelease(release)) return;
@@ -47,7 +60,7 @@
       if (!response.ok) throw new Error(`GitHub returned ${response.status}`);
       return response.json();
     })
-    .then((releases) => releases.find(isCubbyRelease))
+    .then(selectLatestRelease)
     .then((release) => {
       if (!release) return;
       applyRelease(release);

--- a/product_pages/release-links.js
+++ b/product_pages/release-links.js
@@ -1,0 +1,63 @@
+(() => {
+  const releasesUrl = "https://github.com/tsouth89/cubby-clipboard/releases";
+  const releasesApi =
+    "https://api.github.com/repos/tsouth89/cubby-clipboard/releases?per_page=10";
+  const cacheKey = "cubby-latest-release-v1";
+  const cacheLifetimeMs = 60 * 60 * 1000;
+
+  const isCubbyRelease = (release) =>
+    release &&
+    !release.draft &&
+    typeof release.tag_name === "string" &&
+    typeof release.html_url === "string" &&
+    release.html_url.startsWith(`${releasesUrl}/tag/`);
+
+  const applyRelease = (release) => {
+    if (!isCubbyRelease(release)) return;
+
+    document.querySelectorAll("[data-latest-release]").forEach((link) => {
+      link.href = release.html_url;
+    });
+
+    document.querySelectorAll("[data-release-version]").forEach((label) => {
+      label.textContent = `${release.prerelease ? "Latest beta" : "Latest release"} · ${release.tag_name}`;
+    });
+  };
+
+  const readCache = () => {
+    try {
+      const cached = JSON.parse(localStorage.getItem(cacheKey));
+      if (Date.now() - cached.savedAt < cacheLifetimeMs && isCubbyRelease(cached.release)) {
+        return cached.release;
+      }
+    } catch {
+      // A blocked or malformed cache should never prevent the fallback link from working.
+    }
+    return null;
+  };
+
+  const cachedRelease = readCache();
+  if (cachedRelease) {
+    applyRelease(cachedRelease);
+    return;
+  }
+
+  fetch(releasesApi, { headers: { Accept: "application/vnd.github+json" } })
+    .then((response) => {
+      if (!response.ok) throw new Error(`GitHub returned ${response.status}`);
+      return response.json();
+    })
+    .then((releases) => releases.find(isCubbyRelease))
+    .then((release) => {
+      if (!release) return;
+      applyRelease(release);
+      try {
+        localStorage.setItem(cacheKey, JSON.stringify({ savedAt: Date.now(), release }));
+      } catch {
+        // The resolved link still works when storage is unavailable.
+      }
+    })
+    .catch(() => {
+      // Keep the releases-page fallback if GitHub is unavailable or rate-limited.
+    });
+})();

--- a/product_pages/support.html
+++ b/product_pages/support.html
@@ -27,7 +27,7 @@
     <article class="legal-content">
       <div class="support-grid">
         <a class="support-card" href="https://github.com/tsouth89/cubby-clipboard/issues/new"><strong>Report a problem</strong><span>Share reproducible details on GitHub.</span></a>
-        <a class="support-card" href="https://github.com/tsouth89/cubby-clipboard/releases"><strong>Find a release</strong><span>See available Windows downloads and notes.</span></a>
+        <a class="support-card" data-latest-release href="https://github.com/tsouth89/cubby-clipboard/releases"><strong>Get the latest release</strong><span>Download the newest Windows beta and read its notes.</span></a>
         <a class="support-card" href="https://github.com/tsouth89/cubby-clipboard"><strong>Read the source</strong><span>Inspect Cubby or contribute a change.</span></a>
         <a class="support-card" href="privacy.html"><strong>Understand local storage</strong><span>See what Cubby keeps and where.</span></a>
       </div>
@@ -56,7 +56,7 @@
         </details>
         <details>
           <summary>Where is my history stored?</summary>
-          <p>On your Windows PC, in Cubby’s local application-data directory. The current early build does not encrypt this local history, so review the <a href="privacy.html">privacy page</a> before using Cubby with sensitive data.</p>
+          <p>On your Windows PC, in Cubby’s local application-data directory. Clipboard payloads and stored images are encrypted at rest with a key protected for your Windows user. See the <a href="privacy.html">privacy page</a> for the full security model.</p>
         </details>
         <details>
           <summary>Is Cubby free?</summary>
@@ -72,9 +72,10 @@
       </ul>
 
       <h2>Early-release expectations</h2>
-      <p>Cubby is under active development and is not yet presented as a fully hardened general release. Clipboard compatibility varies between applications, and richer formats beyond text and images are still being expanded. Check the release notes for the current supported behavior.</p>
+      <p>Cubby is beta software and is not yet presented as a fully hardened general release. It supports plain text, HTML, RTF, images, and file lists, though clipboard compatibility can still vary between applications and custom formats. Check the latest release notes for current behavior.</p>
     </article>
   </main>
   <footer class="site-footer"><div class="shell footer-grid"><div><a class="brand footer-brand" href="index.html"><img class="brand-mark" src="brand-mark.svg" alt=""><span>cubby clipboard</span></a><p>A better place for what you copy.</p></div><nav aria-label="Footer navigation"><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a><a href="support.html">Support</a><a href="https://github.com/tsouth89/cubby-clipboard">GitHub</a></nav></div><div class="shell footer-bottom"><span>© 2026 SouthForge AI</span><span>Free and open source · GPL-3.0</span></div></footer>
+  <script src="release-links.js" defer></script>
 </body>
 </html>

--- a/product_pages/support.html
+++ b/product_pages/support.html
@@ -27,7 +27,7 @@
     <article class="legal-content">
       <div class="support-grid">
         <a class="support-card" href="https://github.com/tsouth89/cubby-clipboard/issues/new"><strong>Report a problem</strong><span>Share reproducible details on GitHub.</span></a>
-        <a class="support-card" data-latest-release href="https://github.com/tsouth89/cubby-clipboard/releases"><strong>Get the latest release</strong><span>Download the newest Windows beta and read its notes.</span></a>
+        <a class="support-card" data-latest-release href="https://github.com/tsouth89/cubby-clipboard/releases"><strong>Get the latest release</strong><span>Download the newest Windows release and read its notes.</span></a>
         <a class="support-card" href="https://github.com/tsouth89/cubby-clipboard"><strong>Read the source</strong><span>Inspect Cubby or contribute a change.</span></a>
         <a class="support-card" href="privacy.html"><strong>Understand local storage</strong><span>See what Cubby keeps and where.</span></a>
       </div>

--- a/product_pages/terms.html
+++ b/product_pages/terms.html
@@ -37,7 +37,7 @@
       <p>Do not rely on Cubby as the only copy of important information. Clipboard capture can be interrupted by Windows, source applications, remote-session software, permissions, or unsupported clipboard formats.</p>
 
       <h2>4. Privacy</h2>
-      <p>Cubby is designed to store clipboard history locally. Please read the <a href="privacy.html">Privacy Policy</a> for current data handling and the important limitation that early-release history is not encrypted at rest.</p>
+      <p>Cubby is designed to store clipboard history locally, with clipboard payloads encrypted at rest using a key protected for the current Windows user. Please read the <a href="privacy.html">Privacy Policy</a> for the current data-handling and security model.</p>
 
       <h2>5. No warranty</h2>
       <div class="legal-callout"><p><strong>Cubby is provided “as is” and “as available,” without warranties of any kind, to the extent permitted by law.</strong> This includes implied warranties of merchantability, fitness for a particular purpose, and non-infringement.</p></div>


### PR DESCRIPTION
## Summary
- resolve website download CTAs to the newest published GitHub release, including prereleases
- keep the releases page as a resilient fallback
- update beta, format-support, and encrypted-storage copy to match the shipped app

## Validation
- node .github/scripts/check-site.mjs
- node --check product_pages/release-links.js
- verified the GitHub releases API resolves v0.1.0-beta.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Release buttons and “Get the latest release” links now dynamically resolve to the newest available GitHub release and display the current release/beta version.

- **Documentation**
  - Updated Privacy, Support, and Terms pages with revised “last updated” details, expanded storage/content descriptions, and clearer encryption-at-rest behavior (including user-protected keys and images/clipboard payload handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->