### PR TITLE
Fix CSP blocking the GitHub API (direct-download resolver)

### DIFF
--- a/product_pages/_headers
+++ b/product_pages/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; style-src 'self'
+  Content-Security-Policy: default-src 'self'; base-uri 'none'; connect-src 'self' https://api.github.com; form-action 'none'; frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; style-src 'self'
   Permissions-Policy: camera=(), geolocation=(), microphone=()
   Referrer-Policy: strict-origin-when-cross-origin
   X-Content-Type-Options: nosniff


### PR DESCRIPTION
The site CSP (default-src 'self', no connect-src) blocked release-links.js's fetch to api.github.com, so the Download buttons silently fell back to the releases page instead of the direct installer .exe. Add `connect-src 'self' https://api.github.com`.