### PR TITLE
Landing: Star on GitHub CTA with threshold-gated star counter

### DIFF
--- a/product_pages/index.html
+++ b/product_pages/index.html
@@ -42,9 +42,9 @@
         <p class="hero-lede">Cubby is the clipboard history Windows should have shipped: fast to open, easy to search, and dependable enough for the work you do all day.</p>
         <div class="cta-row">
           <a class="button button-primary" data-latest-installer href="https://github.com/tsouth89/cubby-clipboard/releases/latest">Download for Windows <span aria-hidden="true">↓</span></a>
-          <a class="button button-secondary" href="https://github.com/tsouth89/cubby-clipboard">View on GitHub <span aria-hidden="true">↗</span></a>
+          <a class="button button-secondary" href="https://github.com/tsouth89/cubby-clipboard"><span aria-hidden="true">★</span> Star on GitHub<span class="star-count" data-star-count hidden></span></a>
         </div>
-        <p class="release-note"><span data-release-version>Latest beta · v0.1.0-beta.1</span> · Windows 11 · Free and open source</p>
+        <p class="release-note"><span data-release-version>Latest release</span> · Windows 11 · Free and open source</p>
         <p class="release-note">New to this? <a href="start.html">Follow the simple setup guide →</a></p>
       </div>
 

--- a/product_pages/release-links.js
+++ b/product_pages/release-links.js
@@ -71,28 +71,80 @@
     return null;
   };
 
-  const cachedRelease = readCache();
-  if (cachedRelease) {
-    applyRelease(cachedRelease);
-    return;
-  }
+  const resolveRelease = () => {
+    const cachedRelease = readCache();
+    if (cachedRelease) {
+      applyRelease(cachedRelease);
+      return;
+    }
 
-  fetch(releasesApi, { headers: { Accept: "application/vnd.github+json" } })
-    .then((response) => {
-      if (!response.ok) throw new Error(`GitHub returned ${response.status}`);
-      return response.json();
-    })
-    .then(selectLatestRelease)
-    .then((release) => {
-      if (!release) return;
-      applyRelease(release);
-      try {
-        localStorage.setItem(cacheKey, JSON.stringify({ savedAt: Date.now(), release }));
-      } catch {
-        // The resolved link still works when storage is unavailable.
-      }
-    })
-    .catch(() => {
-      // Keep the releases-page fallback if GitHub is unavailable or rate-limited.
+    fetch(releasesApi, { headers: { Accept: "application/vnd.github+json" } })
+      .then((response) => {
+        if (!response.ok) throw new Error(`GitHub returned ${response.status}`);
+        return response.json();
+      })
+      .then(selectLatestRelease)
+      .then((release) => {
+        if (!release) return;
+        applyRelease(release);
+        try {
+          localStorage.setItem(cacheKey, JSON.stringify({ savedAt: Date.now(), release }));
+        } catch {
+          // The resolved link still works when storage is unavailable.
+        }
+      })
+      .catch(() => {
+        // Keep the releases-page fallback if GitHub is unavailable or rate-limited.
+      });
+  };
+
+  // The star count only renders once it is social proof rather than an
+  // admission of obscurity; below the threshold the button stays a plain CTA.
+  const repoApi = "https://api.github.com/repos/tsouth89/cubby-clipboard";
+  const starCacheKey = "cubby-star-count-v1";
+  const minStarsToShow = 75;
+
+  const applyStars = (count) => {
+    if (!Number.isFinite(count) || count < minStarsToShow) return;
+    const formatted =
+      count >= 1000 ? `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k` : `${count}`;
+    document.querySelectorAll("[data-star-count]").forEach((el) => {
+      el.textContent = formatted;
+      el.hidden = false;
     });
+  };
+
+  const resolveStars = () => {
+    try {
+      const cached = JSON.parse(localStorage.getItem(starCacheKey));
+      if (Date.now() - cached.savedAt < cacheLifetimeMs && Number.isFinite(cached.count)) {
+        applyStars(cached.count);
+        return;
+      }
+    } catch {
+      // Fall through to a fresh fetch.
+    }
+
+    fetch(repoApi, { headers: { Accept: "application/vnd.github+json" } })
+      .then((response) => {
+        if (!response.ok) throw new Error(`GitHub returned ${response.status}`);
+        return response.json();
+      })
+      .then((repo) => {
+        const count = repo && repo.stargazers_count;
+        if (!Number.isFinite(count)) return;
+        applyStars(count);
+        try {
+          localStorage.setItem(starCacheKey, JSON.stringify({ savedAt: Date.now(), count }));
+        } catch {
+          // The button works fine without a count.
+        }
+      })
+      .catch(() => {
+        // The button works fine without a count.
+      });
+  };
+
+  resolveRelease();
+  resolveStars();
 })();

--- a/product_pages/styles.css
+++ b/product_pages/styles.css
@@ -54,6 +54,8 @@ h1 span { color: #607075; font-weight: 600; }
 .button-primary:hover { background: var(--blue-dark); }
 .button-secondary { border-color: #c9cac5; background: rgba(255,255,255,.55); color: var(--ink); }
 .button-secondary:hover { border-color: #a9aba6; background: var(--white); }
+.star-count { padding: 2px 9px; border-radius: 999px; background: rgba(96,112,117,.14); color: #536064; font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums; }
+.star-count[hidden] { display: none; }
 .release-note { margin: 14px 0 0; color: #768084; font-size: 13px; }
 
 .product-stage { position: relative; min-height: 560px; display: grid; align-items: center; }


### PR DESCRIPTION
Replaces the hero "View on GitHub" button with a "Star on GitHub" CTA.

- Star count badge only renders at 75+ stars (fetched client-side from the GitHub API, 1h localStorage cache, formats as 1.2k past a thousand). Below the threshold the button is a plain CTA with no number.
- release-links.js restructured so the release lookup and star lookup run independently (the old early-return on a release cache hit would have skipped the star fetch).
- Static fallback label no longer says "Latest beta - v0.1.0-beta.1"; it says "Latest release" and the script fills in the live version.

Verified locally in a browser: badge hidden at the current star count, release label renders "Latest release - v1.2.1", simulated 128-star state renders the pill correctly.