### PR TITLE
Fix website build (page count) + strip em dashes site-wide

### DIFF
--- a/.github/scripts/check-site.mjs
+++ b/.github/scripts/check-site.mjs
@@ -37,7 +37,12 @@ for (const forbidden of ['PastePaw', 'macOS', 'linear-gradient', 'purple', 'viol
   }
 }
 
-if (pages.length !== 4) errors.push(`expected 4 HTML pages, found ${pages.length}`);
+// Em/en dashes read as AI-written. Use a regular hyphen, comma, or period.
+if (combined.includes('—') || combined.includes('–')) {
+  errors.push('active site contains an em or en dash (use a regular hyphen, comma, or period)');
+}
+
+if (pages.length !== 5) errors.push(`expected 5 HTML pages, found ${pages.length}`);
 if (!files.has('_headers')) errors.push('missing Cloudflare Pages security headers');
 
 if (errors.length) {

--- a/product_pages/index.html
+++ b/product_pages/index.html
@@ -149,10 +149,10 @@
       <div class="comparison" role="table" aria-label="Cubby and Windows Clipboard History comparison">
         <div class="comparison-row comparison-head" role="row"><span role="columnheader">What matters</span><span role="columnheader">Windows Clipboard History</span><span role="columnheader" class="cubby-col">Cubby</span></div>
         <div class="comparison-row" role="row"><strong role="rowheader">Long local history</strong><span>Limited</span><span class="cubby-col">Built for it</span></div>
-        <div class="comparison-row" role="row"><strong role="rowheader">Instant search</strong><span>, </span><span class="cubby-col">Included</span></div>
+        <div class="comparison-row" role="row"><strong role="rowheader">Instant search</strong><span>Not available</span><span class="cubby-col">Included</span></div>
         <div class="comparison-row" role="row"><strong role="rowheader">Remote-session workflow</strong><span>Inconsistent</span><span class="cubby-col">First-class target</span></div>
         <div class="comparison-row" role="row"><strong role="rowheader">Pin important clips</strong><span>Included</span><span class="cubby-col">Included</span></div>
-        <div class="comparison-row" role="row"><strong role="rowheader">Open source</strong><span>, </span><span class="cubby-col">GPL-3.0</span></div>
+        <div class="comparison-row" role="row"><strong role="rowheader">Open source</strong><span>No</span><span class="cubby-col">GPL-3.0</span></div>
       </div>
       <p class="comparison-note">Cubby focuses on clipboard history. Windows still owns emoji, GIF, kaomoji, and symbol picking through <kbd>Win</kbd> + <kbd>.</kbd></p>
     </section>

--- a/product_pages/index.html
+++ b/product_pages/index.html
@@ -8,13 +8,13 @@
   <meta name="keywords" content="Windows 11 clipboard manager, clipboard history, Win+V replacement, remote desktop clipboard, open source clipboard manager">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://cubbyclipboard.com/">
-  <meta property="og:title" content="Cubby Clipboard — Keep what you copy">
+  <meta property="og:title" content="Cubby Clipboard, Keep what you copy">
   <meta property="og:description" content="A friendly, reliable clipboard history replacement built for Windows 11.">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://cubbyclipboard.com/">
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="styles.css">
-  <title>Cubby Clipboard — A better clipboard history for Windows 11</title>
+  <title>Cubby Clipboard, A better clipboard history for Windows 11</title>
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
@@ -149,10 +149,10 @@
       <div class="comparison" role="table" aria-label="Cubby and Windows Clipboard History comparison">
         <div class="comparison-row comparison-head" role="row"><span role="columnheader">What matters</span><span role="columnheader">Windows Clipboard History</span><span role="columnheader" class="cubby-col">Cubby</span></div>
         <div class="comparison-row" role="row"><strong role="rowheader">Long local history</strong><span>Limited</span><span class="cubby-col">Built for it</span></div>
-        <div class="comparison-row" role="row"><strong role="rowheader">Instant search</strong><span>—</span><span class="cubby-col">Included</span></div>
+        <div class="comparison-row" role="row"><strong role="rowheader">Instant search</strong><span>, </span><span class="cubby-col">Included</span></div>
         <div class="comparison-row" role="row"><strong role="rowheader">Remote-session workflow</strong><span>Inconsistent</span><span class="cubby-col">First-class target</span></div>
         <div class="comparison-row" role="row"><strong role="rowheader">Pin important clips</strong><span>Included</span><span class="cubby-col">Included</span></div>
-        <div class="comparison-row" role="row"><strong role="rowheader">Open source</strong><span>—</span><span class="cubby-col">GPL-3.0</span></div>
+        <div class="comparison-row" role="row"><strong role="rowheader">Open source</strong><span>, </span><span class="cubby-col">GPL-3.0</span></div>
       </div>
       <p class="comparison-note">Cubby focuses on clipboard history. Windows still owns emoji, GIF, kaomoji, and symbol picking through <kbd>Win</kbd> + <kbd>.</kbd></p>
     </section>

--- a/product_pages/privacy.html
+++ b/product_pages/privacy.html
@@ -8,7 +8,7 @@
   <link rel="canonical" href="https://cubbyclipboard.com/privacy.html">
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="styles.css">
-  <title>Privacy — Cubby Clipboard</title>
+  <title>Privacy, Cubby Clipboard</title>
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/product_pages/start.html
+++ b/product_pages/start.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#f7f5ef">
-  <meta name="description" content="A simple, step-by-step guide to installing Cubby and using it to keep everything you copy. Written for everyone — no computer jargon.">
+  <meta name="description" content="A simple, step-by-step guide to installing Cubby and using it to keep everything you copy. Written for everyone, no computer jargon.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://cubbyclipboard.com/start.html">
   <meta property="og:title" content="Getting started with Cubby">
@@ -12,7 +12,7 @@
   <link rel="canonical" href="https://cubbyclipboard.com/start.html">
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="styles.css">
-  <title>Getting started with Cubby — the easy guide</title>
+  <title>Getting started with Cubby, the easy guide</title>
   <style>
     .start-hero { padding-block: 60px 40px; text-align: center; }
     .start-hero h1 { margin-inline: auto; font-size: clamp(2.6rem, 5vw, 4rem); }
@@ -72,7 +72,7 @@
     <section class="shell start-hero">
       <p class="eyebrow"><span class="status-dot" aria-hidden="true"></span> New here? Start with this</p>
       <h1>Keep everything you copy.</h1>
-      <p class="hero-lede">You copy things all day — a phone number, an address, a bit of text. Windows only remembers the <em>last</em> thing you copied. Cubby quietly keeps them all, so you can grab any of them again whenever you want.</p>
+      <p class="hero-lede">You copy things all day, a phone number, an address, a bit of text. Windows only remembers the <em>last</em> thing you copied. Cubby quietly keeps them all, so you can grab any of them again whenever you want.</p>
       <div class="cta-row">
         <a class="button button-primary" data-latest-installer href="https://github.com/tsouth89/cubby-clipboard/releases/latest">Download Cubby (free) <span aria-hidden="true">↓</span></a>
       </div>
@@ -94,12 +94,12 @@
           <div class="idea">
             <span class="num" aria-hidden="true">2</span>
             <h3>Cubby saves it</h3>
-            <p>Every time you copy, Cubby tucks it away in a tidy list — automatically. You don't have to do anything.</p>
+            <p>Every time you copy, Cubby tucks it away in a tidy list, automatically. You don't have to do anything.</p>
           </div>
           <div class="idea">
             <span class="num" aria-hidden="true">3</span>
             <h3>Paste it back later</h3>
-            <p>Open Cubby, click the thing you want, and it's ready to paste — even something you copied yesterday.</p>
+            <p>Open Cubby, click the thing you want, and it's ready to paste, even something you copied yesterday.</p>
           </div>
         </div>
       </div>
@@ -117,7 +117,7 @@
           <div class="badge" aria-hidden="true">1</div>
           <div>
             <h3>Click the download button</h3>
-            <p>Use the blue <strong>Download Cubby</strong> button on this page. A file will save to your computer — usually into a folder called <strong>Downloads</strong>.</p>
+            <p>Use the blue <strong>Download Cubby</strong> button on this page. A file will save to your computer, usually into a folder called <strong>Downloads</strong>.</p>
             <p><a class="button button-primary" data-latest-installer href="https://github.com/tsouth89/cubby-clipboard/releases/latest" style="min-height:44px;">Download Cubby <span aria-hidden="true">↓</span></a></p>
           </div>
         </div>
@@ -137,7 +137,7 @@
             <p>Windows shows this for brand-new apps it hasn't seen many times yet. Cubby is safe and digitally signed by its maker (SouthForge). To continue:</p>
             <div class="callout">
               <strong>Do this:</strong>
-              <p>Click <strong>More info</strong>, then click the <strong>Run anyway</strong> button that appears. That's it — you can keep going.</p>
+              <p>Click <strong>More info</strong>, then click the <strong>Run anyway</strong> button that appears. That's it, you can keep going.</p>
             </div>
             <p style="margin-top:12px;">Not everyone will see this box. If you don't, just skip to the next step.</p>
           </div>
@@ -174,7 +174,7 @@
             <div class="badge" aria-hidden="true">☰</div>
             <div>
               <h3>To open Cubby, click its little icon near the clock</h3>
-              <p>Look at the <strong>bottom-right corner</strong> of your screen, next to the time and date. You'll see a row of tiny icons — click the <strong>Cubby</strong> one to open your copied history.</p>
+              <p>Look at the <strong>bottom-right corner</strong> of your screen, next to the time and date. You'll see a row of tiny icons, click the <strong>Cubby</strong> one to open your copied history.</p>
               <div class="tray-illustration" aria-hidden="true">
                 <div class="taskbar">
                   <span class="chev">︿</span>
@@ -197,7 +197,7 @@
           </div>
         </div>
 
-        <p class="reassure">Prefer a keyboard shortcut? There's one for that too, and you can change it in Cubby's settings — but clicking the icon works great and is all you ever need.</p>
+        <p class="reassure">Prefer a keyboard shortcut? There's one for that too, and you can change it in Cubby's settings, but clicking the icon works great and is all you ever need.</p>
       </div>
     </section>
 

--- a/product_pages/start.html
+++ b/product_pages/start.html
@@ -72,7 +72,7 @@
     <section class="shell start-hero">
       <p class="eyebrow"><span class="status-dot" aria-hidden="true"></span> New here? Start with this</p>
       <h1>Keep everything you copy.</h1>
-      <p class="hero-lede">You copy things all day, a phone number, an address, a bit of text. Windows only remembers the <em>last</em> thing you copied. Cubby quietly keeps them all, so you can grab any of them again whenever you want.</p>
+      <p class="hero-lede">You copy things all day: a phone number, an address, a bit of text. Windows only remembers the <em>last</em> thing you copied. Cubby quietly keeps them all, so you can grab any of them again whenever you want.</p>
       <div class="cta-row">
         <a class="button button-primary" data-latest-installer href="https://github.com/tsouth89/cubby-clipboard/releases/latest">Download Cubby (free) <span aria-hidden="true">↓</span></a>
       </div>
@@ -137,7 +137,7 @@
             <p>Windows shows this for brand-new apps it hasn't seen many times yet. Cubby is safe and digitally signed by its maker (SouthForge). To continue:</p>
             <div class="callout">
               <strong>Do this:</strong>
-              <p>Click <strong>More info</strong>, then click the <strong>Run anyway</strong> button that appears. That's it, you can keep going.</p>
+              <p>Click <strong>More info</strong>, then click the <strong>Run anyway</strong> button that appears. That's it. You can keep going.</p>
             </div>
             <p style="margin-top:12px;">Not everyone will see this box. If you don't, just skip to the next step.</p>
           </div>
@@ -174,7 +174,7 @@
             <div class="badge" aria-hidden="true">☰</div>
             <div>
               <h3>To open Cubby, click its little icon near the clock</h3>
-              <p>Look at the <strong>bottom-right corner</strong> of your screen, next to the time and date. You'll see a row of tiny icons, click the <strong>Cubby</strong> one to open your copied history.</p>
+              <p>Look at the <strong>bottom-right corner</strong> of your screen, next to the time and date. You'll see a row of tiny icons. Click the <strong>Cubby</strong> one to open your copied history.</p>
               <div class="tray-illustration" aria-hidden="true">
                 <div class="taskbar">
                   <span class="chev">︿</span>

--- a/product_pages/support.html
+++ b/product_pages/support.html
@@ -8,7 +8,7 @@
   <link rel="canonical" href="https://cubbyclipboard.com/support.html">
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="styles.css">
-  <title>Support — Cubby Clipboard</title>
+  <title>Support, Cubby Clipboard</title>
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/product_pages/terms.html
+++ b/product_pages/terms.html
@@ -8,7 +8,7 @@
   <link rel="canonical" href="https://cubbyclipboard.com/terms.html">
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="styles.css">
-  <title>Terms — Cubby Clipboard</title>
+  <title>Terms, Cubby Clipboard</title>
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>


### PR DESCRIPTION
The Website check hardcoded exactly 4 HTML pages; the beginner start.html made it 5, so the check had been failing since that page merged. Bump to 5. Also strip em/en dashes from all pages (they read as AI-written) and add a check-site guard against them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined browser tab titles and page descriptions across privacy, support, terms, and the start/onboarding pages.
  * Updated social sharing (Open Graph) wording and improved on-page instructional copy for clarity.
  * Adjusted comparison-table wording, replacing em-dash placeholders with explicit “Not available” / “No”.

* **Bug Fixes**
  * Strengthened site validation to flag unsupported dash characters (em/en dashes).

* **Chores**
  * Updated automated site checks to reflect the current expected number of HTML pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->