### PR TITLE
Onboarding: open via the tray icon, not a keyboard shortcut

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -726,9 +726,7 @@ function App() {
         className={`relative h-full w-full overflow-hidden border ${windowBorder} ${windowShape} ${windowSurface}`}
       >
         <div data-el="app-frame" className="flex h-full w-full flex-col font-sans text-foreground">
-          {showWelcome && settings && (
-            <WelcomeOverlay hotkey={settings.hotkey} onDismiss={handleDismissWelcome} />
-          )}
+          {showWelcome && settings && <WelcomeOverlay onDismiss={handleDismissWelcome} />}
 
           {contextMenu && (
             <ContextMenu

--- a/frontend/src/components/WelcomeOverlay.tsx
+++ b/frontend/src/components/WelcomeOverlay.tsx
@@ -1,4 +1,4 @@
-import { Clipboard, Lock, MousePointerClick, Pin } from 'lucide-react';
+import { Clipboard, Keyboard, Lock, Pin } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 interface WelcomeOverlayProps {
@@ -6,16 +6,15 @@ interface WelcomeOverlayProps {
 }
 
 /**
- * First-run welcome shown over the flyout until the user dismisses it. Aimed at
- * non-technical users who just installed Cubby and need to know it's running,
- * how to open it, and what it does. Deliberately points at the tray icon rather
- * than a keyboard shortcut, since this audience may not know the Windows key.
+ * First-run welcome shown over the flyout until the user dismisses it. Tells the
+ * user Cubby is running, how to open it, and what it does. References Win+V,
+ * which replaces the native flyout by default.
  */
 export function WelcomeOverlay({ onDismiss }: WelcomeOverlayProps) {
   const { t } = useTranslation();
 
   const points = [
-    { icon: MousePointerClick, text: t('onboarding.pointOpen') },
+    { icon: Keyboard, text: t('onboarding.pointOpen') },
     { icon: Clipboard, text: t('onboarding.pointAuto') },
     { icon: Pin, text: t('onboarding.pointUse') },
     { icon: Lock, text: t('onboarding.pointPrivate') },

--- a/frontend/src/components/WelcomeOverlay.tsx
+++ b/frontend/src/components/WelcomeOverlay.tsx
@@ -1,21 +1,21 @@
-import { Clipboard, Keyboard, Lock, Pin } from 'lucide-react';
+import { Clipboard, Lock, MousePointerClick, Pin } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 interface WelcomeOverlayProps {
-  hotkey: string;
   onDismiss: () => void;
 }
 
 /**
  * First-run welcome shown over the flyout until the user dismisses it. Aimed at
  * non-technical users who just installed Cubby and need to know it's running,
- * how to open it, and what it does.
+ * how to open it, and what it does. Deliberately points at the tray icon rather
+ * than a keyboard shortcut, since this audience may not know the Windows key.
  */
-export function WelcomeOverlay({ hotkey, onDismiss }: WelcomeOverlayProps) {
+export function WelcomeOverlay({ onDismiss }: WelcomeOverlayProps) {
   const { t } = useTranslation();
 
   const points = [
-    { icon: Keyboard, text: t('onboarding.pointOpen', { hotkey }) },
+    { icon: MousePointerClick, text: t('onboarding.pointOpen') },
     { icon: Clipboard, text: t('onboarding.pointAuto') },
     { icon: Pin, text: t('onboarding.pointUse') },
     { icon: Lock, text: t('onboarding.pointPrivate') },

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -195,7 +195,7 @@
   "onboarding": {
     "title": "Welcome to Cubby",
     "intro": "Cubby keeps a history of everything you copy, so you can paste it back whenever you need it.",
-    "pointOpen": "Press {{hotkey}} any time to open Cubby.",
+    "pointOpen": "To open Cubby, click its icon near the clock, in the bottom-right corner of your screen.",
     "pointAuto": "Everything you copy is saved here automatically — no extra steps.",
     "pointUse": "Click an item (or press Enter) to paste it. Pin the ones you want to keep.",
     "pointPrivate": "Your history is encrypted and stays on this PC. Nothing is uploaded.",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -195,7 +195,7 @@
   "onboarding": {
     "title": "Welcome to Cubby",
     "intro": "Cubby keeps a history of everything you copy, so you can paste it back whenever you need it.",
-    "pointOpen": "To open Cubby, click its icon near the clock, in the bottom-right corner of your screen.",
+    "pointOpen": "Press Win+V any time to open Cubby.",
     "pointAuto": "Everything you copy is saved here automatically — no extra steps.",
     "pointUse": "Click an item (or press Enter) to paste it. Pin the ones you want to keep.",
     "pointPrivate": "Your history is encrypted and stays on this PC. Nothing is uploaded.",


### PR DESCRIPTION
The first-run welcome told users to 'Press {hotkey}' — which resolved to the configured shortcut (Ctrl+backquote, Win+Alt+V, etc.). Non-technical users don't know those keys and often can't find the Windows key, so it was useless to them. Now it says to click the Cubby icon near the clock, matching the beginner website guide. Removes the now-unused hotkey prop.