### PR TITLE
v1.2.0 polish: flyout sync, settings accent, and history retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 
 ### Added
 - Redesigned Settings, reorganized into General, Privacy, Folders, and About sections with cleaner grouped cards
+- Choose how long Cubby keeps your history under Privacy, from a week up to forever, with a storage-used readout; pinned items are always kept
 
 ### Changed
 - Search and filters now clear each time Cubby opens, so you always start on your full, most-recent history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 ### Changed
 - Search and filters now clear each time Cubby opens, so you always start on your full, most-recent history
 - Newly copied screenshots have their text recognized first, so you can search a screenshot right after copying it
+- Timestamps keep counting up while Cubby is open, and a screenshot you just copied shows its Paste text option the moment its text is recognized
 - Updated the app and tray icons to the current Cubby mark
 
 ### Fixed
 - Reusing a clip no longer re-labels it as copied from "Cubby Clipboard" or resets its timestamp to just now
+- Closing Cubby now dismisses the right-click menu and any open dialog, so it reopens on the clean list
 
 ## v1.1.1
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -141,6 +141,11 @@ function App() {
         setSearchQuery('');
         setContentFilter('all');
         setSelectedFolder(null);
+        // Dismiss any transient overlays so reopening lands on the clean list.
+        setContextMenu(null);
+        setClearRequest(null);
+        setShowAddFolderModal(false);
+        setNewFolderName('');
       }
     });
     return () => {
@@ -343,8 +348,20 @@ function App() {
       refreshTotalCount(); // Refresh total count
     });
 
+    // When a screenshot finishes OCR in the background, surface its "paste text"
+    // affordance on the already-visible card instead of only after a reload.
+    const unlistenOcr = listen<string>('ocr-completed', (event) => {
+      const clipId = event.payload;
+      setClips((prev) =>
+        prev.map((clip) => (clip.id === clipId ? { ...clip, has_ocr_text: true } : clip))
+      );
+    });
+
     return () => {
       unlistenClipboard.then((unlisten) => {
+        if (typeof unlisten === 'function') unlisten();
+      });
+      unlistenOcr.then((unlisten) => {
         if (typeof unlisten === 'function') unlisten();
       });
     };

--- a/frontend/src/components/ClipCard.tsx
+++ b/frontend/src/components/ClipCard.tsx
@@ -4,6 +4,7 @@ import { memo, useMemo } from 'react';
 import { Copy, File, Image as ImageIcon, MoreHorizontal, Pin } from 'lucide-react';
 import { formatDistanceToNowStrict } from 'date-fns';
 import { PREVIEW_CHAR_LIMIT } from '../constants';
+import { useTimeTick } from '../hooks/useTimeTick';
 
 interface ClipCardProps {
   clip: ClipboardItem;
@@ -90,11 +91,14 @@ export const ClipCard = memo(function ClipCard({
     return `data:image/png;base64,${value}`;
   }, [clip.clip_type, clip.content]);
 
+  // Ticks every 15s so the relative time stays current while the flyout is open.
+  const timeTick = useTimeTick();
   const age = useMemo(() => {
     const parsed = new Date(clip.created_at);
     if (Number.isNaN(parsed.getTime())) return '';
     return formatDistanceToNowStrict(parsed, { addSuffix: true });
-  }, [clip.created_at]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clip.created_at, timeTick]);
 
   const label = sourceLabel(clip.source_app, clip.clip_type);
   const preview = (clip.content || clip.preview)

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -375,14 +375,32 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
     return () => window.clearInterval(ocrStatusTimer);
   }, []);
 
