### PR TITLE
Configured hotkey opens Cubby inside remote sessions (0.1.0-beta.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable Cubby Clipboard changes are documented here. PastePaw entries below Cubby's first beta are retained as upstream history and attribution.
 
+## v0.1.0-beta.2
+
+### Added
+- The configured Cubby hotkey now opens the flyout inside supported remote sessions (Ninja Remote, Windows Remote Desktop, and other recognized clients) when the remote client's own keyboard forwarding is turned off, using the same low-level path as the `Win+V` replacement
+
+### Changed
+- Replaced the double-Ctrl remote-session gesture with the configured hotkey, which also avoids triggering Windows' "show pointer location on Ctrl" behavior
+
+### Known limitations
+- When a remote client such as Ninja Remote has keyboard forwarding enabled it captures the keyboard before Cubby can, so no hotkey opens Cubby in that mode; open Cubby from the tray icon instead
+
+### 新增
+- 当受支持的远程会话（Ninja Remote、Windows 远程桌面及其他已识别的客户端）关闭其键盘转发时，您配置的快捷键现在可在会话内打开 Cubby，使用与 `Win+V` 替代方案相同的底层机制
+
+### 变更
+- 以配置的快捷键取代了原有的双击 Ctrl 远程手势，同时避免触发 Windows 的“按 Ctrl 键时显示指针位置”行为
+
+### 已知限制
+- 当远程客户端（如 Ninja Remote）启用键盘转发时，它会先于 Cubby 捕获键盘，因此在该模式下没有任何快捷键能打开 Cubby；请改用托盘图标
+
 ## v0.1.0-beta.1
 
 ### Added

--- a/docs/REMOTE_SESSIONS.md
+++ b/docs/REMOTE_SESSIONS.md
@@ -4,29 +4,55 @@ Remote-control applications handle keyboard and clipboard input differently from
 ordinary Windows applications. Cubby detects supported remote clients when the
 flyout opens and selects a compatible paste strategy.
 
+## Opening Cubby inside a remote session
+
+Cubby matches your configured hotkey inside the same low-level keyboard hook that
+powers its `Win+V` replacement, so the hotkey that opens the flyout locally also
+opens it while a supported remote client is focused, and the chord is suppressed
+so it does not leak into the remote machine. The trigger tracks whatever hotkey
+you set, so a user coming from Ditto can keep Ctrl+backtick.
+
+Two requirements, both verified by testing:
+
+- **Win+V replacement must be enabled** in Settings. That is what runs the hook.
+- **The remote client's own keyboard forwarding must be off.** When Ninja Remote's
+  "forward keyboard shortcuts" is on, Ninja installs its own keyboard capture that
+  runs ahead of Cubby's hook and consumes the keys first, so the hotkey never
+  reaches Cubby. With forwarding off, Cubby's hook wins and the hotkey works. Avoid
+  `Win+V` itself inside a remote session with forwarding on: the Windows shell
+  handles the Win key low enough that it can both open Cubby locally and leak to
+  the remote.
+
+If you keep keyboard forwarding on, open Cubby from the tray instead of a hotkey.
+
 ## Ninja Remote
 
 Recommended player settings:
 
 - Enable clipboard synchronization.
-- Keep Forward keyboard shortcuts enabled if that is your normal workflow.
+- Turn **Forward keyboard shortcuts off** if you want to open Cubby with a hotkey
+  inside the session. With it on, use the tray icon instead.
 
 Recommended Cubby setting:
 
 - Remote session paste: **Copy, then Ctrl+V**.
 
+Ninja filters injected keyboard input, so Cubby cannot press paste for you inside
+a Ninja session. The reliable, driver-free flow is to let Ninja synchronize the
+clipboard as data and paste it with a physical `Ctrl+V`:
+
 Workflow:
 
 1. Focus the destination inside Ninja Remote.
-2. Double-tap Left Ctrl or Right Ctrl.
+2. Open Cubby (hotkey with forwarding off, otherwise the tray icon).
 3. Select a clip in Cubby.
 4. Cubby writes the complete item to the local clipboard, closes, restores focus
    to Ninja.
-5. Press physical Ctrl+V.
+5. Press physical `Ctrl+V`.
 
 This is the preferred mode for large logs, scripts, formatted text, and other
 large clipboard items. Ninja synchronizes the clipboard as data, so content is
-not typed character by character.
+pasted at once, not typed character by character.
 
 The optional **Paste as keystrokes** mode invokes Ninja's own toolbar action
 through Windows accessibility. It is useful for short text or sensitive values,
@@ -49,6 +75,7 @@ individually because forwarding and clipboard policies vary.
 - `cargo test --all-targets` covers remote-client detection, trigger state, and
   paste-mode selection.
 - `scripts/test-remote-trigger.ps1` validates the helper's direct activation
-  channel and double-Ctrl gesture without requiring Ninja.
+  channel and the configured-hotkey trigger (Ctrl+backtick) without requiring
+  Ninja.
 - `scripts/test-paste-compat.ps1` exercises standard and generic remote focus and
   paste behavior in an isolated Windows test window.

--- a/docs/SHORTCUT_BEHAVIOR.md
+++ b/docs/SHORTCUT_BEHAVIOR.md
@@ -30,10 +30,21 @@ replacement mode is disabled.
 
 ## Remote-session trigger
 
-Some remote-control clients consume Windows-key shortcuts before the host can
-handle them. Cubby therefore supports double-tapping either Ctrl key while a
-known remote client is the foreground application.
+A global shortcut registered locally does not fire while a remote-control client
+is focused, because the client captures keyboard input first. The same low-level
+hook that intercepts `Win+V` also matches the user's configured Cubby hotkey when
+a known remote client is the foreground application, and suppresses the chord so
+it does not reach the remote session, whatever the user set it to (for example
+Ctrl+backtick).
 
-The gesture is active only for supported remote clients, including Ninja Remote,
+This works only when the remote client's own keyboard forwarding is off. Clients
+such as Ninja Remote install their own keyboard capture when forwarding is on,
+and because that capture loads after Cubby's it runs ahead of Cubby's hook and
+consumes the keys first. With forwarding off, Cubby's hook wins. When forwarding
+must stay on, open Cubby from the tray instead.
+
+The trigger is active only for supported remote clients, including Ninja Remote,
 Windows Remote Desktop, AnyDesk, TeamViewer, ScreenConnect, Splashtop, and
-RustDesk. Double-Ctrl does nothing in ordinary local applications.
+RustDesk, and only while replacement mode is enabled (that is what runs the
+hook). It does nothing in ordinary local applications, where the normal global
+shortcut already handles activation.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cubby-clipboard",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "description": "A native-feeling clipboard history replacement for Windows 11",
   "license": "GPL-3.0",
   "type": "module",

--- a/scripts/test-remote-trigger.ps1
+++ b/scripts/test-remote-trigger.ps1
@@ -65,6 +65,11 @@ function Send-Chord {
     Start-Sleep -Milliseconds 35
     [CubbyRemoteTriggerTestInput]::keybd_event($backquote, 0, 0, $testMarker)
     Start-Sleep -Milliseconds 35
+    # Simulate key auto-repeat while held: extra keydowns must debounce to a single activation
+    [CubbyRemoteTriggerTestInput]::keybd_event($backquote, 0, 0, $testMarker)
+    Start-Sleep -Milliseconds 35
+    [CubbyRemoteTriggerTestInput]::keybd_event($backquote, 0, 0, $testMarker)
+    Start-Sleep -Milliseconds 35
     [CubbyRemoteTriggerTestInput]::keybd_event($backquote, 0, $keyUp, $testMarker)
     Start-Sleep -Milliseconds 35
     [CubbyRemoteTriggerTestInput]::keybd_event($leftCtrl, 0, $keyUp, $testMarker)

--- a/scripts/test-remote-trigger.ps1
+++ b/scripts/test-remote-trigger.ps1
@@ -43,10 +43,15 @@ if (-not ("CubbyRemoteTriggerTestInput" -as [type])) {
     Add-Type -TypeDefinition $nativeSource
 }
 
+# Exercises the configured-hotkey remote trigger with Ditto's default chord,
+# Ctrl+` (VK_OEM_3). --accept-injected-test-events lets the helper act on the
+# injected keys and skips the "foreground is a remote client" gate.
 $leftCtrl = [byte]0xA2
 $rightCtrl = [byte]0xA3
+$backquote = [byte]0xC0
 $keyUp = 0x0002
 $testMarker = [UIntPtr]0x43554254
+$activationHotkey = "Ctrl+Backquote"
 $listener = [System.Net.Sockets.UdpClient]::new(0)
 $listener.Client.ReceiveTimeout = 3000
 $activationPort = ([System.Net.IPEndPoint]$listener.Client.LocalEndPoint).Port
@@ -55,26 +60,32 @@ $stdoutPath = Join-Path $env:TEMP "cubby-remote-trigger-test-$stamp.out.log"
 $stderrPath = Join-Path $env:TEMP "cubby-remote-trigger-test-$stamp.err.log"
 $process = $null
 
-function Send-CtrlTap([byte]$key) {
-    [CubbyRemoteTriggerTestInput]::keybd_event($key, 0, 0, $testMarker)
+function Send-Chord {
+    [CubbyRemoteTriggerTestInput]::keybd_event($leftCtrl, 0, 0, $testMarker)
     Start-Sleep -Milliseconds 35
-    [CubbyRemoteTriggerTestInput]::keybd_event($key, 0, $keyUp, $testMarker)
+    [CubbyRemoteTriggerTestInput]::keybd_event($backquote, 0, 0, $testMarker)
+    Start-Sleep -Milliseconds 35
+    [CubbyRemoteTriggerTestInput]::keybd_event($backquote, 0, $keyUp, $testMarker)
+    Start-Sleep -Milliseconds 35
+    [CubbyRemoteTriggerTestInput]::keybd_event($leftCtrl, 0, $keyUp, $testMarker)
     Start-Sleep -Milliseconds 100
 }
 
-function Release-CtrlKeys {
+function Release-Keys {
     [CubbyRemoteTriggerTestInput]::keybd_event($leftCtrl, 0, $keyUp, $testMarker)
     [CubbyRemoteTriggerTestInput]::keybd_event($rightCtrl, 0, $keyUp, $testMarker)
+    [CubbyRemoteTriggerTestInput]::keybd_event($backquote, 0, $keyUp, $testMarker)
 }
 
 try {
-    Release-CtrlKeys
+    Release-Keys
     $process = Start-Process `
         -FilePath $helperPath `
         -ArgumentList @(
             "--timeout-seconds", $TimeoutSeconds,
             "--accept-injected-test-events",
-            "--activation-port", $activationPort
+            "--activation-port", $activationPort,
+            "--activation-hotkey", $activationHotkey
         ) `
         -WindowStyle Hidden `
         -RedirectStandardOutput $stdoutPath `
@@ -95,8 +106,7 @@ try {
         throw "Helper did not become ready. stderr: $(Get-Content -LiteralPath $stderrPath -Raw)"
     }
 
-    Send-CtrlTap $leftCtrl
-    Send-CtrlTap $leftCtrl
+    Send-Chord
 
     $remoteEndpoint = [System.Net.IPEndPoint]::new([System.Net.IPAddress]::Any, 0)
     $message = $listener.Receive([ref]$remoteEndpoint)
@@ -109,35 +119,36 @@ try {
     $events = Get-Content -LiteralPath $stdoutPath |
         Where-Object { $_.Trim() } |
         ForEach-Object { $_ | ConvertFrom-Json }
-    $triggerCount = @($events | Where-Object event -eq "remote_trigger").Count
+    $triggerCount = @($events | Where-Object event -eq "configured_hotkey").Count
     $failures = @($events | Where-Object event -in @("error", "activation_failed"))
 
     if ($triggerCount -ne 1) {
-        throw "Expected 1 remote trigger activation, observed $triggerCount"
+        throw "Expected 1 configured-hotkey activation, observed $triggerCount"
     }
     if ($failures.Count -ne 0) {
         throw "Helper reported failures: $($failures | ConvertTo-Json -Compress)"
     }
 
-    Release-CtrlKeys
+    Release-Keys
     Start-Sleep -Milliseconds 100
     if (
         [CubbyRemoteTriggerTestInput]::GetAsyncKeyState($leftCtrl) -lt 0 -or
-        [CubbyRemoteTriggerTestInput]::GetAsyncKeyState($rightCtrl) -lt 0
+        [CubbyRemoteTriggerTestInput]::GetAsyncKeyState($rightCtrl) -lt 0 -or
+        [CubbyRemoteTriggerTestInput]::GetAsyncKeyState($backquote) -lt 0
     ) {
-        throw "A Ctrl key remains logically down"
+        throw "A trigger key remains logically down"
     }
 
     [pscustomobject]@{
         Passed = $true
-        Trigger = "Double-tap Left Ctrl"
+        Trigger = "Ctrl+` (configured hotkey)"
         DirectActivations = $triggerCount
         KeysStillDown = 0
         Log = $stdoutPath
     } | Format-List
 }
 finally {
-    Release-CtrlKeys
+    Release-Keys
     $listener.Dispose()
     if ($process -and -not $process.HasExited) {
         Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "cubby"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubby"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 description = "A native-feeling clipboard history replacement for Windows 11"
 authors = ["SouthForge AI", "PastePaw contributors"]
 license = "GPL-3.0"

--- a/src-tauri/src/bin/win_v_helper.rs
+++ b/src-tauri/src/bin/win_v_helper.rs
@@ -36,6 +36,10 @@ mod windows_helper {
     /// client's key forwarding, so the same hotkey that opens Cubby locally also
     /// opens it inside RDP/Ninja/etc. `None` means no valid hotkey was supplied.
     static CONFIGURED_CHORD: OnceLock<Option<TriggerChord>> = OnceLock::new();
+    /// Tracks whether the configured hotkey's main key is currently held after a
+    /// remote activation, so key auto-repeat does not re-toggle Cubby and the
+    /// matching key-up is consumed instead of leaking into the remote session.
+    static CONFIGURED_KEY_DOWN: AtomicBool = AtomicBool::new(false);
 
     /// A hotkey reduced to the physical keys the low-level hook can match:
     /// its main key plus the exact set of modifiers that must be held.
@@ -507,19 +511,28 @@ mod windows_helper {
         // remote client is focused (locally the global shortcut already handles
         // it, so this avoids a double toggle). Suppress the chord so it never
         // leaks into the remote session.
-        if is_down {
-            if let Some(Some(chord)) = CONFIGURED_CHORD.get() {
-                if key == chord.key_vk
-                    && modifiers_match(chord)
-                    && (ACCEPT_TEST_INPUT.load(Ordering::SeqCst)
-                        || foreground_is_supported_remote())
-                {
-                    match activate_cubby(None, false) {
-                        Ok(()) => emit("configured_hotkey", Some("activated Cubby directly")),
-                        Err(error) => emit("activation_failed", Some(&error)),
-                    }
+        if let Some(Some(chord)) = CONFIGURED_CHORD.get() {
+            // Consume the main key's release after an activation so it neither
+            // re-triggers nor leaks into the remote session.
+            if is_up && key == chord.key_vk && CONFIGURED_KEY_DOWN.swap(false, Ordering::SeqCst) {
+                return LRESULT(1);
+            }
+            if is_down
+                && key == chord.key_vk
+                && modifiers_match(chord)
+                && (ACCEPT_TEST_INPUT.load(Ordering::SeqCst) || foreground_is_supported_remote())
+            {
+                // Key auto-repeat fires repeated keydowns while the key is held;
+                // activate only on the first and suppress the rest so the toggle
+                // does not immediately hide Cubby again.
+                if CONFIGURED_KEY_DOWN.swap(true, Ordering::SeqCst) {
                     return LRESULT(1);
                 }
+                match activate_cubby(None, false) {
+                    Ok(()) => emit("configured_hotkey", Some("activated Cubby directly")),
+                    Err(error) => emit("activation_failed", Some(&error)),
+                }
+                return LRESULT(1);
             }
         }
 

--- a/src-tauri/src/bin/win_v_helper.rs
+++ b/src-tauri/src/bin/win_v_helper.rs
@@ -15,7 +15,7 @@ mod windows_helper {
     use windows::Win32::UI::Input::KeyboardAndMouse::{
         GetAsyncKeyState, MapVirtualKeyW, SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT,
         KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP, MAPVK_VK_TO_VSC, VIRTUAL_KEY, VK_LCONTROL,
-        VK_LMENU, VK_LWIN, VK_RCONTROL, VK_RWIN, VK_V,
+        VK_LMENU, VK_LSHIFT, VK_LWIN, VK_RCONTROL, VK_RMENU, VK_RSHIFT, VK_RWIN, VK_V,
     };
     use windows::Win32::UI::WindowsAndMessaging::{
         CallNextHookEx, DispatchMessageW, GetForegroundWindow, GetMessageW,
@@ -26,12 +26,27 @@ mod windows_helper {
 
     const DUMMY_KEY: u16 = 0x00FF;
     const CUBBY_INJECTED_FLAG: usize = 0x4355_4242;
-    const REMOTE_TRIGGER_DOUBLE_TAP_MS: u32 = 400;
 
     static STATE: OnceLock<Mutex<RemapState>> = OnceLock::new();
     static HOOK_THREAD_ID: AtomicU32 = AtomicU32::new(0);
     static ACCEPT_TEST_INPUT: AtomicBool = AtomicBool::new(false);
     static ACTIVATION_PORT: AtomicU16 = AtomicU16::new(0);
+    /// The user's configured Cubby hotkey, parsed into a physical chord. When a
+    /// remote client is focused this chord is caught here, below the remote
+    /// client's key forwarding, so the same hotkey that opens Cubby locally also
+    /// opens it inside RDP/Ninja/etc. `None` means no valid hotkey was supplied.
+    static CONFIGURED_CHORD: OnceLock<Option<TriggerChord>> = OnceLock::new();
+
+    /// A hotkey reduced to the physical keys the low-level hook can match:
+    /// its main key plus the exact set of modifiers that must be held.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct TriggerChord {
+        ctrl: bool,
+        alt: bool,
+        shift: bool,
+        win: bool,
+        key_vk: u16,
+    }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum Decision {
@@ -44,7 +59,6 @@ mod windows_helper {
         RestoreWinAndPass {
             win_key: u16,
         },
-        ActivateRemoteTrigger,
     }
 
     #[derive(Debug, Default)]
@@ -53,7 +67,6 @@ mod windows_helper {
         active_chord: bool,
         physical_v_down: bool,
         logical_win_released: bool,
-        last_ctrl_up: Option<(u16, u32)>,
     }
 
     impl RemapState {
@@ -63,24 +76,13 @@ mod windows_helper {
             is_down: bool,
             is_up: bool,
             exact_match: bool,
-            timestamp: u32,
+            _timestamp: u32,
         ) -> Decision {
+            // Ctrl is never remapped. The configured-hotkey remote trigger is
+            // matched in `hook_proc` (it needs the live modifier state), so the
+            // state machine only owns the Win+V chord.
             if key == VK_LCONTROL.0 || key == VK_RCONTROL.0 {
-                if is_up {
-                    let is_double_tap = self.last_ctrl_up.is_some_and(|(last_key, last_time)| {
-                        last_key == key
-                            && timestamp.wrapping_sub(last_time) <= REMOTE_TRIGGER_DOUBLE_TAP_MS
-                    });
-                    self.last_ctrl_up = (!is_double_tap).then_some((key, timestamp));
-                    if is_double_tap {
-                        return Decision::ActivateRemoteTrigger;
-                    }
-                }
                 return Decision::Pass;
-            }
-
-            if is_down {
-                self.last_ctrl_up = None;
             }
 
             if key == VK_LWIN.0 || key == VK_RWIN.0 {
@@ -142,6 +144,132 @@ mod windows_helper {
             self.physical_v_down = false;
             self.logical_win_released = release_was_attempted;
         }
+    }
+
+    /// Map a single hotkey token (as produced by the settings UI, i.e.
+    /// `KeyboardEvent.code` names like `KeyV`/`Digit1`/`Backquote`, letters and
+    /// digits already unwrapped, plus loose single-character symbols) to a
+    /// Windows virtual-key code. Returns `None` for tokens we cannot match.
+    fn key_name_to_vk(name: &str) -> Option<u16> {
+        if name.chars().count() == 1 {
+            let c = name.chars().next().unwrap().to_ascii_uppercase();
+            if c.is_ascii_alphanumeric() {
+                return Some(c as u16); // 'A'..='Z' => 0x41.., '0'..='9' => 0x30..
+            }
+            return match c {
+                '`' | '~' => Some(0xC0),
+                '-' | '_' => Some(0xBD),
+                '=' | '+' => Some(0xBB),
+                '[' | '{' => Some(0xDB),
+                ']' | '}' => Some(0xDD),
+                '\\' | '|' => Some(0xDC),
+                ';' | ':' => Some(0xBA),
+                '\'' | '"' => Some(0xDE),
+                ',' | '<' => Some(0xBC),
+                '.' | '>' => Some(0xBE),
+                '/' | '?' => Some(0xBF),
+                ' ' => Some(0x20),
+                _ => None,
+            };
+        }
+
+        let lower = name.to_ascii_lowercase();
+        if let Some(rest) = lower.strip_prefix("key") {
+            if rest.len() == 1 && rest.starts_with(|c: char| c.is_ascii_alphabetic()) {
+                return Some(rest.to_ascii_uppercase().as_bytes()[0] as u16);
+            }
+        }
+        if let Some(rest) = lower.strip_prefix("digit") {
+            if rest.len() == 1 && rest.starts_with(|c: char| c.is_ascii_digit()) {
+                return Some(rest.as_bytes()[0] as u16);
+            }
+        }
+        if let Some(rest) = lower.strip_prefix('f') {
+            if let Ok(n) = rest.parse::<u16>() {
+                if (1..=24).contains(&n) {
+                    return Some(0x70 + (n - 1)); // VK_F1 = 0x70
+                }
+            }
+        }
+        match lower.as_str() {
+            "backquote" | "grave" => Some(0xC0),
+            "minus" | "hyphen" => Some(0xBD),
+            "equal" => Some(0xBB),
+            "bracketleft" => Some(0xDB),
+            "bracketright" => Some(0xDD),
+            "backslash" => Some(0xDC),
+            "semicolon" => Some(0xBA),
+            "quote" | "apostrophe" => Some(0xDE),
+            "comma" => Some(0xBC),
+            "period" | "dot" => Some(0xBE),
+            "slash" => Some(0xBF),
+            "space" | "spacebar" => Some(0x20),
+            "tab" => Some(0x09),
+            "enter" | "return" => Some(0x0D),
+            "backspace" => Some(0x08),
+            "insert" | "ins" => Some(0x2D),
+            "delete" | "del" => Some(0x2E),
+            "home" => Some(0x24),
+            "end" => Some(0x23),
+            "pageup" | "prior" => Some(0x21),
+            "pagedown" | "next" => Some(0x22),
+            "arrowup" | "up" => Some(0x26),
+            "arrowdown" | "down" => Some(0x28),
+            "arrowleft" | "left" => Some(0x25),
+            "arrowright" | "right" => Some(0x27),
+            _ => None,
+        }
+    }
+
+    /// Parse a `+`-separated hotkey string (e.g. `Ctrl+Shift+V`, `Ctrl+Backquote`)
+    /// into a physical chord. Requires exactly one non-modifier key and at least
+    /// one modifier, so a bare key can never become a global remote trigger.
+    fn parse_hotkey(spec: &str) -> Option<TriggerChord> {
+        let mut chord = TriggerChord {
+            ctrl: false,
+            alt: false,
+            shift: false,
+            win: false,
+            key_vk: 0,
+        };
+        let mut has_key = false;
+        for raw in spec.split('+') {
+            let token = raw.trim();
+            if token.is_empty() {
+                continue;
+            }
+            match token.to_ascii_lowercase().as_str() {
+                "ctrl" | "control" | "ctl" => chord.ctrl = true,
+                "alt" | "option" | "opt" => chord.alt = true,
+                "shift" => chord.shift = true,
+                "win" | "windows" | "super" | "meta" | "cmd" | "command" => chord.win = true,
+                _ => {
+                    let vk = key_name_to_vk(token)?;
+                    if has_key {
+                        return None; // more than one main key is not a chord we match
+                    }
+                    chord.key_vk = vk;
+                    has_key = true;
+                }
+            }
+        }
+        let has_modifier = chord.ctrl || chord.alt || chord.shift || chord.win;
+        (has_key && has_modifier).then_some(chord)
+    }
+
+    fn key_is_down(vk: u16) -> bool {
+        (unsafe { GetAsyncKeyState(vk as i32) } as u16 & 0x8000) != 0
+    }
+
+    /// True when the physically-held modifiers exactly match the chord: every
+    /// required modifier down and every other modifier up. The exact match
+    /// prevents, say, `Ctrl+V` from firing when the user presses `Ctrl+Shift+V`.
+    fn modifiers_match(chord: &TriggerChord) -> bool {
+        let ctrl = key_is_down(VK_LCONTROL.0) || key_is_down(VK_RCONTROL.0);
+        let alt = key_is_down(VK_LMENU.0) || key_is_down(VK_RMENU.0);
+        let shift = key_is_down(VK_LSHIFT.0) || key_is_down(VK_RSHIFT.0);
+        let win = key_is_down(VK_LWIN.0) || key_is_down(VK_RWIN.0);
+        ctrl == chord.ctrl && alt == chord.alt && shift == chord.shift && win == chord.win
     }
 
     #[derive(Serialize)]
@@ -373,6 +501,28 @@ mod windows_helper {
         let is_down = message == WM_KEYDOWN || message == WM_SYSKEYDOWN;
         let is_up = message == WM_KEYUP || message == WM_SYSKEYUP;
         let key = event.vkCode as u16;
+
+        // Configured-hotkey remote trigger: catch the user's own hotkey here,
+        // below the remote client's key forwarding, but only when a supported
+        // remote client is focused (locally the global shortcut already handles
+        // it, so this avoids a double toggle). Suppress the chord so it never
+        // leaks into the remote session.
+        if is_down {
+            if let Some(Some(chord)) = CONFIGURED_CHORD.get() {
+                if key == chord.key_vk
+                    && modifiers_match(chord)
+                    && (ACCEPT_TEST_INPUT.load(Ordering::SeqCst)
+                        || foreground_is_supported_remote())
+                {
+                    match activate_cubby(None, false) {
+                        Ok(()) => emit("configured_hotkey", Some("activated Cubby directly")),
+                        Err(error) => emit("activation_failed", Some(&error)),
+                    }
+                    return LRESULT(1);
+                }
+            }
+        }
+
         let exact_match = if key == VK_V.0 && is_down {
             keyboard_is_exact_win_v()
         } else {
@@ -423,20 +573,6 @@ mod windows_helper {
                     }
                 }
             },
-            Decision::ActivateRemoteTrigger => {
-                if ACCEPT_TEST_INPUT.load(Ordering::SeqCst) || foreground_is_supported_remote() {
-                    match activate_cubby(None, false) {
-                        Ok(()) => emit("remote_trigger", Some("activated Cubby directly")),
-                        Err(error) => emit("activation_failed", Some(&error)),
-                    }
-                } else {
-                    emit(
-                        "remote_trigger_ignored",
-                        Some("foreground app is not a supported remote client"),
-                    );
-                }
-                unsafe { CallNextHookEx(None, code, wparam, lparam) }
-            }
         }
     }
 
@@ -460,6 +596,13 @@ mod windows_helper {
         args.windows(2)
             .find(|pair| pair[0] == "--activation-port")
             .and_then(|pair| pair[1].parse::<u16>().ok())
+    }
+
+    fn parse_activation_hotkey() -> Option<TriggerChord> {
+        let args: Vec<String> = env::args().collect();
+        args.windows(2)
+            .find(|pair| pair[0] == "--activation-hotkey")
+            .and_then(|pair| parse_hotkey(&pair[1]))
     }
 
     fn stop_when_parent_exits(parent_pid: u32) -> Result<(), String> {
@@ -491,6 +634,8 @@ mod windows_helper {
             env::args().any(|arg| arg == "--accept-injected-test-events"),
             Ordering::SeqCst,
         );
+        let configured_chord = parse_activation_hotkey();
+        CONFIGURED_CHORD.get_or_init(|| configured_chord);
         STATE.get_or_init(|| Mutex::new(RemapState::default()));
 
         let thread_id = unsafe { GetCurrentThreadId() };
@@ -516,7 +661,11 @@ mod windows_helper {
             "{}",
             serde_json::to_string(&OutputEvent {
                 event: "ready",
-                detail: Some("Win+V and double Ctrl activate Cubby"),
+                detail: Some(if CONFIGURED_CHORD.get().is_some_and(Option::is_some) {
+                    "Win+V and the configured hotkey activate Cubby"
+                } else {
+                    "Win+V activates Cubby"
+                }),
                 timeout_seconds: parent_pid.is_none().then_some(timeout_seconds),
             })
             .map_err(|error| error.to_string())?
@@ -536,10 +685,10 @@ mod windows_helper {
 
     #[cfg(test)]
     mod tests {
-        use super::{is_supported_remote_process, Decision, RemapState};
-        use windows::Win32::UI::Input::KeyboardAndMouse::{
-            VK_E, VK_LCONTROL, VK_LWIN, VK_RCONTROL, VK_V,
+        use super::{
+            is_supported_remote_process, parse_hotkey, Decision, RemapState, TriggerChord,
         };
+        use windows::Win32::UI::Input::KeyboardAndMouse::{VK_E, VK_LWIN, VK_V};
 
         #[test]
         fn exact_win_v_chord_is_fully_suppressed() {
@@ -611,42 +760,6 @@ mod windows_helper {
         }
 
         #[test]
-        fn double_tapping_right_ctrl_activates_remote_trigger() {
-            let mut state = RemapState::default();
-            assert_eq!(
-                state.handle(VK_RCONTROL.0, false, true, true, 100),
-                Decision::Pass
-            );
-            assert_eq!(
-                state.handle(VK_RCONTROL.0, false, true, true, 420),
-                Decision::ActivateRemoteTrigger
-            );
-        }
-
-        #[test]
-        fn double_tapping_left_ctrl_activates_remote_trigger() {
-            let mut state = RemapState::default();
-            assert_eq!(
-                state.handle(VK_LCONTROL.0, false, true, true, 100),
-                Decision::Pass
-            );
-            assert_eq!(
-                state.handle(VK_LCONTROL.0, false, true, true, 420),
-                Decision::ActivateRemoteTrigger
-            );
-        }
-
-        #[test]
-        fn alternating_ctrl_keys_do_not_activate() {
-            let mut state = RemapState::default();
-            state.handle(VK_LCONTROL.0, false, true, true, 100);
-            assert_eq!(
-                state.handle(VK_RCONTROL.0, false, true, true, 200),
-                Decision::Pass
-            );
-        }
-
-        #[test]
         fn recognizes_supported_remote_clients() {
             assert!(is_supported_remote_process("ncplayer.exe"));
             assert!(is_supported_remote_process("MSTSC.EXE"));
@@ -655,11 +768,56 @@ mod windows_helper {
         }
 
         #[test]
-        fn slow_right_ctrl_taps_do_not_activate() {
+        fn parses_the_coworker_backquote_hotkey() {
+            // Ditto's default (Ctrl+`) is what the settings UI records as
+            // "Ctrl+Backquote"; a lone "`" token is also accepted.
+            let expected = TriggerChord {
+                ctrl: true,
+                alt: false,
+                shift: false,
+                win: false,
+                key_vk: 0xC0,
+            };
+            assert_eq!(parse_hotkey("Ctrl+Backquote"), Some(expected));
+            assert_eq!(parse_hotkey("Ctrl+`"), Some(expected));
+        }
+
+        #[test]
+        fn parses_letters_digits_and_modifier_aliases() {
+            assert_eq!(parse_hotkey("Ctrl+Shift+V").unwrap().key_vk, VK_V.0);
+            assert_eq!(parse_hotkey("Ctrl+Shift+KeyV").unwrap().key_vk, VK_V.0);
+            assert_eq!(parse_hotkey("Ctrl+Digit1").unwrap().key_vk, 0x31);
+            assert_eq!(parse_hotkey("Alt+F5").unwrap().key_vk, 0x74);
+
+            let win_alt_v = parse_hotkey("Win+Alt+V").unwrap();
+            assert!(win_alt_v.win && win_alt_v.alt && !win_alt_v.ctrl);
+            assert!(parse_hotkey("Windows+V").unwrap().win);
+            assert!(parse_hotkey("Cmd+V").unwrap().win);
+        }
+
+        #[test]
+        fn rejects_hotkeys_that_cannot_be_a_remote_trigger() {
+            assert_eq!(parse_hotkey("V"), None); // bare key, no modifier
+            assert_eq!(parse_hotkey("Ctrl"), None); // modifier only
+            assert_eq!(parse_hotkey("Ctrl+Shift+A+B"), None); // two main keys
+            assert_eq!(parse_hotkey("Ctrl+Nonsense"), None); // unknown key
+            assert_eq!(parse_hotkey(""), None);
+        }
+
+        #[test]
+        fn ctrl_is_always_passed_through() {
+            use windows::Win32::UI::Input::KeyboardAndMouse::{VK_LCONTROL, VK_RCONTROL};
             let mut state = RemapState::default();
-            state.handle(VK_RCONTROL.0, false, true, true, 100);
             assert_eq!(
-                state.handle(VK_RCONTROL.0, false, true, true, 501),
+                state.handle(VK_LCONTROL.0, true, false, true, 10),
+                Decision::Pass
+            );
+            assert_eq!(
+                state.handle(VK_LCONTROL.0, false, true, true, 20),
+                Decision::Pass
+            );
+            assert_eq!(
+                state.handle(VK_RCONTROL.0, false, true, true, 30),
                 Decision::Pass
             );
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -325,9 +325,10 @@ pub fn run_app() {
             if !shortcuts_ready {
                 shortcut_settings.replace_win_v = false;
             }
-            if let Err(error) =
-                replacement.configure(shortcuts_ready && shortcut_settings.replace_win_v)
-            {
+            if let Err(error) = replacement.configure(
+                shortcuts_ready && shortcut_settings.replace_win_v,
+                Some(shortcut_settings.hotkey.clone()),
+            ) {
                 log::error!("WIN_V: Startup failed: {}", error);
                 shortcut_settings.replace_win_v = false;
                 shortcuts_ready = shortcuts::register_shortcuts(

--- a/src-tauri/src/settings_commands.rs
+++ b/src-tauri/src/settings_commands.rs
@@ -47,12 +47,17 @@ pub async fn save_settings(app: AppHandle, settings: serde_json::Value) -> Resul
         )?;
     }
 
-    if new_settings.replace_win_v != current.replace_win_v {
+    // Reconfigure the helper whenever the hotkey or the replacement toggle
+    // changes, so the remote-session trigger tracks the current hotkey.
+    if shortcut_settings_changed {
         let replacement = app.state::<Arc<crate::win_v_replacement::WinVReplacementManager>>();
-        if let Err(error) = replacement.configure(new_settings.replace_win_v) {
+        if let Err(error) = replacement.configure(
+            new_settings.replace_win_v,
+            Some(new_settings.hotkey.clone()),
+        ) {
             let _ =
                 crate::shortcuts::register_shortcuts(&app, &current.hotkey, current.replace_win_v);
-            let _ = replacement.configure(current.replace_win_v);
+            let _ = replacement.configure(current.replace_win_v, Some(current.hotkey.clone()));
             return Err(error);
         }
     }
@@ -65,7 +70,7 @@ pub async fn save_settings(app: AppHandle, settings: serde_json::Value) -> Resul
             let _ =
                 crate::shortcuts::register_shortcuts(&app, &current.hotkey, current.replace_win_v);
             let replacement = app.state::<Arc<crate::win_v_replacement::WinVReplacementManager>>();
-            let _ = replacement.configure(current.replace_win_v);
+            let _ = replacement.configure(current.replace_win_v, Some(current.hotkey.clone()));
         }
         return Err(error);
     }

--- a/src-tauri/src/win_v_replacement.rs
+++ b/src-tauri/src/win_v_replacement.rs
@@ -15,6 +15,9 @@ const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 struct HelperState {
     child: Option<Child>,
     desired: bool,
+    /// The Cubby hotkey handed to the running helper. When this changes the
+    /// helper is restarted so it re-parses the new activation chord.
+    hotkey: Option<String>,
 }
 
 struct Inner {
@@ -69,18 +72,25 @@ impl WinVReplacementManager {
         })
     }
 
-    pub fn configure(&self, enabled: bool) -> Result<(), String> {
+    pub fn configure(&self, enabled: bool, hotkey: Option<String>) -> Result<(), String> {
         let mut state = self
             .inner
             .state
             .lock()
             .map_err(|_| "Win+V helper state is unavailable".to_string())?;
+        let hotkey_changed = state.hotkey != hotkey;
         state.desired = enabled;
+        state.hotkey = hotkey;
 
         if !enabled {
             stop_child(&mut state.child);
             log::info!("WIN_V: Replacement helper stopped");
             return Ok(());
+        }
+
+        // Restart a running helper so it re-parses the new activation hotkey.
+        if hotkey_changed {
+            stop_child(&mut state.child);
         }
 
         ensure_child_running(&mut state, self.inner.activation_port)?;
@@ -157,6 +167,10 @@ fn ensure_child_running(state: &mut HelperState, activation_port: u16) -> Result
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
+
+    if let Some(hotkey) = state.hotkey.as_deref() {
+        command.arg("--activation-hotkey").arg(hotkey);
+    }
 
     #[cfg(target_os = "windows")]
     command.creation_flags(CREATE_NO_WINDOW);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "Cubby Clipboard",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "identifier": "ai.southforge.cubbyclipboard",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Routes the user's **configured hotkey** through the same low-level `Win+V` hook that powers the native replacement, so the hotkey that opens Cubby locally also opens it **inside supported remote sessions** (Ninja Remote, Windows Remote Desktop, and other recognized clients) — as long as the remote client's own keyboard forwarding is off. The chord is suppressed so it doesn't leak into the remote machine. Replaces the old double-Ctrl remote gesture (which also tripped Windows' "show pointer location on Ctrl" behavior).

Bumps to **v0.1.0-beta.2** with an EN/中文 changelog entry.

## Base

Built on `origin/main` (the encrypted v0.1.0-beta.1 release line), **not** the stale pre-encryption local main. Cherry-picked cleanly (git auto-merged the one lib.rs overlap). No data-format changes.

## Scope and honest limitation

- **Forwarding OFF**: Win+V and the configured hotkey both work inside remote sessions. ✅
- **Forwarding ON**: no hotkey can work — the remote client captures the keyboard before Cubby, proven three independent ways (global shortcut doesn't fire, the low-level hook loses the install-order race, and even passive key-state polling can't see the key). Documented as a known limitation; the tray is the fallback there.

## Verification

- `cargo test` (10 win_v_helper tests + crypto) — pass
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean
- Live Ninja session (forwarding off) confirmed the hotkey activates Cubby and tags the Ninja window as the paste target
- The remote-trigger harness (`scripts/test-remote-trigger.ps1`) updated to exercise the configured-hotkey path

## Notes

- Review-only PR; the `v0.1.0-beta.2` tag/release is a separate deliberate step.
- Related: SOU-228 (sync local main / prune stale branches), SOU-227 (per-channel data dirs + schema guard so a pre-encryption build can never touch real data again).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for opening Cubby in supported remote sessions via the configured hotkey chord (using the same trigger mechanism as Win+V replacement).
  * The hotkey is suppressed so it won’t leak to the remote when keyboard forwarding is disabled, replacing the previous double-Ctrl gesture.
  * Cubby updated to **v0.1.0-beta.2**.
* **Known Limitations**
  * If a remote client captures forwarded keyboard input, the hotkey won’t open Cubby—use the tray icon instead.
* **Documentation**
  * Updated remote-session and shortcut-trigger guidance, including Ninja Remote workflow details.
* **Tests**
  * Updated the remote hotkey trigger test to validate the new chord-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->