### PR TITLE
feat: make OCR processing durable

### DIFF
--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -7,6 +7,9 @@ import {
   Settings as SettingsIcon,
   Folder as FolderIcon,
   MoreHorizontal,
+  Pause,
+  Play,
+  RefreshCw,
 } from 'lucide-react';
 import { useState, useEffect, useRef } from 'react';
 import { useTheme } from '../hooks/useTheme';
@@ -39,6 +42,15 @@ type DittoImportResult = {
   skipped_empty: number;
   errors: string[];
   dry_run: boolean;
+};
+
+type OcrQueueStatus = {
+  pending: number;
+  processing: number;
+  completed: number;
+  failed: number;
+  unavailable: number;
+  paused: boolean;
 };
 
 export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPanelProps) {
@@ -138,6 +150,19 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
   const [newIgnoredApp, setNewIgnoredApp] = useState('');
   const [appVersion, setAppVersion] = useState('');
   const [dittoBusy, setDittoBusy] = useState(false);
+  const [ocrStatus, setOcrStatus] = useState<OcrQueueStatus | null>(null);
+  const [ocrActionBusy, setOcrActionBusy] = useState(false);
+  const ocrRemaining = (ocrStatus?.pending ?? 0) + (ocrStatus?.processing ?? 0);
+  const ocrFailures = (ocrStatus?.failed ?? 0) + (ocrStatus?.unavailable ?? 0);
+  const ocrStatusLabel = !ocrStatus
+    ? t('common.loading')
+    : ocrStatus.paused
+      ? t('settings.ocrPaused')
+      : ocrRemaining > 0
+        ? t('settings.ocrIndexing')
+        : ocrFailures > 0
+          ? t('settings.ocrNeedsAttention')
+          : t('settings.ocrReady');
 
   // Confirmation Dialog State
   const [confirmDialog, setConfirmDialog] = useState({
@@ -156,12 +181,49 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
     }
   };
 
+  const loadOcrStatus = async () => {
+    try {
+      setOcrStatus(await invoke<OcrQueueStatus>('get_ocr_queue_status'));
+    } catch (error) {
+      console.error('Failed to load OCR index status:', error);
+    }
+  };
+
   useEffect(() => {
     invoke<number>('get_clipboard_history_size').then(setHistorySize).catch(console.error);
     invoke<string[]>('get_ignored_apps').then(setIgnoredApps).catch(console.error);
     getVersion().then(setAppVersion).catch(console.error);
     loadFolders();
+    loadOcrStatus();
+    const ocrStatusTimer = window.setInterval(loadOcrStatus, 3000);
+    return () => window.clearInterval(ocrStatusTimer);
   }, []);
+
+  const handleOcrPauseToggle = async () => {
+    if (!ocrStatus) return;
+    setOcrActionBusy(true);
+    try {
+      await invoke('set_ocr_queue_paused', { paused: !ocrStatus.paused });
+      await loadOcrStatus();
+    } catch (error) {
+      toast.error(String(error));
+    } finally {
+      setOcrActionBusy(false);
+    }
+  };
+
+  const handleRetryOcr = async () => {
+    setOcrActionBusy(true);
+    try {
+      const count = await invoke<number>('retry_failed_ocr');
+      toast.success(t('settings.ocrRetryQueued', { count }));
+      await loadOcrStatus();
+    } catch (error) {
+      toast.error(String(error));
+    } finally {
+      setOcrActionBusy(false);
+    }
+  };
 
   const handleAddIgnoredApp = async () => {
     if (!newIgnoredApp.trim()) return;
@@ -803,6 +865,56 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
                           ))
                         )}
                       </div>
+                    </div>
+                  </section>
+
+                  <section className="space-y-4">
+                    <h3 className="text-sm font-medium text-muted-foreground">
+                      {t('settings.ocrIndex')}
+                    </h3>
+                    <div className="rounded-lg border border-border bg-accent/20 p-3">
+                      <div className="flex items-start justify-between gap-4">
+                        <div>
+                          <span className="text-sm font-medium">{ocrStatusLabel}</span>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {t('settings.ocrIndexDesc')}
+                          </p>
+                          {ocrStatus && (
+                            <p className="mt-2 text-xs text-muted-foreground">
+                              {t('settings.ocrProgress', {
+                                completed: ocrStatus.completed,
+                                remaining: ocrRemaining,
+                                failed: ocrFailures,
+                              })}
+                            </p>
+                          )}
+                          {!!ocrStatus?.unavailable && (
+                            <p className="mt-2 text-xs text-amber-600 dark:text-amber-400">
+                              {t('settings.ocrUnavailableDesc')}
+                            </p>
+                          )}
+                        </div>
+                        <button
+                          onClick={handleOcrPauseToggle}
+                          disabled={!ocrStatus || ocrActionBusy}
+                          className="btn btn-secondary shrink-0 px-3 text-xs"
+                        >
+                          {ocrStatus?.paused ? <Play size={14} /> : <Pause size={14} />}
+                          <span className="ml-2">
+                            {ocrStatus?.paused ? t('common.resume') : t('common.pause')}
+                          </span>
+                        </button>
+                      </div>
+                      {!!ocrStatus && ocrFailures > 0 && (
+                        <button
+                          onClick={handleRetryOcr}
+                          disabled={ocrActionBusy}
+                          className="btn btn-secondary mt-3 px-3 text-xs"
+                        >
+                          <RefreshCw size={14} className="mr-2" />
+                          {t('settings.ocrRetry')}
+                        </button>
+                      )}
                     </div>
                   </section>
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -10,7 +10,9 @@
     "search": "Suchen",
     "loading": "Wird geladen...",
     "copied": "In die Zwischenablage kopiert",