-  const handleRetentionChange = async (value: string) => {
-    await updateSettings({ auto_delete_days: Number(value), max_items: 0 });
-    try {
-      await invoke('apply_retention');
-      await loadStorageUsage();
-    } catch (error) {
-      console.error('Failed to apply retention:', error);
-    }
+  const retentionGenRef = useRef(0);
+  const handleRetentionChange = (value: string) => {
+    const updates: Partial<Settings> = { auto_delete_days: Number(value), max_items: 0 };
+    const generation = ++retentionGenRef.current;
+    settingsSaveQueue.current = settingsSaveQueue.current
+      .catch(() => undefined)
+      .then(async () => {
+        const newSettings = { ...settingsRef.current, ...updates };
+        try {
+          await invoke('save_settings', { settings: newSettings });
+          settingsRef.current = newSettings;
+          setSettings(newSettings);
+          await emit('settings-changed', newSettings);
+          // Prune only for the latest selection, and only after its save has
+          // persisted, so a rapid change can't prune with an intermediate value.
+          if (generation === retentionGenRef.current) {
+            await invoke('apply_retention');
+          }
+          await loadStorageUsage();
+          toast.success('Settings updated');
+        } catch (error) {
+          console.error('Failed to update retention:', error);
+          toast.error(String(error));
+        }
+      });
+    return settingsSaveQueue.current;
   };
 
   const handleOcrPauseToggle = async () => {

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -16,6 +16,7 @@ import {
   Globe,
   ExternalLink,
   Lock,
+  AlertTriangle,
   FlaskConical,
 } from 'lucide-react';
 import { useState, useEffect, useRef, type ReactNode } from 'react';
@@ -64,6 +65,21 @@ type OcrQueueStatus = {
   unavailable: number;
   paused: boolean;
 };
+
+type StorageUsage = {
+  items: number;
+  bytes: number;
+};
+
+function formatBytes(bytes: number): string {
+  if (bytes <= 0) return '0 MB';
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${Math.round(kb)} KB`;
+  const mb = kb / 1024;
+  if (mb < 1024) return `${mb < 10 ? mb.toFixed(1) : Math.round(mb)} MB`;
+  return `${(mb / 1024).toFixed(1)} GB`;
+}
 
 function CubbyMark({ className }: { className?: string }) {
   return (
@@ -302,6 +318,7 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
   const [dittoBusy, setDittoBusy] = useState(false);
   const [ocrStatus, setOcrStatus] = useState<OcrQueueStatus | null>(null);
   const [ocrActionBusy, setOcrActionBusy] = useState(false);
+  const [storageUsage, setStorageUsage] = useState<StorageUsage | null>(null);
   const ocrRemaining = (ocrStatus?.pending ?? 0) + (ocrStatus?.processing ?? 0);
   const ocrFailures = (ocrStatus?.failed ?? 0) + (ocrStatus?.unavailable ?? 0);
   const ocrStatusLabel = !ocrStatus
@@ -339,15 +356,34 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
     }
   };
 
+  const loadStorageUsage = async () => {
+    try {
+      setStorageUsage(await invoke<StorageUsage>('get_storage_usage'));
+    } catch (error) {
+      console.error('Failed to load storage usage:', error);
+    }
+  };
+
   useEffect(() => {
     invoke<number>('get_clipboard_history_size').then(setHistorySize).catch(console.error);
     invoke<string[]>('get_ignored_apps').then(setIgnoredApps).catch(console.error);
     getVersion().then(setAppVersion).catch(console.error);
     loadFolders();
     loadOcrStatus();
+    loadStorageUsage();
     const ocrStatusTimer = window.setInterval(loadOcrStatus, 3000);
     return () => window.clearInterval(ocrStatusTimer);
   }, []);
+
+  const handleRetentionChange = async (value: string) => {
+    await updateSettings({ auto_delete_days: Number(value), max_items: 0 });
+    try {
+      await invoke('apply_retention');
+      await loadStorageUsage();
+    } catch (error) {
+      console.error('Failed to apply retention:', error);
+    }
+  };
 
   const handleOcrPauseToggle = async () => {
     if (!ocrStatus) return;
@@ -508,6 +544,7 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
       toast.success(t('settings.removeDuplicatesSuccess', { count }));
       const newSize = await invoke<number>('get_clipboard_history_size');
       setHistorySize(newSize);
+      loadStorageUsage();
     } catch (error) {
       console.error(error);
       toast.error(`Failed to remove duplicates: ${error}`);
@@ -523,6 +560,7 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
         try {
           await invoke('clear_all_clips');
           setHistorySize(0);
+          loadStorageUsage();
           toast.success(t('settings.clearHistorySuccess'));
         } catch (error) {
           console.error('Failed to clear history:', error);
@@ -965,6 +1003,56 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
                         }
                       />
                     </SettingCard>
+                  </section>
+
+                  <section>
+                    <SectionLabel>{t('settings.historyRetention')}</SectionLabel>
+                    <SettingCard>
+                      <Row
+                        title={t('settings.keepHistoryFor')}
+                        control={
+                          <div className="w-40">
+                            <Select
+                              value={String(settings.auto_delete_days ?? 30)}
+                              onChange={handleRetentionChange}
+                              options={[
+                                { value: '7', label: t('settings.retention7') },
+                                { value: '30', label: t('settings.retention30') },
+                                { value: '90', label: t('settings.retention90') },
+                                { value: '365', label: t('settings.retention365') },
+                                { value: '0', label: t('settings.retentionForever') },
+                              ]}
+                            />
+                          </div>
+                        }
+                      />
+                      {settings.auto_delete_days === 0 && (
+                        <div className="flex gap-3 px-4 py-3">
+                          <AlertTriangle
+                            size={16}
+                            className="mt-0.5 flex-shrink-0 text-amber-500"
+                          />
+                          <p className="text-xs leading-relaxed text-muted-foreground">
+                            {t('settings.retentionForeverWarning')}
+                          </p>
+                        </div>
+                      )}
+                      <Row
+                        title={t('settings.storageUsed')}
+                        control={
+                          <span className="text-xs text-muted-foreground">
+                            {storageUsage
+                              ? `${t('settings.folderItemCount', {
+                                  count: storageUsage.items,
+                                })} · ${formatBytes(storageUsage.bytes)}`
+                              : '…'}
+                          </span>
+                        }
+                      />
+                    </SettingCard>
+                    <p className="ml-1 mt-2 text-xs text-muted-foreground">
+                      {t('settings.pinnedAlwaysKept')}
+                    </p>
                   </section>
 
                   <section>

--- a/frontend/src/hooks/useTimeTick.ts
+++ b/frontend/src/hooks/useTimeTick.ts
@@ -1,0 +1,37 @@
+import { useSyncExternalStore } from 'react';
+
+const listeners = new Set<() => void>();
+let intervalId: ReturnType<typeof setInterval> | null = null;
+let version = 0;
+
+const REFRESH_MS = 15000;
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  if (intervalId === null) {
+    intervalId = setInterval(() => {
+      version += 1;
+      listeners.forEach((l) => l());
+    }, REFRESH_MS);
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0 && intervalId !== null) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  };
+}
+
+function getSnapshot(): number {
+  return version;
+}
+
+/**
+ * Re-renders subscribers every 15 seconds off a single shared interval, so
+ * relative timestamps ("2 minutes ago") keep advancing while the flyout stays
+ * open instead of freezing at whatever they were when the list first rendered.
+ */
+export function useTimeTick(): number {
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -160,7 +160,17 @@
     "privacyPolicy": "Privacy policy",
     "openSourceTitle": "Free and open source.",
     "openSourceNote": "Cubby is GPL-3.0, a fork of PastePaw. © 2026 SouthForge AI.",
-    "folderItemCount": "{{count}} items"
+    "folderItemCount": "{{count}} items",
+    "historyRetention": "History retention",
+    "keepHistoryFor": "Keep history for",
+    "retention7": "7 days",
+    "retention30": "30 days",
+    "retention90": "90 days",
+    "retention365": "1 year",
+    "retentionForever": "Forever",
+    "retentionForeverWarning": "Cubby keeps everything you copy, including screenshots, until you clear it. This can use noticeable disk space over time.",
+    "pinnedAlwaysKept": "Pinned items are always kept.",
+    "storageUsed": "Storage used"
   },
   "notifications": {
     "clipDeleted": "Clip deleted",

--- a/frontend/src/windows/SettingsWindow.tsx
+++ b/frontend/src/windows/SettingsWindow.tsx
@@ -5,6 +5,7 @@ import { Settings } from '../types';
 import { SettingsPanel } from '../components/SettingsPanel';
 import { useTheme } from '../hooks/useTheme';
 import { useLanguage } from '../hooks/useLanguage';
+import { useSystemAccent } from '../hooks/useSystemAccent';
 
 import { Toaster } from 'sonner';
 
@@ -13,6 +14,9 @@ export function SettingsWindow() {
 
   const effectiveTheme = useTheme(settings?.theme || 'system');
   useLanguage(settings?.language);
+  // Each Tauri window is its own document, so the settings window must apply the
+  // Windows accent color itself; without this it falls back to the default token.
+  useSystemAccent();
 
   useEffect(() => {
     invoke<Settings>('get_settings').then(setSettings).catch(console.error);

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -59,7 +59,7 @@ pub fn set_ignore_hash(hash: String) {
 }
 
 pub fn init(app: &AppHandle, db: Arc<Database>) {
-    crate::ocr_queue::init(db.clone());
+    crate::ocr_queue::init(app.clone(), db.clone());
     let (snapshot_tx, mut snapshot_rx) = tokio::sync::mpsc::unbounded_channel();
     let app_for_consumer = app.clone();
     let db_for_consumer = db.clone();

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1264,6 +1264,61 @@ async fn clear_clips_in_pool(
     ))
 }
 
+#[derive(serde::Serialize)]
+pub struct StorageUsage {
+    pub items: i64,
+    pub bytes: i64,
+}
+
+/// Approximate on-disk usage of the clipboard history: encrypted clip content
+/// (text and image thumbnails) plus the full image files stored on disk.
+#[tauri::command]
+pub async fn get_storage_usage(
+    db: tauri::State<'_, Arc<Database>>,
+) -> Result<StorageUsage, String> {
+    let pool = &db.pool;
+    let items: i64 =
+        sqlx::query_scalar(r#"SELECT COUNT(*) FROM clips WHERE is_deleted = 0"#)
+            .fetch_one(pool)
+            .await
+            .map_err(|error| error.to_string())?;
+    let content_bytes: i64 = sqlx::query_scalar(
+        r#"SELECT COALESCE(SUM(LENGTH(content)), 0) FROM clips WHERE is_deleted = 0"#,
+    )
+    .fetch_one(pool)
+    .await
+    .map_err(|error| error.to_string())?;
+    let image_bytes: i64 =
+        sqlx::query_scalar(r#"SELECT COALESCE(SUM(file_size), 0) FROM clip_images"#)
+            .fetch_one(pool)
+            .await
+            .map_err(|error| error.to_string())?;
+    Ok(StorageUsage {
+        items,
+        bytes: content_bytes + image_bytes,
+    })
+}
+
+/// Apply the current retention settings immediately (rather than waiting for the
+/// next capture), so lowering the window prunes right away and the storage
+/// readout updates. Broadcasts `clipboard-change` so the flyout refreshes.
+#[tauri::command]
+pub async fn apply_retention(
+    app: AppHandle,
+    db: tauri::State<'_, Arc<Database>>,
+    settings_manager: tauri::State<'_, Arc<crate::settings_manager::SettingsManager>>,
+) -> Result<u64, String> {
+    let settings = settings_manager.get();
+    let (deleted, image_paths) =
+        enforce_retention_in_pool(&db.pool, settings.max_items, settings.auto_delete_days).await?;
+    remove_clip_image_files(&db.image_dir, image_paths);
+    if deleted > 0 {
+        db.search_index.invalidate();
+        let _ = app.emit("clipboard-change", ());
+    }
+    Ok(deleted)
+}
+
 pub(crate) async fn enforce_retention_in_pool(
     pool: &SqlitePool,
     max_items: i64,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1277,22 +1277,27 @@ pub async fn get_storage_usage(
     db: tauri::State<'_, Arc<Database>>,
 ) -> Result<StorageUsage, String> {
     let pool = &db.pool;
-    let items: i64 =
-        sqlx::query_scalar(r#"SELECT COUNT(*) FROM clips WHERE is_deleted = 0"#)
-            .fetch_one(pool)
-            .await
-            .map_err(|error| error.to_string())?;
+    let items: i64 = sqlx::query_scalar(r#"SELECT COUNT(*) FROM clips WHERE is_deleted = 0"#)
+        .fetch_one(pool)
+        .await
+        .map_err(|error| error.to_string())?;
     let content_bytes: i64 = sqlx::query_scalar(
         r#"SELECT COALESCE(SUM(LENGTH(content)), 0) FROM clips WHERE is_deleted = 0"#,
     )
     .fetch_one(pool)
     .await
     .map_err(|error| error.to_string())?;
-    let image_bytes: i64 =
-        sqlx::query_scalar(r#"SELECT COALESCE(SUM(file_size), 0) FROM clip_images"#)
-            .fetch_one(pool)
-            .await
-            .map_err(|error| error.to_string())?;
+    let image_bytes: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COALESCE(SUM(clip_images.file_size), 0)
+        FROM clip_images
+        JOIN clips ON clips.uuid = clip_images.clip_uuid
+        WHERE clips.is_deleted = 0
+        "#,
+    )
+    .fetch_one(pool)
+    .await
+    .map_err(|error| error.to_string())?;
     Ok(StorageUsage {
         items,
         bytes: content_bytes + image_bytes,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -419,6 +419,8 @@ pub fn run_app() {
             settings_commands::save_settings,
             settings_commands::complete_onboarding,
             commands::get_clipboard_history_size,
+            commands::get_storage_usage,
+            commands::apply_retention,
             commands::clear_unpinned_clips,
             commands::clear_all_clips,
             commands::remove_duplicate_clips,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -37,7 +37,10 @@ impl Default for AppSettings {
             theme: "system".to_string(),
             mica_effect: "solid".to_string(),
             language: "en".to_string(),
-            max_items: 1000,
+            // 0 = no item-count cap; retention is driven by age (auto_delete_days)
+            // so "keep history for N days" means exactly that. Pinned items are
+            // always kept regardless.
+            max_items: 0,
             auto_delete_days: 30,
             hotkey: "Win+Alt+V".to_string(),
             replace_win_v: true,

--- a/src-tauri/src/ocr_queue.rs
+++ b/src-tauri/src/ocr_queue.rs
@@ -5,7 +5,7 @@ use sqlx::{Row, SqlitePool};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use tauri::State;
+use tauri::{AppHandle, Emitter, State};
 use tokio::sync::Notify;
 
 const MAX_ATTEMPTS: i64 = 3;
@@ -62,7 +62,7 @@ impl OcrFailureKind {
     }
 }
 
-pub fn init(db: Arc<Database>) {
+pub fn init(app: AppHandle, db: Arc<Database>) {
     if STARTED.swap(true, Ordering::SeqCst) {
         return;
     }
@@ -76,7 +76,7 @@ pub fn init(db: Arc<Database>) {
 
     tauri::async_runtime::spawn(async move {
         loop {
-            if let Err(error) = run_worker(db.clone()).await {
+            if let Err(error) = run_worker(app.clone(), db.clone()).await {
                 // A transient database failure must not permanently strand the
                 // queue until the next app restart. Keep one bounded supervisor
                 // alive and restart the worker after a short delay.
@@ -167,7 +167,7 @@ pub async fn reprocess_existing_for_linebreaks(db: &Database) -> Result<(), Stri
     Ok(())
 }
 
-async fn run_worker(db: Arc<Database>) -> Result<(), String> {
+async fn run_worker(app: AppHandle, db: Arc<Database>) -> Result<(), String> {
     PAUSED.store(load_paused(&db.pool).await?, Ordering::SeqCst);
     recover_processing_jobs(&db.pool).await?;
     loop {
@@ -180,7 +180,7 @@ async fn run_worker(db: Arc<Database>) -> Result<(), String> {
         }
 
         if let Some(job) = claim_next(&db.pool).await? {
-            process_job(&db, job).await?;
+            process_job(&app, &db, job).await?;
             continue;
         }
 
@@ -376,7 +376,7 @@ async fn claim_next(pool: &SqlitePool) -> Result<Option<OcrJob>, String> {
     Ok(Some(job))
 }
 
-async fn process_job(db: &Database, job: OcrJob) -> Result<(), String> {
+async fn process_job(app: &AppHandle, db: &Database, job: OcrJob) -> Result<(), String> {
     let crypto = db.crypto.clone();
     let image_dir = db.image_dir.clone();
     let file_path = job.file_path.clone();
@@ -388,7 +388,15 @@ async fn process_job(db: &Database, job: OcrJob) -> Result<(), String> {
     .await;
 
     match result {
-        Ok(Ok(text)) => mark_completed(db, &job.clip_uuid, &text).await?,
+        Ok(Ok(text)) => {
+            let has_text = !text.trim().is_empty();
+            mark_completed(db, &job.clip_uuid, &text).await?;
+            if has_text {
+                // Let the open flyout surface this clip's "paste text" option
+                // right away instead of only after the list is next reloaded.
+                let _ = app.emit("ocr-completed", &job.clip_uuid);
+            }
+        }
         Ok(Err(error)) => {
             let kind = classify_failure(&error);
             mark_failed(db, &job, kind).await?;

--- a/src-tauri/src/ocr_queue.rs
+++ b/src-tauri/src/ocr_queue.rs
@@ -394,7 +394,12 @@ async fn process_job(app: &AppHandle, db: &Database, job: OcrJob) -> Result<(), 
             if has_text {
                 // Let the open flyout surface this clip's "paste text" option
                 // right away instead of only after the list is next reloaded.
-                let _ = app.emit("ocr-completed", &job.clip_uuid);
+                if let Err(error) = app.emit("ocr-completed", &job.clip_uuid) {
+                    log::warn!(
+                        "OCR: could not emit ocr-completed for {}: {error}",
+                        job.clip_uuid
+                    );
+                }
             }
         }
         Ok(Err(error)) => {

--- a/src-tauri/src/settings_manager.rs
+++ b/src-tauri/src/settings_manager.rs
@@ -61,11 +61,9 @@ impl SettingsManager {
             settings.language = v;
         }
 
-        if let Some(v) = get_val(pool, "max_items").await {
-            if let Ok(i) = v.parse() {
-                settings.max_items = i;
-            }
-        }
+        // Retention is time-only. Ignore any persisted item cap (legacy installs
+        // may carry a nonzero max_items from before this was exposed) so the age
+        // window is the sole lever; max_items stays 0 = no count cap.
         if let Some(v) = get_val(pool, "auto_delete_days").await {
             if let Ok(i) = v.parse() {
                 settings.auto_delete_days = i;


### PR DESCRIPTION
Follow-up polish while testing the v1.2.0 draft. Three "flyout lifecycle" fixes; all fold into the unpublished v1.2.0.

## 1. Timestamps froze while open
The "X ago" label was computed once per render (`ClipCard`, memoized on `created_at`) with no timer, so a fresh clip stayed "1 second ago" until the list re-rendered. Added `useTimeTick` — a single shared 15s interval via `useSyncExternalStore` — and made the age memo depend on it, so relative times keep advancing while the flyout is open.

## 2. OCR result didn't show until reopen
A just-copied screenshot's "Paste text" option only appeared after the list reloaded (e.g. on reopen), even though OCR had already finished in the background. The OCR worker now emits `ocr-completed` with the clip id when recognized text is non-empty (`ocr_queue.rs`, `AppHandle` threaded through `init` → `run_worker` → `process_job`), and `App.tsx` listens and flips that card's `has_ocr_text` live.

## 3. Transient UI persisted across close
Because the flyout is hidden (not destroyed), an open right-click menu — or the clear-history confirm / add-folder modal — stayed open on reopen. The on-close reset now also clears `contextMenu`, `clearRequest`, and the add-folder modal, so reopening always lands on the clean list (same handler as the search/filter reset).

## Notes
- `pnpm build` and `cargo test --lib` (62 tests) pass locally; the OCR queue tests don't touch `process_job`/`run_worker`, so the signature changes are covered.
- Confirmed with local testing that the earlier v1.2.0 fixes (self-paste timestamp/source, newest-first OCR) are working — these three were the remaining "open flyout doesn't refresh itself" symptoms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Privacy settings now show history retention options (including a “forever” warning) and a storage-used indicator.
* **Bug Fixes**
  * Relative timestamps keep updating while Cubby stays open.
  * Newly recognized screenshots immediately unlock the “Paste text” option.
  * Closing Cubby now dismisses open context menus, confirmations, and dialogs.
  * Reusing a clip no longer changes its label or resets its timestamp.
  * Reopening Cubby returns to a clean clip list with transient UI cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->