### PR TITLE
Bump version to 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable Cubby Clipboard changes are documented here. PastePaw entries below Cubby's first beta are retained as upstream history and attribution.
 
+## v1.2.1
+
+### Fixed
+- Cubby now opens at the top of your history, showing your most recent copy, instead of wherever you had last scrolled
+
+### Changed
+- Lower peak memory use when recognizing text in very large screenshots
+
 ## v1.2.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cubby-clipboard",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A native-feeling clipboard history replacement for Windows 11",
   "license": "GPL-3.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "cubby"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubby"
-version = "1.2.0"
+version = "1.2.1"
 description = "A native-feeling clipboard history replacement for Windows 11"
 authors = ["SouthForge AI", "PastePaw contributors"]
 license = "GPL-3.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "Cubby Clipboard",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "identifier": "ai.southforge.cubbyclipboard",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Patch release: scroll-to-top on reopen (#66) and the OCR decode memory bound (#67, SOU-269), both already merged to main. Docs/version-only.