### PR TITLE
Add portable mode + signed portable release zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,6 +261,57 @@ jobs:
         run: |
           gh release upload "$env:TAG" "${{ steps.installer.outputs.name }}.sig" --clobber
 
+      - name: Assemble the portable package
+        if: matrix.arch == 'x64'
+        id: portable
+        shell: pwsh
+        run: |
+          $stage = Join-Path (Get-Location) "portable"
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+          Copy-Item "src-tauri/target/${{ matrix.target }}/release/cubby.exe" (Join-Path $stage "Cubby Clipboard.exe")
+          # The marker's presence next to the exe switches Cubby to portable mode.
+          Set-Content -Path (Join-Path $stage "portable.txt") -Value @(
+            "This file makes Cubby run in portable mode. Keep it next to Cubby Clipboard.exe.",
+            "Your clipboard history is stored in the 'data' folder here, not in AppData."
+          )
+          Set-Content -Path (Join-Path $stage "README.txt") -Value @(
+            "Cubby Clipboard - Portable",
+            "",
+            "Run 'Cubby Clipboard.exe'. Everything (history, settings, images) is stored in",
+            "the 'data' folder next to it, and nothing is written to AppData or the registry.",
+            "",
+            "Your history is encrypted with your Windows account, so this portable copy works",
+            "fully on this PC and account. Moved to a different PC or Windows user, it starts",
+            "a fresh history there.",
+            "",
+            "Requires Windows 10/11 (WebView2, which ships with Windows 11)."
+          )
+          "exe=$(Join-Path $stage 'Cubby Clipboard.exe')" >> $env:GITHUB_OUTPUT
+
+      - name: Sign the portable executable
+        if: matrix.arch == 'x64'
+        uses: Azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ vars.ARTIFACT_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.ARTIFACT_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ vars.ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME }}
+          files: ${{ steps.portable.outputs.exe }}
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Zip and upload the portable package
+        if: matrix.arch == 'x64'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.create-release.outputs.tag }}
+          VERSION: ${{ needs.create-release.outputs.version }}
+        run: |
+          $zip = "Cubby-Clipboard-Portable-$($env:VERSION)-x64.zip"
+          Compress-Archive -Path "portable/*" -DestinationPath $zip -Force
+          gh release upload "$env:TAG" $zip --clobber
+
   updater-manifest:
     name: Assemble updater manifest
     needs: [create-release, build-installers]

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -636,14 +636,17 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
                           {t('settings.startupWithWindows')}
                         </span>
                         <p className="text-xs text-muted-foreground">
-                          {t('settings.startupWithWindowsDesc')}
+                          {settings.is_portable
+                            ? t('settings.startupWithWindowsPortable')
+                            : t('settings.startupWithWindowsDesc')}
                         </p>
                       </div>
                       <button
+                        disabled={settings.is_portable}
                         onClick={() =>
                           updateSetting('startup_with_windows', !settings.startup_with_windows)
                         }
-                        className={`h-6 w-11 rounded-full transition-colors ${settings.startup_with_windows ? 'bg-primary' : 'bg-accent'}`}
+                        className={`h-6 w-11 rounded-full transition-colors ${settings.startup_with_windows ? 'bg-primary' : 'bg-accent'} ${settings.is_portable ? 'cursor-not-allowed opacity-40' : ''}`}
                       >
                         <div
                           className={`h-5 w-5 rounded-full bg-white shadow-sm transition-transform ${settings.startup_with_windows ? 'translate-x-5' : 'translate-x-0.5'}`}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -83,6 +83,7 @@
     "floatAboveTaskbarDesc": "Show the window on top of the taskbar",
     "startupWithWindows": "Startup with Windows",
     "startupWithWindowsDesc": "Automatically start when Windows boots",
+    "startupWithWindowsPortable": "Not available in the portable version (it never touches the registry).",
     "roundCorners": "Rounded Corners",
     "roundCornersDesc": "Use rounded corners for the Cubby flyout.",
     "ignoreGhostClips": "Ignore Ghost Clips",

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -32,6 +32,7 @@ export interface Settings {
   max_items: number;
   auto_delete_days: number;
   startup_with_windows: boolean;
+  is_portable?: boolean;
   show_in_taskbar: boolean;
   hotkey: string;
   replace_win_v: boolean;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -619,10 +619,32 @@ pub fn animate_window_hide(
     });
 }
 
