### PR TITLE
Tighten v1.2.0 changelog for the public release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,18 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 ## v1.2.0
 
 ### Added
-- Redesigned Settings, reorganized into General, Privacy, Folders, and About sections with cleaner grouped cards
-- Choose how long Cubby keeps your history under Privacy, from a week up to forever, with a storage-used readout; pinned items are always kept
+- Redesigned Settings, organized into General, Privacy, Folders, and About with cleaner grouped sections
+- History retention: choose how long Cubby keeps your history, from a week up to forever, with a storage-used readout. Pinned items are always kept
 
 ### Changed
-- Search and filters now clear each time Cubby opens, so you always start on your full, most-recent history
-- Newly copied screenshots have their text recognized first, so you can search a screenshot right after copying it
-- Timestamps keep counting up while Cubby is open, and a screenshot you just copied shows its Paste text option the moment its text is recognized
-- Updated the app and tray icons to the current Cubby mark
+- Search and filters reset each time Cubby opens, so you always start on your full, most-recent history
+- A screenshot you just copied is read first and updates live, so it becomes searchable and offers Paste text moments after you copy it
+- Timestamps keep counting up while Cubby is open
+- New app and tray icons
 
 ### Fixed
-- Reusing a clip no longer re-labels it as copied from "Cubby Clipboard" or resets its timestamp to just now
-- Closing Cubby now dismisses the right-click menu and any open dialog, so it reopens on the clean list
+- Reusing a clip no longer relabels its source as "Cubby Clipboard" or resets its timestamp
+- Closing Cubby dismisses the right-click menu and any open dialog, so it reopens on a clean list
 
 ## v1.1.1
 


### PR DESCRIPTION
Docs-only: crisper v1.2.0 release notes ahead of publishing. No code changes.