### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable Cubby Clipboard changes are documented here. PastePaw entries below Cubby's first beta are retained as upstream history and attribution.
 
+## v1.0.0
+
+### Added
+- First-run welcome guide so new users know how to open and use Cubby
+- Automatic updates: Cubby checks for new versions and installs them for you
+- Skips clipboard items that apps such as password managers mark as sensitive, with a setting to capture everything if you prefer
+- Offline text recognition for copied screenshots, so images are searchable by the text inside them
+- Import clipboard history and pinned items from Ditto
+- The configured hotkey opens Cubby inside supported remote sessions when the remote client's keyboard forwarding is off
+
+### Changed
+- Windows installers are now digitally signed, so Windows recognizes Cubby's publisher
+
+### 新增
+- 首次启动引导，帮助新用户了解如何打开和使用 Cubby
+- 自动更新：Cubby 会检查新版本并为您安装
+- 自动跳过应用（如密码管理器）标记为敏感的剪贴板内容，并提供设置以在需要时捕获全部内容
+- 对复制的截图进行离线文字识别，使图片可按其中的文字进行搜索
+- 从 Ditto 导入剪贴板历史和固定项目
+- 当远程客户端关闭键盘转发时，配置的快捷键可在受支持的远程会话中打开 Cubby
+
+### 变更
+- Windows 安装程序现已进行数字签名，使 Windows 能够识别 Cubby 的发布者
+
 ## v0.1.0-beta.2
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cubby-clipboard",
-  "version": "0.1.0-beta.2",
+  "version": "1.0.0",
   "description": "A native-feeling clipboard history replacement for Windows 11",
   "license": "GPL-3.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "cubby"
-version = "0.1.0-beta.2"
+version = "1.0.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubby"
-version = "0.1.0-beta.2"
+version = "1.0.0"
 description = "A native-feeling clipboard history replacement for Windows 11"
 authors = ["SouthForge AI", "PastePaw contributors"]
 license = "GPL-3.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "Cubby Clipboard",
-  "version": "0.1.0-beta.2",
+  "version": "1.0.0",
   "identifier": "ai.southforge.cubbyclipboard",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump to **1.0.0** (first stable public release) across package.json, tauri.conf.json, Cargo.toml, Cargo.lock, plus the CHANGELOG entry. Merging this, then tagging `v1.0.0` triggers the signed release pipeline (build → Trusted Signing → updater manifest → publish).