### PR TITLE
Offline screenshot OCR (Windows.Media.Ocr)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,7 +43,7 @@ clipboard-win = "5.4.1"
 
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.62.2", features = ["UI_ViewManagement", "Win32_UI_Accessibility", "Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Win32_System_Threading", "Win32_System_ProcessStatus", "Win32_System_LibraryLoader", "Win32_Security", "Win32_Security_Cryptography", "Win32_System_DataExchange", "Win32_UI_Shell", "Win32_Graphics_Gdi", "Win32_Graphics_Dwm", "Win32_Storage_FileSystem", "Win32_System_SystemInformation", "Win32_System_Memory", "Win32_UI_Input_KeyboardAndMouse", "Win32_System_Com"] }
+windows = { version = "0.62.2", features = ["UI_ViewManagement", "Win32_UI_Accessibility", "Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Win32_System_Threading", "Win32_System_ProcessStatus", "Win32_System_LibraryLoader", "Win32_Security", "Win32_Security_Cryptography", "Win32_System_DataExchange", "Win32_UI_Shell", "Win32_Graphics_Gdi", "Win32_Graphics_Dwm", "Win32_Storage_FileSystem", "Win32_System_SystemInformation", "Win32_System_Memory", "Win32_UI_Input_KeyboardAndMouse", "Win32_System_Com", "Foundation", "Foundation_Collections", "Media_Ocr", "Graphics_Imaging", "Security_Cryptography", "Storage_Streams"] }
 
 
 [features]

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -681,6 +681,33 @@ async fn process_clipboard_snapshot(
     };
     let db_write_ms = db_write_started.elapsed().as_millis();
 
