### PR TITLE
Make the v1.0.0 changelog entry English only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,17 +15,6 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 ### Changed
 - Windows installers are now digitally signed, so Windows recognizes Cubby's publisher
 
-### 新增
-- 首次启动引导，帮助新用户了解如何打开和使用 Cubby
-- 自动更新：Cubby 会检查新版本并为您安装
-- 自动跳过应用（如密码管理器）标记为敏感的剪贴板内容，并提供设置以在需要时捕获全部内容
-- 对复制的截图进行离线文字识别，使图片可按其中的文字进行搜索
-- 从 Ditto 导入剪贴板历史和固定项目
-- 当远程客户端关闭键盘转发时，配置的快捷键可在受支持的远程会话中打开 Cubby
-
-### 变更
-- Windows 安装程序现已进行数字签名，使 Windows 能够识别 Cubby 的发布者
-
 ## v0.1.0-beta.2
 
 ### Added


### PR DESCRIPTION
Removes the Chinese sections from the v1.0.0 changelog entry. The live v1.0.0 release notes were already updated to English only.