### PR TITLE
Add first-run onboarding for new users

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { ContentFilter, FlyoutHeader } from './components/FlyoutHeader';
 import { ContextMenu } from './components/ContextMenu';
 import { FolderModal } from './components/FolderModal';
 import { ConfirmDialog } from './components/ConfirmDialog';
+import { WelcomeOverlay } from './components/WelcomeOverlay';
 import { useKeyboard } from './hooks/useKeyboard';
 import { useTheme } from './hooks/useTheme';
 import { useLanguage } from './hooks/useLanguage';
@@ -39,6 +40,7 @@ function App() {
   } | null>(null);
   const [clearRequest, setClearRequest] = useState<'unpinned' | 'all' | null>(null);
   const [isClearing, setIsClearing] = useState(false);
+  const [showWelcome, setShowWelcome] = useState(false);
 
   // Add Folder Modal State
   const [showAddFolderModal, setShowAddFolderModal] = useState(false);
@@ -86,6 +88,9 @@ function App() {
       .then((s) => {
         setTheme(s.theme);
         setSettings(s);
+        if (!s.has_completed_onboarding) {
+          setShowWelcome(true);
+        }
       })
       .catch(console.error);
 
@@ -156,6 +161,12 @@ function App() {
     settingsWin.once('tauri://error', function (e) {
       console.error('Error creating settings window', e);
     });
+  }, []);
+
+  const handleDismissWelcome = useCallback(() => {
+    setShowWelcome(false);
+    setSettings((prev) => (prev ? { ...prev, has_completed_onboarding: true } : prev));
+    invoke('complete_onboarding').catch(console.error);
   }, []);
 
   const loadClips = useCallback(
@@ -479,7 +490,7 @@ function App() {
 
   useEffect(() => {
     const focusSearchOnTyping = (event: KeyboardEvent) => {
-      if (contextMenu || clearRequest || showAddFolderModal) return;
+      if (contextMenu || clearRequest || showAddFolderModal || showWelcome) return;
       const target = event.target as HTMLElement | null;
       const isEditing =
         target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || target?.isContentEditable;
@@ -496,7 +507,7 @@ function App() {
 
     document.addEventListener('keydown', focusSearchOnTyping);
     return () => document.removeEventListener('keydown', focusSearchOnTyping);
-  }, [clearRequest, contextMenu, showAddFolderModal]);
+  }, [clearRequest, contextMenu, showAddFolderModal, showWelcome]);
 
   const handleNavigateUp = useCallback(() => {
     if (visibleClips.length === 0) return;
@@ -546,7 +557,7 @@ function App() {
   }, [selectedClipId, handleCopy]);
 
   useKeyboard({
-    disabled: Boolean(contextMenu || clearRequest || showAddFolderModal),
+    disabled: Boolean(contextMenu || clearRequest || showAddFolderModal || showWelcome),
     onClose: () => {
       if (searchQuery) {
         setSearchQuery('');
@@ -713,6 +724,10 @@ function App() {
         className={`relative h-full w-full overflow-hidden border ${windowBorder} ${windowShape} ${windowSurface}`}
       >
         <div data-el="app-frame" className="flex h-full w-full flex-col font-sans text-foreground">
+          {showWelcome && settings && (
+            <WelcomeOverlay hotkey={settings.hotkey} onDismiss={handleDismissWelcome} />
+          )}
+
           {contextMenu && (
             <ContextMenu
               x={contextMenu.x}

--- a/frontend/src/components/WelcomeOverlay.tsx
+++ b/frontend/src/components/WelcomeOverlay.tsx
@@ -1,0 +1,53 @@
+import { Clipboard, Keyboard, Lock, Pin } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+interface WelcomeOverlayProps {
+  hotkey: string;
+  onDismiss: () => void;
+}
+
+/**
+ * First-run welcome shown over the flyout until the user dismisses it. Aimed at
+ * non-technical users who just installed Cubby and need to know it's running,
+ * how to open it, and what it does.
+ */
+export function WelcomeOverlay({ hotkey, onDismiss }: WelcomeOverlayProps) {
+  const { t } = useTranslation();
+
+  const points = [
+    { icon: Keyboard, text: t('onboarding.pointOpen', { hotkey }) },
+    { icon: Clipboard, text: t('onboarding.pointAuto') },
+    { icon: Pin, text: t('onboarding.pointUse') },
+    { icon: Lock, text: t('onboarding.pointPrivate') },
+  ];
+
+  return (
+    <div className="animate-in fade-in absolute inset-0 z-50 flex items-center justify-center bg-black/60 p-3 backdrop-blur-sm duration-200">
+      <div className="animate-in zoom-in-95 flex max-h-full w-full max-w-sm flex-col overflow-hidden rounded-lg border border-border bg-background shadow-lg duration-200">
+        <div className="flex flex-col gap-1 px-5 pt-5">
+          <h2 className="text-base font-semibold text-foreground">{t('onboarding.title')}</h2>
+          <p className="text-xs text-muted-foreground">{t('onboarding.intro')}</p>
+        </div>
+        <ul className="flex flex-col gap-3 overflow-y-auto px-5 py-4">
+          {points.map(({ icon: Icon, text }, index) => (
+            <li key={index} className="flex items-start gap-3">
+              <div className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+                <Icon size={14} />
+              </div>
+              <span className="text-xs leading-relaxed text-foreground/90">{text}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="px-5 pb-5">
+          <button
+            onClick={onDismiss}
+            autoFocus
+            className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary/90"
+          >
+            {t('onboarding.dismiss')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -189,5 +189,14 @@
     "confirmUnpinned": "Clear unpinned",
     "confirmAll": "Clear everything",
     "clearing": "Clearing…"
+  },
+  "onboarding": {
+    "title": "Welcome to Cubby",
+    "intro": "Cubby keeps a history of everything you copy, so you can paste it back whenever you need it.",
+    "pointOpen": "Press {{hotkey}} any time to open Cubby.",
+    "pointAuto": "Everything you copy is saved here automatically — no extra steps.",
+    "pointUse": "Click an item (or press Enter) to paste it. Pin the ones you want to keep.",
+    "pointPrivate": "Your history is encrypted and stays on this PC. Nothing is uploaded.",
+    "dismiss": "Got it"
   }
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -36,6 +36,7 @@ export interface Settings {
   auto_paste: boolean;
   remote_paste_mode: 'copy_then_paste' | 'paste_as_keystrokes';
   ignore_ghost_clips: boolean;
+  has_completed_onboarding?: boolean;
 }
 
 export interface PasteContext {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -371,6 +371,15 @@ pub fn run_app() {
                 }
             });
 
+            // First launch: surface the flyout so the welcome overlay is visible.
+            // Otherwise Cubby starts hidden in the tray and a new user has no idea
+            // it's running or how to open it.
+            if !manager.get().has_completed_onboarding {
+                if let Some(win) = app_handle.get_webview_window("main") {
+                    crate::position_window_near_cursor(&win);
+                }
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -391,6 +400,7 @@ pub fn run_app() {
             // Replaced by settings_commands
             settings_commands::get_settings,
             settings_commands::save_settings,
+            settings_commands::complete_onboarding,
             commands::hide_window,
             commands::get_clipboard_history_size,
             commands::clear_clipboard_history,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -22,6 +22,9 @@ pub struct AppSettings {
     pub float_above_taskbar: bool,
     pub density: String,
 
+    // First-run onboarding: false until the user dismisses the welcome overlay.
+    pub has_completed_onboarding: bool,
+
     // Privacy
     pub ignored_apps: HashSet<String>,
 }
@@ -43,6 +46,8 @@ impl Default for AppSettings {
             round_corners: true,
             float_above_taskbar: true,
             density: "comfortable".to_string(),
+
+            has_completed_onboarding: false,
 
             ignored_apps: HashSet::new(),
         }

--- a/src-tauri/src/settings_commands.rs
+++ b/src-tauri/src/settings_commands.rs
@@ -134,6 +134,17 @@ pub async fn save_settings(app: AppHandle, settings: serde_json::Value) -> Resul
 }
 
 #[tauri::command]
+pub async fn complete_onboarding(app: AppHandle) -> Result<(), String> {
+    let manager = app.state::<Arc<SettingsManager>>();
+    let mut current = manager.get();
+    if !current.has_completed_onboarding {
+        current.has_completed_onboarding = true;
+        manager.save(current)?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn add_ignored_app(app_name: String, app: AppHandle) -> Result<(), String> {
     let manager = app.state::<Arc<SettingsManager>>();
     let mut current = manager.get();


### PR DESCRIPTION
## What

First-run onboarding so a non-technical person who just installed Cubby understands what it is and how to use it, instead of getting a silent tray app.

### Behavior
- On **first launch** (when `has_completed_onboarding` is false), Cubby surfaces the flyout automatically and shows a **welcome overlay** — otherwise the app starts hidden in the tray and a new user has no idea it's running.
- The overlay explains, in plain language: press **your hotkey** to open Cubby, everything you copy is saved automatically, click/Enter to paste and pin what you want to keep, and your history is **encrypted and stays on this PC**.
- "Got it" dismisses it and persists the flag, so it never shows again.

### Implementation
- `WelcomeOverlay.tsx` — overlay component, styled to match `ConfirmDialog`, strings via i18n (`onboarding.*` in `en.json`; other locales fall back to English).
- `AppSettings.has_completed_onboarding: bool` — `#[serde(default)]` on the struct means existing `settings.json` files upgrade cleanly to `false` without wiping other settings.
- `complete_onboarding` Tauri command persists dismissal (mirrors the `add_ignored_app` pattern).
- `App.tsx` shows the overlay when the flag is false and suppresses keyboard nav/search while it's open.
- `lib.rs` setup: on first run, calls `position_window_near_cursor` (the same show path the hotkey uses) so the welcome is visible.

## Verification
- `pnpm run build` (tsc + vite) — clean
- `cargo check` + `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean; changed frontend files pass `prettier --check`

## Scope
This is item #1 of the "Facebook-ready v1" plan (onboarding → auto-updater → password-manager safety). The install-guide/SmartScreen-warning copy for the website is separate (site source isn't in this repo).

## Note
Existing beta users will see the welcome once on their next launch (the flag defaults false for everyone). That's intentional and a one-click dismiss.