+    // Background OCR: pull text out of screenshot/image clips so they become
+    // searchable by their words. Runs on its own thread, off the capture path,
+    // and never blocks capture; a missing OCR language just leaves ocr_text unset.
+    if inserted_new && clip_type == "image" {
+        if let Some(full_bytes) = full_image_content.clone() {
+            let db_for_ocr = db.clone();
+            let clip_for_ocr = emitted_id.clone();
+            std::thread::spawn(move || match crate::ocr::recognize_png(&full_bytes) {
+                Ok(text) if !text.trim().is_empty() => {
+                    let Ok(encrypted) = db_for_ocr.crypto.encrypt_text(text.trim()) else {
+                        return;
+                    };
+                    if let Ok(runtime) = crate::models::get_runtime() {
+                        let _ = runtime.block_on(
+                            sqlx::query("UPDATE clips SET ocr_text = ? WHERE uuid = ?")
+                                .bind(&encrypted)
+                                .bind(&clip_for_ocr)
+                                .execute(&db_for_ocr.pool),
+                        );
+                    }
+                }
+                Ok(_) => {}
+                Err(error) => log::debug!("OCR: skipped clip {}: {}", clip_for_ocr, error),
+            });
+        }
+    }
+
     if let Err(error) = replace_clip_formats(pool, &db.crypto, &emitted_id, &captured_formats).await
     {
         log::error!("CLIPBOARD: Failed to persist auxiliary formats: {}", error);

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -686,25 +686,52 @@ async fn process_clipboard_snapshot(
     // and never blocks capture; a missing OCR language just leaves ocr_text unset.
     if inserted_new && clip_type == "image" {
         if let Some(full_bytes) = full_image_content.clone() {
-            let db_for_ocr = db.clone();
-            let clip_for_ocr = emitted_id.clone();
-            std::thread::spawn(move || match crate::ocr::recognize_png(&full_bytes) {
-                Ok(text) if !text.trim().is_empty() => {
-                    let Ok(encrypted) = db_for_ocr.crypto.encrypt_text(text.trim()) else {
-                        return;
-                    };
-                    if let Ok(runtime) = crate::models::get_runtime() {
-                        let _ = runtime.block_on(
-                            sqlx::query("UPDATE clips SET ocr_text = ? WHERE uuid = ?")
-                                .bind(&encrypted)
-                                .bind(&clip_for_ocr)
-                                .execute(&db_for_ocr.pool),
-                        );
+            use std::sync::atomic::{AtomicUsize, Ordering};
+            // Cap concurrent OCR workers so a burst of image copies can't spawn
+            // unbounded threads; excess images simply skip OCR.
+            static OCR_IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
+            const MAX_OCR_WORKERS: usize = 3;
+            if OCR_IN_FLIGHT.fetch_add(1, Ordering::SeqCst) >= MAX_OCR_WORKERS {
+                OCR_IN_FLIGHT.fetch_sub(1, Ordering::SeqCst);
+            } else {
+                let db_for_ocr = db.clone();
+                let clip_for_ocr = emitted_id.clone();
+                std::thread::spawn(move || {
+                    match crate::ocr::recognize_png(&full_bytes) {
+                        Ok(text) if !text.trim().is_empty() => {
+                            match db_for_ocr.crypto.encrypt_text(text.trim()) {
+                                Ok(encrypted) => match crate::models::get_runtime() {
+                                    Ok(runtime) => {
+                                        if let Err(error) = runtime.block_on(
+                                            sqlx::query(
+                                                "UPDATE clips SET ocr_text = ? WHERE uuid = ?",
+                                            )
+                                            .bind(&encrypted)
+                                            .bind(&clip_for_ocr)
+                                            .execute(&db_for_ocr.pool),
+                                        ) {
+                                            log::warn!(
+                                                "OCR: could not store text for {}: {}",
+                                                clip_for_ocr,
+                                                error
+                                            );
+                                        }
+                                    }
+                                    Err(error) => log::warn!("OCR: runtime unavailable: {}", error),
+                                },
+                                Err(error) => log::warn!(
+                                    "OCR: could not encrypt text for {}: {}",
+                                    clip_for_ocr,
+                                    error
+                                ),
+                            }
+                        }
+                        Ok(_) => {}
+                        Err(error) => log::debug!("OCR: skipped clip {}: {}", clip_for_ocr, error),
                     }
-                }
-                Ok(_) => {}
-                Err(error) => log::debug!("OCR: skipped clip {}: {}", clip_for_ocr, error),
-            });
+                    OCR_IN_FLIGHT.fetch_sub(1, Ordering::SeqCst);
+                });
+            }
         }
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -36,6 +36,8 @@ fn decrypt_clip_fields(db: &Database, clip: &mut Clip) -> Result<(), String> {
     db.crypto.decrypt_optional_text(&mut clip.source_app)?;
     db.crypto.decrypt_optional_text(&mut clip.source_icon)?;
     db.crypto.decrypt_optional_text(&mut clip.metadata)?;
+    // OCR text is auxiliary; never let a bad value block loading the clip.
+    let _ = db.crypto.decrypt_optional_text(&mut clip.ocr_text);
     Ok(())
 }
 
@@ -948,7 +950,11 @@ pub async fn search_clips(
             let is_match = String::from_utf8_lossy(&clip.content)
                 .to_lowercase()
                 .contains(&normalized_query)
-                || clip.text_preview.to_lowercase().contains(&normalized_query);
+                || clip.text_preview.to_lowercase().contains(&normalized_query)
+                || clip
+                    .ocr_text
+                    .as_deref()
+                    .is_some_and(|text| text.to_lowercase().contains(&normalized_query));
             if !is_match {
                 continue;
             }
@@ -1606,6 +1612,7 @@ mod tests {
             source_app: None,
             source_icon: None,
             metadata: None,
+            ocr_text: None,
             created_at: chrono::Utc::now(),
             last_accessed: chrono::Utc::now(),
         };

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -154,6 +154,9 @@ impl Database {
             "ALTER TABLE clips ADD COLUMN is_pinned INTEGER NOT NULL DEFAULT 0",
         )
         .await?;
+        // Encrypted OCR text extracted from screenshot/image clips, so images are
+        // findable by their words. NULL until (or unless) OCR runs for a clip.
+        add_column_if_missing(&self.pool, "ALTER TABLE clips ADD COLUMN ocr_text TEXT").await?;
 
         sqlx::query(
             r#"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ mod constants;
 mod crypto;
 mod database;
 mod models;
+mod ocr;
 pub mod paste_engine;
 mod settings_commands;
 mod settings_manager;

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -85,7 +85,7 @@ impl<'r> FromRow<'r, SqliteRow> for Clip {
             source_app: row.try_get("source_app")?,
             source_icon: row.try_get("source_icon")?,
             metadata: row.try_get("metadata")?,
-            ocr_text: row.try_get("ocr_text").unwrap_or(None),
+            ocr_text: row.try_get("ocr_text")?,
             created_at: row.try_get("created_at")?,
             last_accessed: row.try_get("last_accessed")?,
         })

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -64,6 +64,7 @@ pub struct Clip {
     pub source_app: Option<String>,
     pub source_icon: Option<String>,
     pub metadata: Option<String>,
+    pub ocr_text: Option<String>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub last_accessed: chrono::DateTime<chrono::Utc>,
 }
@@ -84,6 +85,7 @@ impl<'r> FromRow<'r, SqliteRow> for Clip {
             source_app: row.try_get("source_app")?,
             source_icon: row.try_get("source_icon")?,
             metadata: row.try_get("metadata")?,
+            ocr_text: row.try_get("ocr_text").unwrap_or(None),
             created_at: row.try_get("created_at")?,
             last_accessed: row.try_get("last_accessed")?,
         })

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -1,0 +1,100 @@
+//! Offline screenshot OCR using the native Windows OCR engine
+//! (`Windows.Media.Ocr`). Runs fully on-device: no network, no cloud, no extra
+//! dependency beyond Windows itself.
+//!
+//! Wired into image capture in a follow-up; kept standalone here so the WinRT
+//! path can be validated on its own.
+#![allow(dead_code)]
+
+/// Recognize text from PNG-encoded image bytes with the user's installed OCR
+/// languages. Returns the recognized text (possibly empty), or an error when no
+/// OCR language is available on the machine.
+#[cfg(target_os = "windows")]
+pub fn recognize_png(png_bytes: &[u8]) -> Result<String, String> {
+    use windows::Graphics::Imaging::{BitmapPixelFormat, SoftwareBitmap};
+    use windows::Media::Ocr::OcrEngine;
+    use windows::Security::Cryptography::CryptographicBuffer;
+
+    // Decode the PNG and convert RGBA -> BGRA, the layout SoftwareBitmap wants.
+    let image = image::load_from_memory(png_bytes)
+        .map_err(|e| format!("could not decode screenshot: {e}"))?
+        .to_rgba8();
+    let (width, height) = image.dimensions();
+    let mut bgra = image.into_raw();
+    for pixel in bgra.chunks_exact_mut(4) {
+        pixel.swap(0, 2);
+    }
+
+    let buffer = CryptographicBuffer::CreateFromByteArray(&bgra).map_err(|e| e.to_string())?;
+    let bitmap = SoftwareBitmap::CreateCopyFromBuffer(
+        &buffer,
+        BitmapPixelFormat::Bgra8,
+        width as i32,
+        height as i32,
+    )
+    .map_err(|e| e.to_string())?;
+
+    let engine = OcrEngine::TryCreateFromUserProfileLanguages()
+        .map_err(|_| "Windows OCR is unavailable (no OCR language installed)".to_string())?;
+
+    // OCR runs off the capture hot path; poll the single async op to completion.
+    // AsyncStatus ABI values: 0 = Started, 1 = Completed, 2 = Canceled, 3 = Error.
+    let operation = engine.RecognizeAsync(&bitmap).map_err(|e| e.to_string())?;
+    loop {
+        match operation.Status().map_err(|e| e.to_string())?.0 {
+            1 => break,
+            2 => return Err("Windows OCR was canceled".to_string()),
+            3 => return Err("Windows OCR failed".to_string()),
+            _ => std::thread::sleep(std::time::Duration::from_millis(2)),
+        }
+    }
+    let result = operation.GetResults().map_err(|e| e.to_string())?;
+
+    Ok(result.Text().map_err(|e| e.to_string())?.to_string())
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn recognize_png(_png_bytes: &[u8]) -> Result<String, String> {
+    Err("Screenshot OCR requires Windows".to_string())
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod tests {
+    use super::recognize_png;
+
+    #[test]
+    fn reads_text_from_a_generated_image() {
+        // Draw known text to a PNG with System.Drawing so we have a real image.
+        let path = std::env::temp_dir().join("cubby-ocr-test.png");
+        let target = path.to_string_lossy().replace('\\', "\\\\");
+        let script = format!(
+            "Add-Type -AssemblyName System.Drawing; \
+             $b = New-Object System.Drawing.Bitmap 640,160; \
+             $g = [System.Drawing.Graphics]::FromImage($b); \
+             $g.Clear([System.Drawing.Color]::White); \
+             $f = New-Object System.Drawing.Font('Segoe UI',40); \
+             $g.DrawString('CUBBY OCR 12345', $f, [System.Drawing.Brushes]::Black, 10, 40); \
+             $g.Dispose(); $b.Save('{target}'); $b.Dispose()"
+        );
+        let generated = std::process::Command::new("powershell")
+            .args(["-NoProfile", "-Command", &script])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !generated {
+            eprintln!("skipping OCR test: could not generate the sample image");
+            return;
+        }
+        let png = std::fs::read(&path).expect("sample image should be readable");
+        let _ = std::fs::remove_file(&path);
+
+        match recognize_png(&png) {
+            Ok(text) => assert!(
+                text.to_uppercase().contains("CUBBY"),
+                "expected OCR to read the image, got: {text:?}"
+            ),
+            // No OCR language pack (e.g. on some CI images) -> skip, don't fail.
+            Err(error) => eprintln!("skipping OCR assertion: engine unavailable ({error})"),
+        }
+    }
+}

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -38,12 +38,16 @@ pub fn recognize_png(png_bytes: &[u8]) -> Result<String, String> {
     // OCR runs off the capture hot path; poll the single async op to completion.
     // AsyncStatus ABI values: 0 = Started, 1 = Completed, 2 = Canceled, 3 = Error.
     let operation = engine.RecognizeAsync(&bitmap).map_err(|e| e.to_string())?;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
     loop {
         match operation.Status().map_err(|e| e.to_string())?.0 {
             1 => break,
             2 => return Err("Windows OCR was canceled".to_string()),
             3 => return Err("Windows OCR failed".to_string()),
-            _ => std::thread::sleep(std::time::Duration::from_millis(2)),
+            _ if std::time::Instant::now() >= deadline => {
+                return Err("Windows OCR timed out".to_string());
+            }
+            _ => std::thread::sleep(std::time::Duration::from_millis(5)),
         }
     }
     let result = operation.GetResults().map_err(|e| e.to_string())?;
@@ -92,7 +96,12 @@ mod tests {
                 "expected OCR to read the image, got: {text:?}"
             ),
             // No OCR language pack (e.g. on some CI images) -> skip, don't fail.
-            Err(error) => eprintln!("skipping OCR assertion: engine unavailable ({error})"),
+            // Only the missing-language case is an acceptable skip; any other
+            // failure (bitmap, API, poll) must fail the test loudly.
+            Err(error) if error.contains("no OCR language") => {
+                eprintln!("skipping OCR assertion: {error}")
+            }
+            Err(error) => panic!("OCR failed unexpectedly: {error}"),
         }
     }
 }

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -2,9 +2,7 @@
 //! (`Windows.Media.Ocr`). Runs fully on-device: no network, no cloud, no extra
 //! dependency beyond Windows itself.
 //!
-//! Wired into image capture in a follow-up; kept standalone here so the WinRT
-//! path can be validated on its own.
-#![allow(dead_code)]
+//! Called from image capture; also exercised by a self-contained test.
 
 /// Recognize text from PNG-encoded image bytes with the user's installed OCR
 /// languages. Returns the recognized text (possibly empty), or an error when no


### PR DESCRIPTION
## Summary

Adds **offline screenshot OCR**. When you copy a screenshot, Cubby reads the text out of it with the native Windows OCR engine (`Windows.Media.Ocr`), fully on-device (no network, no cloud, no extra dependency), so the screenshot becomes **searchable by its words**.

## How it works
- `ocr::recognize_png` decodes the image, builds a `SoftwareBitmap`, and runs the Windows OCR engine. Enables the WinRT `Media_Ocr` / `Graphics_Imaging` / `Security_Cryptography` / `Storage_Streams` features on the `windows` crate.
- On image capture, OCR runs on a **background thread** (never blocks capture) and stores the recognized text encrypted in a new `clips.ocr_text` column.
- Search matches `ocr_text`, so a screenshot is findable by its text. Clip loading decrypts it leniently, so a bad value can never block a clip.
- No OCR language installed simply leaves `ocr_text` unset (graceful).

## Tests
- `recognize_png` is validated by a self-contained test that draws known text to an image and reads it back (skips gracefully if no OCR language is present, e.g. some CI images).
- Full suite (34 tests) green; clippy + fmt clean.

## Follow-ups (not in this PR)
- Expose the OCR text directly (a "copy as text" / paste-as-text action on a screenshot clip).
- Backfill OCR for existing image clips.

Makes the site's "Screenshot OCR, offline" claim true.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic offline OCR for image and screenshot clips on Windows.
  * When OCR succeeds, the extracted text is securely stored, searchable, and refreshed without blocking clipboard capture.
* **Compatibility / Bug Fixes**
  * Clip loading no longer fails if OCR text decryption fails.
  * Clip search now considers OCR text in addition to existing fields.
* **Database**
  * Added support for storing optional OCR text for clips.
* **Tests**
  * Added a Windows-only OCR validation test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->