### PR TITLE
Document the worktree convention and squash-merge caveat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,3 +176,26 @@ Always be truthful and face problems directly. Never fabricate, obscure, or work
 
 ### Changelog
 CHANGELOG.md includes both English and Chinese entries for every version. Always add both when writing a new version section.
+
+### Worktrees
+Create task worktrees under `../.worktrees/<task-name>`, never beside the repo in the projects root. Sibling worktrees (`cubby-clipboard-<task>`) bury the real projects in a long directory listing.
+
+```bash
+git worktree add ../.worktrees/sou-123-fix -b codex/sou-123-fix
+```
+
+When the work has landed, remove the worktree and prune, then delete the directory:
+
+```bash
+git worktree remove ../.worktrees/sou-123-fix
+git worktree prune
+rm -rf ../.worktrees/sou-123-fix   # Windows leaves an empty tree behind
+```
+
+On Windows `git worktree remove` deletes the files but leaves the empty directory tree in place, so the explicit `rm -rf` is required. Skipping it is what accumulates empty skeleton directories.
+
+This repo squash-merges every PR, so a branch's commits never become ancestors of `main`. Do not use `git merge-base --is-ancestor` or `git log main..branch` to decide whether work has landed — both report merged work as unmerged. Check the branch's merged PR instead:
+
+```bash
+gh pr list --state merged --limit 40 --json number,headRefName,title
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,16 +186,20 @@ git worktree add ../.worktrees/sou-123-fix -b codex/sou-123-fix
 
 When the work has landed, remove the worktree and prune, then delete the directory:
 
-```bash
+```powershell
 git worktree remove ../.worktrees/sou-123-fix
 git worktree prune
-rm -rf ../.worktrees/sou-123-fix   # Windows leaves an empty tree behind
+Remove-Item -Recurse -Force ../.worktrees/sou-123-fix
 ```
 
-On Windows `git worktree remove` deletes the files but leaves the empty directory tree in place, so the explicit `rm -rf` is required. Skipping it is what accumulates empty skeleton directories.
+The last line is PowerShell, the default shell here. In Git Bash or WSL use `rm -rf ../.worktrees/sou-123-fix` instead.
+
+On Windows `git worktree remove` deletes the files but leaves the empty directory tree in place, so that explicit delete is required. Skipping it is what accumulates empty skeleton directories.
 
 This repo squash-merges every PR, so a branch's commits never become ancestors of `main`. Do not use `git merge-base --is-ancestor` or `git log main..branch` to decide whether work has landed — both report merged work as unmerged. Check the branch's merged PR instead:
 
 ```bash
-gh pr list --state merged --limit 40 --json number,headRefName,title
+gh pr list --state merged --head <branch> --json number,headRefName,title
 ```
+
+Filter by `--head`. Listing merged PRs and scanning the results can page past the one you care about and report a merged branch as unmerged, which is the mistake this note exists to prevent.


### PR DESCRIPTION
Task worktrees were being created beside the repo (`cubby-clipboard-<task>`), which buried real projects in the projects root. On Windows `git worktree remove` deletes the files but leaves an empty directory tree, so skeleton directories accumulated (14 cleaned up).

Documents:
- Create worktrees under `../.worktrees/<task>`, not beside the repo
- Follow `git worktree remove` + `prune` with an explicit `rm -rf` on Windows
- This repo squash-merges, so a branch's commits never become ancestors of `main`. Ancestry checks report already-merged work as unmerged; use the merged PR list instead.

Docs only, no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating, managing, and cleaning up task worktrees.
  * Documented Windows-specific cleanup steps.
  * Clarified how to verify whether work has been integrated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->