### PR TITLE
Sign Windows installers with Azure Trusted Signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,8 +138,10 @@ jobs:
     name: Build ${{ matrix.arch }} installer
     needs: create-release
     runs-on: windows-latest
+    environment: release
     permissions:
       contents: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -175,16 +177,49 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Build and upload NSIS installer
+      - name: Build NSIS installer
         uses: tauri-apps/tauri-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           projectPath: .
-          releaseId: ${{ needs.create-release.outputs.release_id }}
-          uploadUpdaterJson: false
-          releaseAssetNamePattern: '[name]_[version]_[arch][setup].[ext]'
           args: --target ${{ matrix.target }} --bundles nsis
+
+      - name: Locate the built installer
+        id: installer
+        shell: bash
+        run: |
+          file=$(ls "src-tauri/target/${{ matrix.target }}/release/bundle/nsis/"*-setup.exe | head -1)
+          if [ -z "$file" ]; then
+            echo "No NSIS installer was produced"; exit 1
+          fi
+          echo "path=$file" >> "$GITHUB_OUTPUT"
+          echo "name=$(basename "$file" | tr ' ' '.')" >> "$GITHUB_OUTPUT"
+
+      - name: Sign in to Azure with GitHub OIDC
+        uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign the installer with Trusted Signing
+        uses: Azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ vars.ARTIFACT_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.ARTIFACT_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ vars.ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME }}
+          files: ${{ steps.installer.outputs.path }}
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Upload the signed installer
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.create-release.outputs.tag }}
+        run: |
+          cp "${{ steps.installer.outputs.path }}" "${{ steps.installer.outputs.name }}"
+          gh release upload "$TAG" "${{ steps.installer.outputs.name }}" --clobber
 
   publish-release:
     name: Publish validated release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
         run: |
           VERSION="${{ steps.metadata.outputs.version }}"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            BODY="Unsigned test build for v${VERSION} from commit ${{ github.sha }}. Use for release-candidate testing only."
+            BODY="Test build for v${VERSION} from commit ${{ github.sha }}, signed with Azure Trusted Signing. For release-candidate testing only."
           else
             BODY=$(awk -v heading="## v${VERSION}" '
               $0 == heading { capture=1; next }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,14 +185,16 @@ jobs:
 
       - name: Locate the built installer
         id: installer
-        shell: bash
+        shell: pwsh
         run: |
-          file=$(ls "src-tauri/target/${{ matrix.target }}/release/bundle/nsis/"*-setup.exe | head -1)
-          if [ -z "$file" ]; then
-            echo "No NSIS installer was produced"; exit 1
-          fi
-          echo "path=$file" >> "$GITHUB_OUTPUT"
-          echo "name=$(basename "$file" | tr ' ' '.')" >> "$GITHUB_OUTPUT"
+          $file = Get-ChildItem "src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*-setup.exe" | Select-Object -First 1
+          if (-not $file) {
+            Write-Error "No NSIS installer was produced"
+            exit 1
+          }
+          # The signing action requires a rooted (absolute) path; $file.FullName is a Windows-rooted path.
+          "path=$($file.FullName)" >> $env:GITHUB_OUTPUT
+          "name=$($file.Name -replace ' ', '.')" >> $env:GITHUB_OUTPUT
 
       - name: Sign in to Azure with GitHub OIDC
         uses: azure/login@v3
@@ -213,13 +215,13 @@ jobs:
           timestamp-digest: SHA256
 
       - name: Upload the signed installer
-        shell: bash
+        shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.create-release.outputs.tag }}
         run: |
-          cp "${{ steps.installer.outputs.path }}" "${{ steps.installer.outputs.name }}"
-          gh release upload "$TAG" "${{ steps.installer.outputs.name }}" --clobber
+          Copy-Item "${{ steps.installer.outputs.path }}" "${{ steps.installer.outputs.name }}"
+          gh release upload "$env:TAG" "${{ steps.installer.outputs.name }}" --clobber
 
   publish-release:
     name: Publish validated release


### PR DESCRIPTION
## Summary

Signs Cubby's Windows installers with **Azure Trusted Signing**, so installs stop hitting the SmartScreen "unknown publisher" wall.

## What changed
`build-installers` now:
1. Runs in the **`release` environment** with `id-token: write` (so the OIDC token subject is `repo:tsouth89/cubby-clipboard:environment:release`).
2. Authenticates to Azure via **`azure/login`** (OIDC, no secret).
3. Builds the NSIS installer with tauri-action **build-only** (no upload), so signing never runs on local dev builds.
4. Signs the `*-setup.exe` with **`Azure/artifact-signing-action`** (SHA256 + RFC3161 timestamp).
5. Uploads the **signed** installer to the draft release.

Same proven approach as the Ceiling repo. Uses these repo variables (already set): `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `ARTIFACT_SIGNING_ENDPOINT`, `ARTIFACT_SIGNING_ACCOUNT_NAME`, `ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME`.

## Validation (required before trusting for a real release)
CI can't fully exercise this without running it. After merge, kick a **`workflow_dispatch`** test build; it produces a **signed** draft. Install the signed x64 `-setup.exe` and confirm the SmartScreen "unknown publisher" warning is gone. If it signs and installs clean, the real tagged release path is good.

Note: reviewed by me only (CodeRabbit trial ended).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows installers are now digitally signed before being published, improving trust and security for downloaded installations.
* **Release Improvements**
  * Signed installer files are uploaded automatically to the corresponding release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->