+/// Portable data directory, or None for a normal installed run.
+///
+/// Cubby runs in portable mode when a `portable.txt` marker sits next to the
+/// executable (the portable download ships one). In that mode every piece of
+/// state (database, images, `storage.key`, settings) lives in `<exe_dir>/data`,
+/// so nothing is written to AppData or the registry. History stays encrypted
+/// with the machine's Windows account key, so a portable copy is fully portable
+/// on the same PC/account; carried to a different account it starts fresh.
+pub fn portable_data_dir() -> Option<std::path::PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let dir = exe.parent()?;
+    if dir.join("portable.txt").exists() {
+        Some(dir.join("data"))
+    } else {
+        None
+    }
+}
+
 fn get_data_dir() -> std::path::PathBuf {
     #[cfg(debug_assertions)]
     if let Some(path) = std::env::var_os("CUBBY_DATA_DIR") {
         return std::path::PathBuf::from(path);
+    }
+
+    if let Some(portable) = portable_data_dir() {
+        return portable;
     }
 
     let current_dir = std::env::current_dir().unwrap_or(std::path::PathBuf::from("."));

--- a/src-tauri/src/settings_commands.rs
+++ b/src-tauri/src/settings_commands.rs
@@ -9,8 +9,17 @@ pub async fn get_settings(app: AppHandle) -> Result<serde_json::Value, String> {
     let settings = manager.get();
     let mut value = serde_json::to_value(&settings).map_err(|e| e.to_string())?;
 
+    // Portable mode never touches the registry, so autostart is unavailable.
+    let portable = crate::portable_data_dir().is_some();
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("is_portable".to_string(), serde_json::json!(portable));
+        if portable {
+            obj.insert("startup_with_windows".to_string(), serde_json::json!(false));
+        }
+    }
+
     #[cfg(not(feature = "app-store"))]
-    {
+    if !portable {
         use tauri_plugin_autostart::ManagerExt;
         if let Ok(is_enabled) = app.autolaunch().is_enabled() {
             if let Some(obj) = value.as_object_mut() {
@@ -110,8 +119,9 @@ pub async fn save_settings(app: AppHandle, settings: serde_json::Value) -> Resul
         }
     }
 
+    // Portable mode must not write to the registry, so skip autostart entirely.
     #[cfg(not(feature = "app-store"))]
-    {
+    if crate::portable_data_dir().is_none() {
         use tauri_plugin_autostart::ManagerExt;
         // Check if startup changed
         let startup = new_settings.startup_with_windows;

--- a/src-tauri/src/settings_manager.rs
+++ b/src-tauri/src/settings_manager.rs
@@ -13,7 +13,10 @@ pub struct SettingsManager {
 
 impl SettingsManager {
     pub async fn new(app: &AppHandle, db: &Database) -> Self {
-        let path = app.path().app_data_dir().unwrap().join("settings.json");
+        // In portable mode settings live beside the executable with the rest of
+        // the data; otherwise they stay in the per-user AppData directory.
+        let base = crate::portable_data_dir().unwrap_or_else(|| app.path().app_data_dir().unwrap());
+        let path = base.join("settings.json");
         let settings = if path.exists() {
             // Load from file
             match fs::read_to_string(&path) {


### PR DESCRIPTION
Portable Cubby (same-PC MVP). When a portable.txt marker sits next to the exe, all data (DB, images, storage.key, settings) lives in <exe_dir>/data instead of AppData, and autostart's registry write is skipped. get_settings reports is_portable so the UI disables 'Start with Windows'. The release now also builds a signed Cubby-Clipboard-Portable-<version>-x64.zip. Encryption still uses the Windows account key, so it's fully portable on the same PC/account (SOU-270).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a portable x64 release package that runs from its extracted folder.
  * Portable mode stores application data alongside the executable.
  * Portable packages include guidance files explaining storage behavior.
* **Enhancements**
  * Settings now indicate when the app is running in portable mode.
  * “Startup with Windows” is unavailable and disabled in portable mode.
* **Bug Fixes**
  * Prevented portable installations from attempting to configure Windows startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->