### PR TITLE
Speed up the release workflow (cache + prebuilt audit + parallel jobs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,23 @@ jobs:
         with:
           components: clippy, rustfmt
 
+      # Cache the cargo registry + src-tauri/target across runs so the cargo test
+      # and clippy compiles below are incremental instead of cold every run.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      # Install a prebuilt cargo-audit binary instead of compiling it from source
+      # (cargo install cargo-audit) on every run.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
       - run: pnpm install --frozen-lockfile
       - run: pnpm run format:check
       - run: pnpm run release:check
       - run: pnpm run build
       - run: pnpm audit --prod
-      - run: cargo install cargo-audit --locked
       - shell: pwsh
         run: ./scripts/audit-rust.ps1
       - run: cargo fmt --manifest-path src-tauri/Cargo.toml --check
@@ -48,7 +59,9 @@ jobs:
 
   create-release:
     name: Create GitHub release
-    needs: validate
+    # Intentionally does NOT depend on validate: the release object is only ever a
+    # draft here, so it can be created in parallel with validation. publish-release
+    # gates on validate, so an unvalidated build never becomes public.
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -167,13 +180,12 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - uses: actions/cache@v5
+      # Per-target cargo cache (keyed by matrix.target so x64 and arm64 don't
+      # clobber each other) to keep the installer compiles incremental.
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            src-tauri/target
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+          workspaces: src-tauri
+          key: ${{ matrix.target }}
 
       - run: pnpm install --frozen-lockfile
 
@@ -226,7 +238,8 @@ jobs:
   publish-release:
     name: Publish validated release
     if: github.event_name != 'workflow_dispatch'
-    needs: [create-release, build-installers]
+    # Gate publishing on validate too, since create-release/build no longer do.
+    needs: [validate, create-release, build-installers]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## What

Cut release-workflow wall-clock time without paying for larger runners. Three independent changes:

1. **Prebuilt `cargo-audit`.** The `validate` job ran `cargo install cargo-audit --locked`, which compiles the tool from source on every run (~3-5 min of pure waste). Swapped for `taiki-e/install-action` (downloads a prebuilt binary in seconds). `scripts/audit-rust.ps1` just calls `cargo audit` on PATH, so it's unaffected.

2. **Cargo caching in `validate`.** That job had **no** cargo cache, so `cargo test --all-targets` + `cargo clippy --all-targets` compiled cold every single run. Added `Swatinem/rust-cache@v2` (caches the registry + `src-tauri/target`, keyed on lockfile + rustc). Also replaced the installer job's hand-rolled `actions/cache` with `rust-cache` (keyed per `matrix.target` so x64/arm64 don't clobber each other).

3. **Parallelize `validate` and `build-installers`.** They were chained (`validate` → `create-release` → `build-installers`), so the two heavy Rust compiles ran back-to-back. Now `create-release` doesn't depend on `validate` (the release object is only ever a **draft** at that point), so the installer build runs concurrently with validation. `publish-release` now gates on `validate`, so an unvalidated build can never become public.

## Trade-off

With #3, a real tag push whose validation fails will still have produced a **draft** release with installer assets attached. That's harmless (it's a draft, never published, replaced on the next good run) and only happens on a failing build. In exchange, green runs — the overwhelming majority — get roughly `max(validate, build)` wall-clock instead of `validate + build`.

## Expected effect

- **Warm runs:** large drop — `validate` goes from full cold compile to incremental, and the audit-tool compile is gone entirely.
- **Cold runs (deps changed):** still saves the ~3-5 min audit compile and overlaps the two big compiles.

## Note on PR #21 (Trusted Signing)

`main`'s `build-installers` job is the pre-signing version, so this branches cleanly off `main`. PR #21 also edits `build-installers` (adds the Azure sign/upload steps). **Recommend merging #21 first**, then I'll rebase this and reconcile the one overlapping job. The `validate`-job and `needs:` changes here don't touch anything #21 changes.
