### PR TITLE
Home page: download buttons link directly to the installer .exe

### DIFF
--- a/product_pages/index.html
+++ b/product_pages/index.html
@@ -41,7 +41,7 @@
         <h1>Keep what you copy.<br><span>Find it when you need it.</span></h1>
         <p class="hero-lede">Cubby is the clipboard history Windows should have shipped: fast to open, easy to search, and dependable enough for the work you do all day.</p>
         <div class="cta-row">
-          <a class="button button-primary" data-latest-release href="https://github.com/tsouth89/cubby-clipboard/releases">Download for Windows <span aria-hidden="true">↓</span></a>
+          <a class="button button-primary" data-latest-installer href="https://github.com/tsouth89/cubby-clipboard/releases/latest">Download for Windows <span aria-hidden="true">↓</span></a>
           <a class="button button-secondary" href="https://github.com/tsouth89/cubby-clipboard">View on GitHub <span aria-hidden="true">↗</span></a>
         </div>
         <p class="release-note"><span data-release-version>Latest beta · v0.1.0-beta.1</span> · Windows 11 · Free and open source</p>
@@ -180,7 +180,7 @@
         <p>Cubby handles the clipboard formats you use most, with encrypted local history and workflows built for everyday Windows use. Your feedback helps us keep polishing compatibility and the details that make it feel at home on Windows.</p>
       </div>
       <div class="release-actions">
-        <a class="button button-primary" data-latest-release href="https://github.com/tsouth89/cubby-clipboard/releases">Download the latest release</a>
+        <a class="button button-primary" data-latest-installer href="https://github.com/tsouth89/cubby-clipboard/releases/latest">Download the latest release</a>
         <a class="text-link" href="https://github.com/tsouth89/cubby-clipboard/issues">Report an issue <span aria-hidden="true">→</span></a>
       </div>
     </section>


### PR DESCRIPTION
The two 'Download' buttons on the home page pointed at the GitHub releases page. Switch them to data-latest-installer (direct x64 .exe, same as the beginner guide), with a releases/latest fallback. The Support page's 'read its notes' link intentionally still goes to the release page.