-    "pasteSuccess": "Erfolgreich eingefügt"
+    "pasteSuccess": "Erfolgreich eingefügt",
+    "pause": "Pausieren",
+    "resume": "Fortsetzen"
   },
   "clipList": {
     "empty": "Noch keine Einträge",
@@ -55,6 +57,16 @@
     "shortcuts": "Tastenkombinationen",
     "privacyExceptions": "Datenschutz-Ausnahmen",
     "dataManagement": "Datenverwaltung",
+    "ocrIndex": "Screenshot-Suchindex",
+    "ocrIndexing": "Screenshots werden indexiert",
+    "ocrPaused": "Screenshot-Indexierung pausiert",
+    "ocrReady": "Screenshot-Index ist bereit",
+    "ocrNeedsAttention": "Screenshot-Index erfordert Aufmerksamkeit",
+    "ocrUnavailableDesc": "Windows OCR ist nicht verfügbar. Installiere ein OCR-Sprachpaket in den Windows-Spracheinstellungen und versuche es erneut.",
+    "ocrIndexDesc": "Cubby indexiert Screenshot-Text lokal im Hintergrund. Bilder werden nie hochgeladen.",
+    "ocrProgress": "{{completed}} indexiert · {{remaining}} ausstehend · {{failed}} benötigen Aufmerksamkeit",
+    "ocrRetry": "Fehlgeschlagene Bilder erneut versuchen",
+    "ocrRetryQueued": "{{count}} Bilder für einen neuen OCR-Versuch eingeplant",
     "aiConfiguration": "KI-Konfiguration",
     "customPrompts": "Benutzerdefinierte Prompts",
     "customPromptsDesc": "Leer lassen, um die Standard-Prompts zu verwenden.",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -10,7 +10,9 @@
     "search": "Search",
     "loading": "Loading...",
     "copied": "Copied to clipboard",
-    "pasteSuccess": "Pasted successfully"
+    "pasteSuccess": "Pasted successfully",
+    "pause": "Pause",
+    "resume": "Resume"
   },
   "clipList": {
     "empty": "No clips yet",
@@ -76,6 +78,16 @@
     "shortcuts": "Shortcuts",
     "privacyExceptions": "Privacy Exceptions",
     "dataManagement": "Data Management",
+    "ocrIndex": "Screenshot search index",
+    "ocrIndexing": "Indexing screenshots",
+    "ocrPaused": "Screenshot indexing paused",
+    "ocrReady": "Screenshot index ready",
+    "ocrNeedsAttention": "Screenshot index needs attention",
+    "ocrUnavailableDesc": "Windows OCR is unavailable. Install an OCR language pack in Windows Language settings, then retry.",
+    "ocrIndexDesc": "Cubby indexes screenshot text locally in the background. Images are never uploaded.",
+    "ocrProgress": "{{completed}} indexed · {{remaining}} remaining · {{failed}} need attention",
+    "ocrRetry": "Retry failed images",
+    "ocrRetryQueued": "Queued {{count}} images for another OCR attempt",
     "aiConfiguration": "AI Configuration",
     "customPrompts": "Custom Prompts",
     "customPromptsDesc": "Leave blank to use default prompts.",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -10,7 +10,9 @@
     "search": "Rechercher",
     "loading": "Chargement...",
     "copied": "Copié dans le presse-papiers",
-    "pasteSuccess": "Collé avec succès"
+    "pasteSuccess": "Collé avec succès",
+    "pause": "Pause",
+    "resume": "Reprendre"
   },
   "clipList": {
     "empty": "Aucun élément pour le moment",
@@ -55,6 +57,16 @@
     "shortcuts": "Raccourcis",
     "privacyExceptions": "Exceptions de confidentialité",
     "dataManagement": "Gestion des données",
+    "ocrIndex": "Index de recherche des captures d’écran",
+    "ocrIndexing": "Indexation des captures d’écran",
+    "ocrPaused": "Indexation des captures d’écran en pause",
+    "ocrReady": "Index des captures d’écran prêt",
+    "ocrNeedsAttention": "L’index des captures d’écran nécessite votre attention",
+    "ocrUnavailableDesc": "La reconnaissance OCR de Windows est indisponible. Installez un module linguistique OCR dans les paramètres de langue de Windows, puis réessayez.",
+    "ocrIndexDesc": "Cubby indexe localement le texte des captures d’écran en arrière-plan. Les images ne sont jamais envoyées.",
+    "ocrProgress": "{{completed}} indexées · {{remaining}} restantes · {{failed}} à vérifier",
+    "ocrRetry": "Réessayer les images en échec",
+    "ocrRetryQueued": "{{count}} images ajoutées pour une nouvelle tentative OCR",
     "aiConfiguration": "Configuration de l'IA",
     "customPrompts": "Prompts personnalisés",
     "customPromptsDesc": "Laissez vide pour utiliser les prompts par défaut.",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -10,7 +10,9 @@
     "search": "検索",
     "loading": "読み込み中...",
     "copied": "クリップボードにコピーしました",
-    "pasteSuccess": "貼り付けに成功しました"
+    "pasteSuccess": "貼り付けに成功しました",
+    "pause": "一時停止",
+    "resume": "再開"
   },
   "clipList": {
     "empty": "まだクリップがありません",
@@ -55,6 +57,16 @@
     "shortcuts": "ショートカット",
     "privacyExceptions": "プライバシー例外",
     "dataManagement": "データ管理",
+    "ocrIndex": "スクリーンショット検索インデックス",
+    "ocrIndexing": "スクリーンショットをインデックス中",
+    "ocrPaused": "スクリーンショットのインデックスを一時停止中",
+    "ocrReady": "スクリーンショットのインデックスは準備完了です",
+    "ocrNeedsAttention": "スクリーンショットのインデックスを確認してください",
+    "ocrUnavailableDesc": "Windows OCR を利用できません。Windows の言語設定で OCR 言語パックをインストールしてから再試行してください。",
+    "ocrIndexDesc": "Cubby はスクリーンショット内のテキストをローカルでバックグラウンド処理します。画像がアップロードされることはありません。",
+    "ocrProgress": "{{completed}} 件完了 · {{remaining}} 件残り · {{failed}} 件要確認",
+    "ocrRetry": "失敗した画像を再試行",
+    "ocrRetryQueued": "{{count}} 件の画像を OCR 再試行に追加しました",
     "aiConfiguration": "AI 設定",
     "customPrompts": "カスタムプロンプト",
     "customPromptsDesc": "空欄のままにするとデフォルトのプロンプトを使用します。",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -10,7 +10,9 @@
     "search": "搜索",
     "loading": "加载中...",
     "copied": "已复制到剪贴板",
-    "pasteSuccess": "粘贴成功"
+    "pasteSuccess": "粘贴成功",
+    "pause": "暂停",
+    "resume": "继续"
   },
   "clipList": {
     "empty": "暂无剪贴",
@@ -55,6 +57,16 @@
     "shortcuts": "快捷键",
     "privacyExceptions": "隐私例外",
     "dataManagement": "数据管理",
+    "ocrIndex": "截图搜索索引",
+    "ocrIndexing": "正在索引截图",
+    "ocrPaused": "截图索引已暂停",
+    "ocrReady": "截图索引已就绪",
+    "ocrNeedsAttention": "截图索引需要处理",
+    "ocrUnavailableDesc": "Windows OCR 不可用。请在 Windows 语言设置中安装 OCR 语言包，然后重试。",
+    "ocrIndexDesc": "Cubby 会在后台本地索引截图文字，图片绝不会上传。",
+    "ocrProgress": "已索引 {{completed}} 项 · 剩余 {{remaining}} 项 · {{failed}} 项需要处理",
+    "ocrRetry": "重试失败的图片",
+    "ocrRetryQueued": "已将 {{count}} 张图片加入 OCR 重试队列",
     "aiConfiguration": "AI 配置",
     "customPrompts": "自定义提示词",
     "customPromptsDesc": "留空则使用默认提示词。",

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -59,6 +59,7 @@ pub fn set_ignore_hash(hash: String) {
 }
 
 pub fn init(app: &AppHandle, db: Arc<Database>) {
+    crate::ocr_queue::init(db.clone());
     let (snapshot_tx, mut snapshot_rx) = tokio::sync::mpsc::unbounded_channel();
     let app_for_consumer = app.clone();
     let db_for_consumer = db.clone();
@@ -634,8 +635,8 @@ async fn process_clipboard_snapshot(
 
         if let Err(error) = sqlx::query(
             r#"
-            INSERT INTO clips (uuid, clip_type, content, text_preview, content_hash, folder_id, is_deleted, is_thumbnail, source_app, source_icon, metadata, created_at, last_accessed)
-            VALUES (?, ?, ?, ?, ?, NULL, 0, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            INSERT INTO clips (uuid, clip_type, content, text_preview, content_hash, folder_id, is_deleted, is_thumbnail, source_app, source_icon, metadata, ocr_status, created_at, last_accessed)
+            VALUES (?, ?, ?, ?, ?, NULL, 0, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
             "#,
         )
         .bind(&clip_uuid)
@@ -647,6 +648,7 @@ async fn process_clipboard_snapshot(
         .bind(&encrypted_source_app)
         .bind(&encrypted_source_icon)
         .bind(encrypted_metadata)
+        .bind((clip_type == "image").then_some("pending"))
         .execute(pool)
         .await
         {
@@ -712,57 +714,11 @@ async fn process_clipboard_snapshot(
     };
     let db_write_ms = db_write_started.elapsed().as_millis();
 
-    // Background OCR: pull text out of screenshot/image clips so they become
-    // searchable by their words. Runs on its own thread, off the capture path,
-    // and never blocks capture; a missing OCR language just leaves ocr_text unset.
-    if inserted_new && clip_type == "image" {
-        if let Some(full_bytes) = full_image_content.clone() {
-            use std::sync::atomic::{AtomicUsize, Ordering};
-            // Cap concurrent OCR workers so a burst of image copies can't spawn
-            // unbounded threads; excess images simply skip OCR.
-            static OCR_IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
-            const MAX_OCR_WORKERS: usize = 3;
-            if OCR_IN_FLIGHT.fetch_add(1, Ordering::SeqCst) >= MAX_OCR_WORKERS {
-                OCR_IN_FLIGHT.fetch_sub(1, Ordering::SeqCst);
-            } else {
-                let db_for_ocr = db.clone();
-                let clip_for_ocr = emitted_id.clone();
-                std::thread::spawn(move || {
-                    match crate::ocr::recognize_png(&full_bytes) {
-                        Ok(text) if !text.trim().is_empty() => {
-                            match db_for_ocr.crypto.encrypt_text(text.trim()) {
-                                Ok(encrypted) => match crate::models::get_runtime() {
-                                    Ok(runtime) => {
-                                        if let Err(error) = runtime.block_on(
-                                            sqlx::query(
-                                                "UPDATE clips SET ocr_text = ? WHERE uuid = ?",
-                                            )
-                                            .bind(&encrypted)
-                                            .bind(&clip_for_ocr)
-                                            .execute(&db_for_ocr.pool),
-                                        ) {
-                                            log::warn!(
-                                                "OCR: could not store text for {}: {}",
-                                                clip_for_ocr,
-                                                error
-                                            );
-                                        }
-                                    }
-                                    Err(error) => log::warn!("OCR: runtime unavailable: {}", error),
-                                },
-                                Err(error) => log::warn!(
-                                    "OCR: could not encrypt text for {}: {}",
-                                    clip_for_ocr,
-                                    error
-                                ),
-                            }
-                        }
-                        Ok(_) => {}
-                        Err(error) => log::debug!("OCR: skipped clip {}: {}", clip_for_ocr, error),
-                    }
-                    OCR_IN_FLIGHT.fetch_sub(1, Ordering::SeqCst);
-                });
-            }
+    // Durable background OCR is queued only after the image payload is safely
+    // stored. Re-copying an image with missing OCR also gives it a fresh retry.
+    if clip_type == "image" {
+        if let Err(error) = crate::ocr_queue::enqueue(&db, &emitted_id).await {
+            log::warn!("OCR: could not queue stored image: {error}");
         }
     }
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -157,6 +157,50 @@ impl Database {
         // Encrypted OCR text extracted from screenshot/image clips, so images are
         // findable by their words. NULL until (or unless) OCR runs for a clip.
         add_column_if_missing(&self.pool, "ALTER TABLE clips ADD COLUMN ocr_text TEXT").await?;
+        add_column_if_missing(&self.pool, "ALTER TABLE clips ADD COLUMN ocr_status TEXT").await?;
+        add_column_if_missing(
+            &self.pool,
+            "ALTER TABLE clips ADD COLUMN ocr_attempts INTEGER NOT NULL DEFAULT 0",
+        )
+        .await?;
+        add_column_if_missing(
+            &self.pool,
+            "ALTER TABLE clips ADD COLUMN ocr_next_retry_at DATETIME",
+        )
+        .await?;
+        add_column_if_missing(
+            &self.pool,
+            "ALTER TABLE clips ADD COLUMN ocr_error_kind TEXT",
+        )
+        .await?;
+
+        // Existing images without OCR become durable background work. A process
+        // that exited while a job was running leaves it as `processing`; reset
+        // those jobs so the next launch can recover them.
+        sqlx::query(
+            r#"
+            UPDATE clips
+            SET ocr_status = CASE
+                    WHEN ocr_text IS NOT NULL THEN 'completed'
+                    ELSE 'pending'
+                END,
+                ocr_next_retry_at = NULL,
+                ocr_error_kind = NULL
+            WHERE clip_type = 'image'
+              AND (ocr_status IS NULL OR ocr_status IN ('processing', 'unavailable'))
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+
+        sqlx::query(
+            r#"
+            CREATE INDEX IF NOT EXISTS idx_clips_ocr_queue
+            ON clips(ocr_status, ocr_next_retry_at, created_at)
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
 
         sqlx::query(
             r#"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ mod database;
 mod ditto_import;
 mod models;
 mod ocr;
+mod ocr_queue;
 pub mod paste_engine;
 mod settings_commands;
 mod settings_manager;
@@ -422,7 +423,10 @@ pub fn run_app() {
             commands::get_system_accent_color,
             commands::test_log,
             commands::focus_window,
-            commands::refresh_window
+            commands::refresh_window,
+            ocr_queue::get_ocr_queue_status,
+            ocr_queue::set_ocr_queue_paused,
+            ocr_queue::retry_failed_ocr
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/ocr_queue.rs
+++ b/src-tauri/src/ocr_queue.rs
@@ -1,0 +1,645 @@
+use crate::database::Database;
+use once_cell::sync::Lazy;
+use serde::Serialize;
+use sqlx::{Row, SqlitePool};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tauri::State;
+use tokio::sync::Notify;
+
+const MAX_ATTEMPTS: i64 = 3;
+const IDLE_POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+static STARTED: AtomicBool = AtomicBool::new(false);
+static PAUSED: AtomicBool = AtomicBool::new(false);
+static WORK_AVAILABLE: Lazy<Notify> = Lazy::new(Notify::new);
+
+#[derive(Debug, Serialize)]
+pub struct OcrQueueStatus {
+    pending: i64,
+    processing: i64,
+    completed: i64,
+    failed: i64,
+    unavailable: i64,
+    paused: bool,
+}
+
+#[derive(Debug)]
+struct OcrJob {
+    clip_uuid: String,
+    file_path: Option<String>,
+    full_content: Vec<u8>,
+    attempts: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OcrFailureKind {
+    Unavailable,
+    Timeout,
+    Canceled,
+    Decode,
+    MissingImage,
+    Engine,
+}
+
+impl OcrFailureKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Unavailable => "unavailable",
+            Self::Timeout => "timeout",
+            Self::Canceled => "canceled",
+            Self::Decode => "decode",
+            Self::MissingImage => "missing_image",
+            Self::Engine => "engine",
+        }
+    }
+
+    fn is_retryable(self) -> bool {
+        matches!(self, Self::Timeout | Self::Canceled | Self::Engine)
+    }
+}
+
+pub fn init(db: Arc<Database>) {
+    if STARTED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+
+    tauri::async_runtime::spawn(async move {
+        loop {
+            if let Err(error) = run_worker(db.clone()).await {
+                // A transient database failure must not permanently strand the
+                // queue until the next app restart. Keep one bounded supervisor
+                // alive and restart the worker after a short delay.
+                log::error!("OCR queue stopped unexpectedly; retrying: {error}");
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        }
+    });
+}
+
+pub async fn enqueue(db: &Database, clip_uuid: &str) -> Result<(), String> {
+    sqlx::query(
+        r#"
+        UPDATE clips
+        SET ocr_status = 'pending',
+            ocr_attempts = 0,
+            ocr_next_retry_at = NULL,
+            ocr_error_kind = NULL
+        WHERE uuid = ?
+          AND clip_type = 'image'
+          AND ocr_text IS NULL
+        "#,
+    )
+    .bind(clip_uuid)
+    .execute(&db.pool)
+    .await
+    .map_err(|error| error.to_string())?;
+
+    WORK_AVAILABLE.notify_one();
+    Ok(())
+}
+
+async fn run_worker(db: Arc<Database>) -> Result<(), String> {
+    PAUSED.store(load_paused(&db.pool).await?, Ordering::SeqCst);
+    recover_processing_jobs(&db.pool).await?;
+    loop {
+        if PAUSED.load(Ordering::SeqCst) {
+            tokio::select! {
+                _ = WORK_AVAILABLE.notified() => {},
+                _ = tokio::time::sleep(IDLE_POLL_INTERVAL) => {},
+            }
+            continue;
+        }
+
+        if let Some(job) = claim_next(&db.pool).await? {
+            process_job(&db, job).await?;
+            continue;
+        }
+
+        tokio::select! {
+            _ = WORK_AVAILABLE.notified() => {},
+            _ = tokio::time::sleep(IDLE_POLL_INTERVAL) => {},
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn get_ocr_queue_status(db: State<'_, Arc<Database>>) -> Result<OcrQueueStatus, String> {
+    let rows = sqlx::query(
+        r#"
+        SELECT COALESCE(ocr_status, 'pending') AS status, COUNT(*) AS count
+        FROM clips
+        WHERE clip_type = 'image' AND is_deleted = 0
+        GROUP BY COALESCE(ocr_status, 'pending')
+        "#,
+    )
+    .fetch_all(&db.pool)
+    .await
+    .map_err(|error| error.to_string())?;
+
+    let mut status = OcrQueueStatus {
+        pending: 0,
+        processing: 0,
+        completed: 0,
+        failed: 0,
+        unavailable: 0,
+        paused: PAUSED.load(Ordering::SeqCst),
+    };
+    for row in rows {
+        let name: String = row.try_get("status").map_err(|error| error.to_string())?;
+        let count: i64 = row.try_get("count").map_err(|error| error.to_string())?;
+        match name.as_str() {
+            "pending" | "retry" => status.pending += count,
+            "processing" => status.processing += count,
+            "completed" => status.completed += count,
+            "failed" => status.failed += count,
+            "unavailable" => status.unavailable += count,
+            _ => status.pending += count,
+        }
+    }
+    Ok(status)
+}
+
+#[tauri::command]
+pub async fn set_ocr_queue_paused(
+    paused: bool,
+    db: State<'_, Arc<Database>>,
+) -> Result<(), String> {
+    sqlx::query(
+        r#"
+        INSERT INTO settings (key, value) VALUES ('ocr_queue_paused', ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        "#,
+    )
+    .bind(if paused { "true" } else { "false" })
+    .execute(&db.pool)
+    .await
+    .map_err(|error| error.to_string())?;
+    PAUSED.store(paused, Ordering::SeqCst);
+    WORK_AVAILABLE.notify_one();
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn retry_failed_ocr(db: State<'_, Arc<Database>>) -> Result<u64, String> {
+    let result = sqlx::query(
+        r#"
+        UPDATE clips
+        SET ocr_status = 'pending',
+            ocr_attempts = 0,
+            ocr_next_retry_at = NULL,
+            ocr_error_kind = NULL
+        WHERE clip_type = 'image'
+          AND ocr_text IS NULL
+          AND ocr_status IN ('failed', 'unavailable')
+        "#,
+    )
+    .execute(&db.pool)
+    .await
+    .map_err(|error| error.to_string())?;
+    WORK_AVAILABLE.notify_one();
+    Ok(result.rows_affected())
+}
+
+async fn load_paused(pool: &SqlitePool) -> Result<bool, String> {
+    let value: Option<String> =
+        sqlx::query_scalar("SELECT value FROM settings WHERE key = 'ocr_queue_paused'")
+            .fetch_optional(pool)
+            .await
+            .map_err(|error| error.to_string())?;
+    Ok(value.as_deref() == Some("true"))
+}
+
+async fn recover_processing_jobs(pool: &SqlitePool) -> Result<u64, String> {
+    let result = sqlx::query(
+        r#"
+        UPDATE clips
+        SET ocr_status = 'retry',
+            ocr_next_retry_at = NULL,
+            ocr_error_kind = NULL
+        WHERE clip_type = 'image'
+          AND is_deleted = 0
+          AND ocr_text IS NULL
+          AND ocr_status = 'processing'
+        "#,
+    )
+    .execute(pool)
+    .await
+    .map_err(|error| error.to_string())?;
+
+    Ok(result.rows_affected())
+}
+
+async fn claim_next(pool: &SqlitePool) -> Result<Option<OcrJob>, String> {
+    let mut transaction = pool.begin().await.map_err(|error| error.to_string())?;
+    let row = sqlx::query(
+        r#"
+        SELECT clips.uuid, clip_images.file_path, clip_images.full_content, clips.ocr_attempts
+        FROM clips
+        LEFT JOIN clip_images ON clip_images.clip_uuid = clips.uuid
+        WHERE clips.clip_type = 'image'
+          AND clips.is_deleted = 0
+          AND clips.ocr_text IS NULL
+          AND clips.ocr_status IN ('pending', 'retry')
+          AND (clips.ocr_next_retry_at IS NULL OR clips.ocr_next_retry_at <= CURRENT_TIMESTAMP)
+        ORDER BY clips.created_at ASC, clips.id ASC
+        LIMIT 1
+        "#,
+    )
+    .fetch_optional(&mut *transaction)
+    .await
+    .map_err(|error| error.to_string())?;
+
+    let Some(row) = row else {
+        transaction
+            .commit()
+            .await
+            .map_err(|error| error.to_string())?;
+        return Ok(None);
+    };
+
+    let clip_uuid: String = row.try_get("uuid").map_err(|error| error.to_string())?;
+    let updated = sqlx::query(
+        r#"
+        UPDATE clips
+        SET ocr_status = 'processing',
+            ocr_attempts = ocr_attempts + 1,
+            ocr_next_retry_at = NULL,
+            ocr_error_kind = NULL
+        WHERE uuid = ? AND ocr_status IN ('pending', 'retry')
+        "#,
+    )
+    .bind(&clip_uuid)
+    .execute(&mut *transaction)
+    .await
+    .map_err(|error| error.to_string())?;
+
+    if updated.rows_affected() != 1 {
+        transaction
+            .rollback()
+            .await
+            .map_err(|error| error.to_string())?;
+        return Ok(None);
+    }
+
+    let attempts: i64 = row
+        .try_get::<i64, _>("ocr_attempts")
+        .map_err(|error| error.to_string())?
+        + 1;
+    let job = OcrJob {
+        clip_uuid,
+        file_path: row
+            .try_get("file_path")
+            .map_err(|error| error.to_string())?,
+        full_content: row
+            .try_get::<Option<Vec<u8>>, _>("full_content")
+            .map_err(|error| error.to_string())?
+            .unwrap_or_default(),
+        attempts,
+    };
+
+    transaction
+        .commit()
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(Some(job))
+}
+
+async fn process_job(db: &Database, job: OcrJob) -> Result<(), String> {
+    let crypto = db.crypto.clone();
+    let image_dir = db.image_dir.clone();
+    let file_path = job.file_path.clone();
+    let full_content = job.full_content.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        let image = load_image(&crypto, &image_dir, file_path.as_deref(), &full_content)?;
+        crate::ocr::recognize_png(&image)
+    })
+    .await;
+
+    match result {
+        Ok(Ok(text)) => mark_completed(db, &job.clip_uuid, &text).await?,
+        Ok(Err(error)) => {
+            let kind = classify_failure(&error);
+            mark_failed(db, &job, kind).await?;
+        }
+        Err(error) => {
+            log::warn!("OCR: blocking worker could not be joined: {error}");
+            mark_failed(db, &job, OcrFailureKind::Engine).await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn load_image(
+    crypto: &crate::crypto::CryptoManager,
+    image_dir: &std::path::Path,
+    file_path: Option<&str>,
+    full_content: &[u8],
+) -> Result<Vec<u8>, String> {
+    if let Some(path) = file_path
+        .filter(|path| !path.is_empty())
+        .filter(|path| is_managed_image_path(image_dir, path))
+    {
+        if let Ok(image) = crate::clipboard::read_full_image_file(crypto, path) {
+            return Ok(image);
+        }
+    }
+
+    if full_content.is_empty() {
+        return Err("stored image is missing".to_string());
+    }
+
+    if crypto.is_encrypted(full_content) {
+        crypto
+            .decrypt(full_content)
+            .map_err(|_| "stored image could not be decrypted".to_string())
+    } else {
+        Ok(full_content.to_vec())
+    }
+}
+
+fn is_managed_image_path(image_dir: &std::path::Path, file_path: &str) -> bool {
+    let Ok(managed_dir) = image_dir.canonicalize() else {
+        return false;
+    };
+    let Some(parent) = std::path::Path::new(file_path).parent() else {
+        return false;
+    };
+    parent
+        .canonicalize()
+        .map(|candidate| candidate == managed_dir)
+        .unwrap_or(false)
+}
+
+async fn mark_completed(db: &Database, clip_uuid: &str, text: &str) -> Result<(), String> {
+    let encrypted = if text.trim().is_empty() {
+        None
+    } else {
+        Some(db.crypto.encrypt_text(text.trim())?)
+    };
+
+    sqlx::query(
+        r#"
+        UPDATE clips
+        SET ocr_text = ?,
+            ocr_status = 'completed',
+            ocr_next_retry_at = NULL,
+            ocr_error_kind = NULL
+        WHERE uuid = ?
+        "#,
+    )
+    .bind(encrypted)
+    .bind(clip_uuid)
+    .execute(&db.pool)
+    .await
+    .map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+async fn mark_failed(db: &Database, job: &OcrJob, kind: OcrFailureKind) -> Result<(), String> {
+    if kind == OcrFailureKind::Unavailable {
+        sqlx::query(
+            r#"
+            UPDATE clips
+            SET ocr_status = 'unavailable',
+                ocr_next_retry_at = NULL,
+                ocr_error_kind = ?
+            WHERE clip_type = 'image'
+              AND ocr_text IS NULL
+              AND ocr_status IN ('pending', 'retry', 'processing')
+            "#,
+        )
+        .bind(kind.as_str())
+        .execute(&db.pool)
+        .await
+        .map_err(|error| error.to_string())?;
+        return Ok(());
+    }
+
+    if kind.is_retryable() && job.attempts < MAX_ATTEMPTS {
+        let delay_seconds = retry_delay_seconds(job.attempts);
+        let modifier = format!("+{delay_seconds} seconds");
+        sqlx::query(
+            r#"
+            UPDATE clips
+            SET ocr_status = 'retry',
+                ocr_next_retry_at = datetime('now', ?),
+                ocr_error_kind = ?
+            WHERE uuid = ?
+            "#,
+        )
+        .bind(modifier)
+        .bind(kind.as_str())
+        .bind(&job.clip_uuid)
+        .execute(&db.pool)
+        .await
+        .map_err(|error| error.to_string())?;
+    } else {
+        sqlx::query(
+            r#"
+            UPDATE clips
+            SET ocr_status = 'failed',
+                ocr_next_retry_at = NULL,
+                ocr_error_kind = ?
+            WHERE uuid = ?
+            "#,
+        )
+        .bind(kind.as_str())
+        .bind(&job.clip_uuid)
+        .execute(&db.pool)
+        .await
+        .map_err(|error| error.to_string())?;
+    }
+
+    Ok(())
+}
+
+fn retry_delay_seconds(attempts: i64) -> i64 {
+    30 * 2_i64.pow(attempts.saturating_sub(1).min(4) as u32)
+}
+
+fn classify_failure(error: &str) -> OcrFailureKind {
+    let normalized = error.to_ascii_lowercase();
+    if normalized.contains("no ocr language") || normalized.contains("requires windows") {
+        OcrFailureKind::Unavailable
+    } else if normalized.contains("timed out") {
+        OcrFailureKind::Timeout
+    } else if normalized.contains("canceled") {
+        OcrFailureKind::Canceled
+    } else if normalized.contains("decode") || normalized.contains("decrypted") {
+        OcrFailureKind::Decode
+    } else if normalized.contains("missing") || normalized.contains("unreadable") {
+        OcrFailureKind::MissingImage
+    } else {
+        OcrFailureKind::Engine
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        claim_next, classify_failure, load_paused, mark_completed, recover_processing_jobs,
+        retry_delay_seconds, OcrFailureKind,
+    };
+    use crate::crypto::CryptoManager;
+    use crate::database::Database;
+    use sqlx::sqlite::SqlitePoolOptions;
+    use std::sync::Arc;
+
+    async fn test_database() -> Database {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory database should open");
+        let database = Database {
+            pool,
+            crypto: Arc::new(CryptoManager::ephemeral()),
+            image_dir: std::env::temp_dir().join(format!("cubby-ocr-{}", uuid::Uuid::new_v4())),
+        };
+        database.migrate().await.expect("migration should succeed");
+        database
+    }
+
+    async fn insert_image(database: &Database, uuid: &str, status: Option<&str>) {
+        sqlx::query(
+            r#"
+            INSERT INTO clips (
+                uuid, clip_type, content, text_preview, content_hash,
+                is_deleted, is_thumbnail, ocr_status
+            ) VALUES (?, 'image', x'', '', ?, 0, 0, ?)
+            "#,
+        )
+        .bind(uuid)
+        .bind(format!("hash-{uuid}"))
+        .bind(status)
+        .execute(&database.pool)
+        .await
+        .expect("image should insert");
+        sqlx::query("INSERT INTO clip_images (clip_uuid, full_content) VALUES (?, x'89504E47')")
+            .bind(uuid)
+            .execute(&database.pool)
+            .await
+            .expect("image payload should insert");
+    }
+
+    #[tokio::test]
+    async fn durable_queue_drains_every_pending_image_without_drops() {
+        let database = test_database().await;
+        for index in 0..10 {
+            insert_image(&database, &format!("clip-{index}"), Some("pending")).await;
+        }
+
+        let mut processed = 0;
+        while let Some(job) = claim_next(&database.pool)
+            .await
+            .expect("claim should succeed")
+        {
+            mark_completed(&database, &job.clip_uuid, "")
+                .await
+                .expect("completion should persist");
+            processed += 1;
+        }
+
+        assert_eq!(processed, 10);
+        let remaining: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM clips WHERE ocr_status != 'completed'")
+                .fetch_one(&database.pool)
+                .await
+                .expect("count should load");
+        assert_eq!(remaining, 0);
+    }
+
+    #[tokio::test]
+    async fn migration_backfills_missing_ocr_and_recovers_interrupted_jobs() {
+        let database = test_database().await;
+        insert_image(&database, "untracked", None).await;
+        insert_image(&database, "interrupted", Some("processing")).await;
+
+        database.migrate().await.expect("migration should rerun");
+
+        let statuses: Vec<String> =
+            sqlx::query_scalar("SELECT ocr_status FROM clips ORDER BY uuid")
+                .fetch_all(&database.pool)
+                .await
+                .expect("statuses should load");
+        assert_eq!(statuses, vec!["pending", "pending"]);
+    }
+
+    #[tokio::test]
+    async fn worker_recovery_requeues_claimed_processing_jobs() {
+        let database = test_database().await;
+        insert_image(&database, "claimed", Some("pending")).await;
+
+        claim_next(&database.pool)
+            .await
+            .expect("claim should succeed")
+            .expect("job should be claimed");
+        assert_eq!(recover_processing_jobs(&database.pool).await.unwrap(), 1);
+
+        let status: String =
+            sqlx::query_scalar("SELECT ocr_status FROM clips WHERE uuid = 'claimed'")
+                .fetch_one(&database.pool)
+                .await
+                .expect("status should load");
+        assert_eq!(status, "retry");
+        assert!(claim_next(&database.pool)
+            .await
+            .expect("claim should succeed")
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn queue_claims_oldest_pending_image_first() {
+        let database = test_database().await;
+        insert_image(&database, "newer", Some("pending")).await;
+        insert_image(&database, "older", Some("pending")).await;
+        sqlx::query("UPDATE clips SET created_at = '2025-01-02 00:00:00' WHERE uuid = 'newer'")
+            .execute(&database.pool)
+            .await
+            .expect("newer timestamp should update");
+        sqlx::query("UPDATE clips SET created_at = '2025-01-01 00:00:00' WHERE uuid = 'older'")
+            .execute(&database.pool)
+            .await
+            .expect("older timestamp should update");
+
+        let job = claim_next(&database.pool)
+            .await
+            .expect("claim should succeed")
+            .expect("job should be claimed");
+        assert_eq!(job.clip_uuid, "older");
+    }
+
+    #[test]
+    fn classifies_safe_error_categories_without_persisting_raw_messages() {
+        assert_eq!(
+            classify_failure("Windows OCR is unavailable (no OCR language installed)"),
+            OcrFailureKind::Unavailable
+        );
+        assert_eq!(
+            classify_failure("Windows OCR timed out"),
+            OcrFailureKind::Timeout
+        );
+        assert_eq!(
+            classify_failure("stored image is missing or unreadable"),
+            OcrFailureKind::MissingImage
+        );
+        assert_eq!(retry_delay_seconds(1), 30);
+        assert_eq!(retry_delay_seconds(2), 60);
+        assert_eq!(retry_delay_seconds(3), 120);
+    }
+
+    #[tokio::test]
+    async fn paused_state_is_persisted_in_settings() {
+        let database = test_database().await;
+        sqlx::query("INSERT INTO settings (key, value) VALUES ('ocr_queue_paused', 'true')")
+            .execute(&database.pool)
+            .await
+            .expect("pause setting should insert");
+        assert!(load_paused(&database.pool)
+            .await
+            .expect("pause setting should load"));
+    }
+}


### PR DESCRIPTION
## What changed

- replaces the drop-on-saturation OCR threads with one bounded, durable background queue
- persists pending, processing, retry, completed, unavailable, and failed states in SQLite
- backfills existing image clips without OCR and recovers interrupted jobs after restart
- retries transient OCR failures with finite exponential backoff and restarts the worker after transient database failures
- keeps image loading inside Cubby's managed storage boundary and keeps OCR text encrypted at rest
- adds Settings status, progress, pause/resume, retry, and missing-language-pack guidance
- adds localized UI copy for every currently supported language

## Why

The previous implementation allowed only three in-flight OCR jobs. Any image copied while those slots were occupied remained saved but was silently skipped forever. That made Cubby's main screenshot-search feature unreliable under bursts and provided no recovery path for old or interrupted work.

## Privacy and resource behavior

- OCR remains entirely local through `Windows.Media.Ocr`
- clipboard capture never waits for OCR
- one background worker bounds CPU and memory pressure
- persisted errors use controlled categories rather than clipboard content, paths, or raw engine messages
- pause stops new jobs after the currently running image finishes

## Validation

- 52 Rust library tests, including real Windows OCR, queue saturation, restart recovery, retry classification, and persisted pause state
- helper binary test suites
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- Rust advisory gate (`scripts/audit-rust.ps1`)
- `pnpm install --frozen-lockfile`
- `pnpm run format:check`
- `pnpm run release:check`
- `pnpm build`
- `pnpm audit --prod`
- website validation and analytics worker tests

## Follow-ups retained in SOU-234

This PR completes the durable queue and recovery slice. The fixed screenshot accuracy corpus, explicit resource-budget measurements, and paste-recognized-text action remain tracked before SOU-234 is marked complete.

Linear: SOU-234


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an OCR Index section to Settings for monitoring screenshot indexing progress.
  * Users can pause or resume OCR processing and retry failed items.
  * Added status indicators for indexing, paused, ready, attention needed, and unavailable states.
  * New image clips are automatically queued for OCR processing.

* **Localization**
  * Added OCR queue and pause/resume translations across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->