### PR TITLE
Scroll the flyout list to the top on reopen

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -141,6 +141,10 @@ function App() {
         setSearchQuery('');
         setContentFilter('all');
         setSelectedFolder(null);
+        // Reset selection and scroll the list back to the top, so reopening
+        // always shows your most-recent copy instead of wherever you'd scrolled.
+        setSelectedClipId(null);
+        setClipListResetToken((prev) => prev + 1);
         // Dismiss any transient overlays so reopening lands on the clean list.
         setContextMenu(null);
         setClearRequest(null);


### PR DESCRIPTION
Reported after v1.2.0: Cubby sometimes opens scrolled down, so you have to scroll up to see your most recent copy.

**Cause:** the flyout is hidden, not destroyed, so the list's scroll position (a DOM property) persisted across close/reopen. `ClipList` only scrolls to top when `resetToken` changes or the selection changes, and neither happened on reopen.

**Fix:** in the on-close reset (same handler as the search/filter reset), also clear the selection and bump `clipListResetToken`, so `ClipList` scrolls back to the top while hidden and the next open always shows the most-recent item. This uses the exact reset pattern already used when switching folders.

`pnpm build` + prettier pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reset clip selection and return the clip list to the top when the app window loses focus.
  * Clear temporary search and filter state when the flyout is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->