### PR TITLE
Show matched OCR context in image search

### DIFF
--- a/frontend/src/components/ClipCard.tsx
+++ b/frontend/src/components/ClipCard.tsx
@@ -183,11 +183,23 @@ export const ClipCard = memo(function ClipCard({
               <p className="truncate text-[13px] font-medium text-foreground">
                 {imageLabel(label)}
               </p>
-              {imageDetails.length > 0 && (
+              {clip.ocr_match ? (
+                <p
+                  data-el="ocr-match"
+                  className="mt-1 line-clamp-2 break-words text-[11px] leading-[15px] text-foreground/65"
+                  title={`${clip.ocr_match.before}${clip.ocr_match.matched}${clip.ocr_match.after}`}
+                >
+                  {clip.ocr_match.before}
+                  <mark className="rounded-[3px] bg-primary/25 px-0.5 font-medium text-foreground">
+                    {clip.ocr_match.matched}
+                  </mark>
+                  {clip.ocr_match.after}
+                </p>
+              ) : imageDetails.length > 0 ? (
                 <p className="mt-1 truncate text-[11px] text-foreground/55">
                   {imageDetails.join(' · ')}
                 </p>
-              )}
+              ) : null}
               <p className="mt-1.5 truncate text-[11px] text-muted-foreground">
                 {label}
                 {age && <span className="px-1.5 text-muted-foreground/40">•</span>}

--- a/frontend/src/debug/demoData.ts
+++ b/frontend/src/debug/demoData.ts
@@ -191,5 +191,5 @@ export function generateDemoClips(): ClipboardItem[] {
       source_icon: null,
       metadata: JSON.stringify({ size_bytes: 92160 }),
     },
-  ].map((clip) => ({ ...clip, is_pinned: false }));
+  ].map((clip) => ({ ...clip, is_pinned: false, ocr_match: null }));
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -9,6 +9,13 @@ export interface ClipboardItem {
   source_app: string | null;
   source_icon: string | null;
   metadata: string | null;
+  ocr_match: OcrMatch | null;
+}
+
+export interface OcrMatch {
+  before: string;
+  matched: string;
+  after: string;
 }
 
 export interface FolderItem {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -92,7 +92,30 @@ fn build_ocr_match(ocr_text: &str, query: &str) -> Option<OcrMatch> {
     let before = normalize_ocr_whitespace(&ocr_text[..match_start]);
     let after = normalize_ocr_whitespace(&ocr_text[match_end..]);
 
-    let remaining = OCR_SNIPPET_CHAR_LIMIT.saturating_sub(matched.chars().count());
+    let matched_length = matched.chars().count();
+    if matched_length >= OCR_SNIPPET_CHAR_LIMIT {
+        let (mut matched, cropped) = head_chars(&matched, OCR_SNIPPET_CHAR_LIMIT - 1);
+        if cropped {
+            matched.push('…');
+        }
+        return Some(OcrMatch {
+            before: String::new(),
+            matched,
+            after: String::new(),
+        });
+    }
+
+    // Reserve the maximum decoration cost: one separator and one ellipsis on
+    // each side. Very long matches remain useful on their own without context.
+    if matched_length + 4 >= OCR_SNIPPET_CHAR_LIMIT {
+        return Some(OcrMatch {
+            before: String::new(),
+            matched,
+            after: String::new(),
+        });
+    }
+
+    let remaining = OCR_SNIPPET_CHAR_LIMIT - matched_length - 4;
     let before_limit = remaining / 2;
     let after_limit = remaining - before_limit;
     let (mut before, before_cropped) = tail_chars(&before, before_limit);
@@ -1498,6 +1521,7 @@ mod tests {
         build_ocr_match, clear_clips_in_pool, clipboard_contents_for_restore,
         enforce_retention_in_pool, migrate_clip_format_model, migrate_encrypted_storage,
         remove_clip_image_files, restore_hash_material, toggle_clip_pin_in_pool, ClipboardContent,
+        OCR_SNIPPET_CHAR_LIMIT,
     };
     use crate::clipboard::CapturedFormat;
     use crate::database::Database;
@@ -1531,13 +1555,15 @@ mod tests {
             .expect("OCR query should produce a visible match");
 
         assert_eq!(matched.matched, "Windows clipboard history");
+        assert!(matched.before.starts_with('…'));
         assert!(matched.before.ends_with("because the "));
         assert!(matched.after.starts_with(" service is unavailable."));
+        assert!(matched.after.ends_with('…'));
         assert!(
             format!("{}{}{}", matched.before, matched.matched, matched.after)
                 .chars()
                 .count()
-                <= 98
+                <= OCR_SNIPPET_CHAR_LIMIT
         );
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,5 +1,5 @@
 use crate::database::Database;
-use crate::models::{Clip, ClipboardItem, Folder, FolderItem};
+use crate::models::{Clip, ClipboardItem, Folder, FolderItem, OcrMatch};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use clipboard_rs::common::RustImage;
 use clipboard_rs::{Clipboard, ClipboardContent, ClipboardContext, RustImageData};
@@ -27,7 +27,106 @@ fn clip_to_list_item(clip: &Clip) -> ClipboardItem {
         source_app: clip.source_app.clone(),
         source_icon: clip.source_icon.clone(),
         metadata: clip.metadata.clone(),
+        ocr_match: None,
     }
+}
+
+const OCR_SNIPPET_CHAR_LIMIT: usize = 96;
+
+fn find_case_insensitive(haystack: &str, needle: &str) -> Option<(usize, usize)> {
+    let folded_needle = needle.to_lowercase();
+    if folded_needle.is_empty() {
+        return None;
+    }
+
+    for (start, _) in haystack.char_indices() {
+        let mut folded_candidate = String::new();
+        for (relative_start, character) in haystack[start..].char_indices() {
+            folded_candidate.extend(character.to_lowercase());
+            if !folded_needle.starts_with(&folded_candidate) {
+                break;
+            }
+            if folded_candidate == folded_needle {
+                return Some((start, start + relative_start + character.len_utf8()));
+            }
+        }
+    }
+
+    None
+}
+
+fn normalize_ocr_whitespace(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn tail_chars(value: &str, limit: usize) -> (String, bool) {
+    let characters: Vec<char> = value.chars().collect();
+    if characters.len() <= limit {
+        return (value.to_string(), false);
+    }
+
+    let mut tail: String = characters[characters.len() - limit..].iter().collect();
+    if let Some(first_space) = tail.find(char::is_whitespace) {
+        tail = tail[first_space..].trim_start().to_string();
+    }
+    (tail, true)
+}
+
+fn head_chars(value: &str, limit: usize) -> (String, bool) {
+    let characters: Vec<char> = value.chars().collect();
+    if characters.len() <= limit {
+        return (value.to_string(), false);
+    }
+
+    let mut head: String = characters[..limit].iter().collect();
+    if let Some(last_space) = head.rfind(char::is_whitespace) {
+        head.truncate(last_space);
+    }
+    (head, true)
+}
+
+fn build_ocr_match(ocr_text: &str, query: &str) -> Option<OcrMatch> {
+    let query = query.trim();
+    let (match_start, match_end) = find_case_insensitive(ocr_text, query)?;
+    let matched = normalize_ocr_whitespace(&ocr_text[match_start..match_end]);
+    let before = normalize_ocr_whitespace(&ocr_text[..match_start]);
+    let after = normalize_ocr_whitespace(&ocr_text[match_end..]);
+
+    let remaining = OCR_SNIPPET_CHAR_LIMIT.saturating_sub(matched.chars().count());
+    let before_limit = remaining / 2;
+    let after_limit = remaining - before_limit;
+    let (mut before, before_cropped) = tail_chars(&before, before_limit);
+    let (mut after, after_cropped) = head_chars(&after, after_limit);
+
+    if before_cropped {
+        before = format!("…{before}");
+    }
+    if !before.is_empty() {
+        before.push(' ');
+    }
+    if !after.is_empty() {
+        after.insert(0, ' ');
+    }
+    if after_cropped {
+        after.push('…');
+    }
+
+    Some(OcrMatch {
+        before,
+        matched,
+        after,
+    })
+}
+
+fn clip_to_search_item(clip: &Clip, query: &str) -> ClipboardItem {
+    let mut item = clip_to_list_item(clip);
+    if clip.clip_type == "image" {
+        item.ocr_match = clip
+            .ocr_text
+            .as_deref()
+            .and_then(|text| build_ocr_match(text, query));
+    }
+    item
 }
 
 fn decrypt_clip_fields(db: &Database, clip: &mut Clip) -> Result<(), String> {
@@ -59,6 +158,7 @@ fn clip_to_detail_item(clip: &Clip, full_image_content: Option<&[u8]>) -> Clipbo
         source_app: clip.source_app.clone(),
         source_icon: clip.source_icon.clone(),
         metadata: clip.metadata.clone(),
+        ocr_match: None,
     }
 }
 
@@ -980,7 +1080,10 @@ pub async fn search_clips(
         .count();
     let raw_bytes: usize = clips.iter().map(|clip| clip.content.len()).sum();
     let map_started = Instant::now();
-    let items: Vec<ClipboardItem> = clips.iter().map(clip_to_list_item).collect();
+    let items: Vec<ClipboardItem> = clips
+        .iter()
+        .map(|clip| clip_to_search_item(clip, &query))
+        .collect();
     let map_ms = map_started.elapsed().as_millis();
     let total_ms = started.elapsed().as_millis();
     log::info!(
@@ -1392,9 +1495,9 @@ pub async fn import_from_ditto(
 #[cfg(test)]
 mod tests {
     use super::{
-        clear_clips_in_pool, clipboard_contents_for_restore, enforce_retention_in_pool,
-        migrate_clip_format_model, migrate_encrypted_storage, remove_clip_image_files,
-        restore_hash_material, toggle_clip_pin_in_pool, ClipboardContent,
+        build_ocr_match, clear_clips_in_pool, clipboard_contents_for_restore,
+        enforce_retention_in_pool, migrate_clip_format_model, migrate_encrypted_storage,
+        remove_clip_image_files, restore_hash_material, toggle_clip_pin_in_pool, ClipboardContent,
     };
     use crate::clipboard::CapturedFormat;
     use crate::database::Database;
@@ -1419,6 +1522,45 @@ mod tests {
         };
         database.migrate().await.expect("migration should succeed");
         database
+    }
+
+    #[test]
+    fn ocr_match_centers_and_highlights_the_query() {
+        let ocr_text = "The application could not start because the Windows clipboard history service is unavailable. Restart the computer and try again.";
+        let matched = build_ocr_match(ocr_text, "windows clipboard history")
+            .expect("OCR query should produce a visible match");
+
+        assert_eq!(matched.matched, "Windows clipboard history");
+        assert!(matched.before.ends_with("because the "));
+        assert!(matched.after.starts_with(" service is unavailable."));
+        assert!(
+            format!("{}{}{}", matched.before, matched.matched, matched.after)
+                .chars()
+                .count()
+                <= 98
+        );
+    }
+
+    #[test]
+    fn ocr_match_is_case_insensitive_and_collapses_line_breaks() {
+        let matched = build_ocr_match(
+            "Receipt total\n\nCONFIRMATION NUMBER\nABCD-1234",
+            "confirmation number",
+        )
+        .expect("case-insensitive OCR query should match");
+
+        assert_eq!(matched.before, "Receipt total ");
+        assert_eq!(matched.matched, "CONFIRMATION NUMBER");
+        assert_eq!(matched.after, " ABCD-1234");
+    }
+
+    #[test]
+    fn ocr_match_returns_none_for_unrelated_text() {
+        assert_eq!(
+            build_ocr_match("A recipe for tomato soup", "error code"),
+            None
+        );
+        assert_eq!(build_ocr_match("Some OCR text", "   "), None);
     }
 
     #[tokio::test]

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -153,6 +153,14 @@ pub struct ClipboardItem {
     pub source_app: Option<String>,
     pub source_icon: Option<String>,
     pub metadata: Option<String>,
+    pub ocr_match: Option<OcrMatch>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OcrMatch {
+    pub before: String,
+    pub matched: String,
+    pub after: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## What changed

- return a compact OCR match context only for image search results
- center the snippet around the matched phrase, normalize OCR whitespace, and crop it to a two-line-friendly length
- render the matched phrase with a visible highlight in image cards
- keep full OCR text out of normal clipboard list payloads
- add focused coverage for case-insensitive matching, whitespace normalization, cropping, and non-matches

## Why

Image results could match text found by OCR without explaining why they appeared. The visible snippet makes OCR search understandable and trustworthy, and gives the launch demo a clear visual payoff.

## Validation

- `pnpm build`
- `pnpm format:check`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` (44 passed)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings`
- `git diff --check`

Linear: SOU-241


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Image search results now surface OCR match snippets with the matched terms highlighted.
  - OCR previews show surrounding context around the match for easier interpretation.
  - Search matching is improved to be case-insensitive and robust to OCR line/whitespace differences.
- **Bug Fixes**
  - Image result previews now properly fall back to standard image metadata when no OCR match is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->