### PR TITLE
Fix publish-release job (pass -R for repo context)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,4 +306,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.create-release.outputs.tag }}
-        run: gh release edit "$RELEASE_TAG" --draft=false
+        # -R is required: this job has no checkout, so gh has no git context.
+        run: gh release edit "$RELEASE_TAG" -R ${{ github.repository }} --draft=false


### PR DESCRIPTION
The final `publish-release` job ran `gh release edit --draft=false` with no checkout and no `-R`, so it failed with 'not a git repository' on the first tag-push release (v1.0.0). v1.0.0 was published manually; this fixes it so v1.0.1 and future releases auto-publish.