### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable Cubby Clipboard changes are documented here. PastePaw entries below Cubby's first beta are retained as upstream history and attribution.
 
+## v1.1.0
+
+### Added
+- Copy or paste the text recognized inside a screenshot by right-clicking an image result or pressing Shift+Enter
+- Search now finds words inside your screenshots and shows where they matched
+
+### Changed
+- Recognized screenshot text keeps its line breaks now, instead of running together
+- Your existing screenshots are re-scanned in the background so their recognized text improves too
+- Screenshot text recognition runs as a durable background task that resumes after a restart
+- Faster clipboard search that keeps your unencrypted text out of the database
+
 ## v1.0.2
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cubby-clipboard",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A native-feeling clipboard history replacement for Windows 11",
   "license": "GPL-3.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "cubby"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubby"
-version = "1.0.2"
+version = "1.1.0"
 description = "A native-feeling clipboard history replacement for Windows 11"
 authors = ["SouthForge AI", "PastePaw contributors"]
 license = "GPL-3.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "Cubby Clipboard",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "identifier": "ai.southforge.cubbyclipboard",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump 1.0.2 -> 1.1.0 + changelog. Ships the OCR search/copy-paste work and encrypted-safe in-memory search from #57. Tag triggers the signed pipeline + auto-publish.