### PR TITLE
Add Discord community badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   [![CI](https://github.com/tsouth89/cubby-clipboard/actions/workflows/ci.yml/badge.svg)](https://github.com/tsouth89/cubby-clipboard/actions/workflows/ci.yml)
   [![Windows 11](https://img.shields.io/badge/Windows-11-0078D4?logo=windows11&logoColor=white)](https://cubbyclipboard.com/start.html)
   [![GPL-3.0](https://img.shields.io/github/license/tsouth89/cubby-clipboard)](LICENSE)
+  [![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/Xsn27MxdBA)
 
   [Download](https://github.com/tsouth89/cubby-clipboard/releases/latest) · [Getting started](https://cubbyclipboard.com/start.html) · [Website](https://cubbyclipboard.com) · [Report an issue](https://github.com/tsouth89/cubby-clipboard/issues)
 </div>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   [![CI](https://github.com/tsouth89/cubby-clipboard/actions/workflows/ci.yml/badge.svg)](https://github.com/tsouth89/cubby-clipboard/actions/workflows/ci.yml)
   [![Windows 11](https://img.shields.io/badge/Windows-11-0078D4?logo=windows11&logoColor=white)](https://cubbyclipboard.com/start.html)
   [![GPL-3.0](https://img.shields.io/github/license/tsouth89/cubby-clipboard)](LICENSE)
-  [![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/TRb4HSsVzY)
+  [![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/Xsn27MxdBA)
 
   [Download](https://github.com/tsouth89/cubby-clipboard/releases/latest) · [Getting started](https://cubbyclipboard.com/start.html) · [Website](https://cubbyclipboard.com) · [Report an issue](https://github.com/tsouth89/cubby-clipboard/issues)
 </div>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   [![CI](https://github.com/tsouth89/cubby-clipboard/actions/workflows/ci.yml/badge.svg)](https://github.com/tsouth89/cubby-clipboard/actions/workflows/ci.yml)
   [![Windows 11](https://img.shields.io/badge/Windows-11-0078D4?logo=windows11&logoColor=white)](https://cubbyclipboard.com/start.html)
   [![GPL-3.0](https://img.shields.io/github/license/tsouth89/cubby-clipboard)](LICENSE)
-  [![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/Xsn27MxdBA)
+  [![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/TRb4HSsVzY)
 
   [Download](https://github.com/tsouth89/cubby-clipboard/releases/latest) · [Getting started](https://cubbyclipboard.com/start.html) · [Website](https://cubbyclipboard.com) · [Report an issue](https://github.com/tsouth89/cubby-clipboard/issues)
 </div>


### PR DESCRIPTION
Adds a Discord badge to the README badge row, matching the pattern used on the toolport repo. Links to the community invite (`discord.gg/Xsn27MxdBA`) — swap the URL if Cubby should point at a separate server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Discord community badge to the README, providing a direct link to the project’s Discord invite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->