### PR TITLE
Add physical clipboard file fixtures (SOU-217)

### DIFF
--- a/docs/CAPTURE_PROBE_RESULTS.md
+++ b/docs/CAPTURE_PROBE_RESULTS.md
@@ -30,7 +30,7 @@ cargo run --locked --bin clipboard_probe -- --burst 100 --interval-ms 10 --timeo
 ## Remaining proof
 
 - Run the interactive probe during RDP and NinjaOne sessions.
-- Add image, physical file-list, and virtual-file burst fixtures.
+- Add image and delayed-rendered virtual-file burst fixtures.
 - Verify content remains available after disconnecting or closing the source session.
 - Run the new controlled-contention scenario and record the retry margin.
 
@@ -39,21 +39,26 @@ cargo run --locked --bin clipboard_probe -- --burst 100 --interval-ms 10 --timeo
 The probe's `--fixtures` mode covers the portable, deterministic subset of the
 rich-format matrix. It publishes each payload from a child process, then verifies
 exact Unicode text, raw CF_HTML and RTF bytes, decoded HTML/RTF, ordered
-`CF_HDROP` paths, and arbitrary binary bytes with embedded NUL/high-byte values.
+`CF_HDROP` paths backed by physical files and a folder, their exact on-disk
+bytes and types, and arbitrary binary bytes with embedded NUL/high-byte values.
 
 ```powershell
 scripts/test-clipboard-formats.ps1
 ```
 
-Live result on the Windows 11 development machine (2026-07-21): 10 consecutive
-runs, 30 fixture payloads observed and verified, zero read failures. The stress
-run exposed transient Win32 error 1418 while reading an auxiliary format after a
-clipboard notification; the probe now applies the same bounded retry principle
+Latest live result on the Windows 11 development machine (2026-07-21): 10
+consecutive runs, 30 fixture payloads observed and verified, zero read failures.
+Each file-list payload used a new isolated temporary directory containing a
+whitespace-sensitive text file, a Unicode-named binary file, and a folder. All
+targets were validated before cleanup, and no fixture directories remained.
+An earlier stress run exposed transient Win32 error 1418 while reading an
+auxiliary format after a clipboard notification; the probe now applies the same
+bounded retry principle
 used by production capture instead of treating the first contended read as data
 loss.
 
-Physical file lists, delayed-rendered virtual files, and the real application
-matrix remain separate because synthetic payloads cannot establish those claims.
+Delayed-rendered virtual files and the real application matrix remain separate
+because these local deterministic payloads cannot establish those claims.
 
 ## NinjaOne remote-session validation
 

--- a/docs/CAPTURE_PROBE_RESULTS.md
+++ b/docs/CAPTURE_PROBE_RESULTS.md
@@ -46,7 +46,7 @@ bytes and types, and arbitrary binary bytes with embedded NUL/high-byte values.
 scripts/test-clipboard-formats.ps1
 ```
 
-Latest live result on the Windows 11 development machine (2026-07-21): 10
+Latest live result on the Windows 11 development machine (2026-07-26): 10
 consecutive runs, 30 fixture payloads observed and verified, zero read failures.
 Each file-list payload used a new isolated temporary directory containing a
 whitespace-sensitive text file, a Unicode-named binary file, and a folder. All

--- a/docs/CLIPBOARD_RELIABILITY.md
+++ b/docs/CLIPBOARD_RELIABILITY.md
@@ -98,13 +98,16 @@ listener verifies both decoded values and exact bytes:
 
 - Unicode text (including leading/trailing whitespace) with simultaneous CF_HTML
   and RTF payloads
-- Unicode text with a multi-item `CF_HDROP` file list
+- Unicode text with an ordered multi-item `CF_HDROP` list containing a real
+  whitespace-sensitive text file, a Unicode-named binary file, and a folder
 - Unicode text with an application-defined binary format containing embedded NUL
   and high bytes
 
 Fixture validation retries transient auxiliary-format read contention with
 bounded exponential backoff. The writer retains each payload long enough for the
 complete retry window, so a retry cannot accidentally validate the next fixture.
+Physical targets stay on disk while the listener verifies their order, names,
+types, and exact bytes, then the writer removes the isolated temporary directory.
 
 This suite proves the local Windows clipboard can materialize those payloads
 without normalization or format loss. Application-specific compatibility still

--- a/src-tauri/src/bin/clipboard_probe.rs
+++ b/src-tauri/src/bin/clipboard_probe.rs
@@ -104,7 +104,10 @@ mod windows_probe {
         let config = parse_args();
         if config.writer {
             if config.fixtures {
-                run_fixture_writer();
+                if let Err(error) = run_fixture_writer() {
+                    eprintln!("clipboard fixture writer failed: {error}");
+                    std::process::exit(1);
+                }
                 return;
             }
             run_burst_writer(
@@ -384,12 +387,9 @@ mod windows_probe {
         }
     }
 
-    fn run_fixture_writer() {
+    fn run_fixture_writer() -> Result<(), String> {
         thread::sleep(Duration::from_millis(250));
-        let clipboard = ClipboardContext::new().unwrap_or_else(|error| {
-            eprintln!("failed to create fixture clipboard context: {error}");
-            std::process::exit(1);
-        });
+        let clipboard = ClipboardContext::new().map_err(|error| error.to_string())?;
 
         set_fixture(
             &clipboard,
@@ -404,18 +404,19 @@ mod windows_probe {
                 ]
             },
             "rich",
-        );
+        )?;
 
+        let physical_files = PhysicalFileFixture::create()?;
         set_fixture(
             &clipboard,
             || {
                 vec![
                     ClipboardContent::Text(FILES_MARKER.to_string()),
-                    ClipboardContent::Files(fixture_file_paths()),
+                    ClipboardContent::Files(physical_files.paths.clone()),
                 ]
             },
             "files",
-        );
+        )?;
 
         set_fixture(
             &clipboard,
@@ -426,14 +427,17 @@ mod windows_probe {
                 ]
             },
             "binary",
-        );
+        )?;
+
+        Ok(())
     }
 
     fn set_fixture(
         clipboard: &ClipboardContext,
         contents: impl Fn() -> Vec<ClipboardContent>,
         name: &str,
-    ) {
+    ) -> Result<(), String> {
+        let mut last_error = None;
         for attempt in 0..10_u32 {
             match clipboard.set(contents()) {
                 Ok(()) => {
@@ -441,20 +445,21 @@ mod windows_probe {
                     // Clipboard owners and monitors can transiently contend even
                     // after WM_CLIPBOARDUPDATE has been delivered.
                     thread::sleep(Duration::from_millis(500));
-                    return;
-                }
-                Err(error) if attempt < 9 => {
-                    thread::sleep(Duration::from_millis(2_u64.pow(attempt.min(6))));
-                    if attempt == 8 {
-                        eprintln!("retrying fixture {name} after clipboard error: {error}");
-                    }
+                    return Ok(());
                 }
                 Err(error) => {
-                    eprintln!("failed to write fixture {name}: {error}");
-                    std::process::exit(1);
+                    last_error = Some(error.to_string());
+                    if attempt < 9 {
+                        thread::sleep(Duration::from_millis(2_u64.pow(attempt.min(6))));
+                    }
                 }
             }
         }
+
+        Err(format!(
+            "failed to write fixture {name}: {}",
+            last_error.unwrap_or_else(|| "unknown clipboard error".to_string())
+        ))
     }
 
     fn spawn_fixture_writer() -> Child {
@@ -467,11 +472,55 @@ mod windows_probe {
             })
     }
 
-    fn fixture_file_paths() -> Vec<String> {
-        vec![
-            r"C:\Cubby Probe\leading space.txt".to_string(),
-            r"C:\Cubby Probe\Unicode-文档.txt".to_string(),
-        ]
+    struct PhysicalFileFixture {
+        root: std::path::PathBuf,
+        paths: Vec<String>,
+    }
+
+    impl PhysicalFileFixture {
+        fn create() -> Result<Self, String> {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos();
+            let root = env::temp_dir().join(format!(
+                "cubby-clipboard-probe-files-{}-{unique}",
+                std::process::id()
+            ));
+            std::fs::create_dir(&root).map_err(|error| error.to_string())?;
+
+            let text_file = root.join(" leading and trailing.txt");
+            let binary_file = root.join("Unicode-文档.bin");
+            let folder = root.join("Folder with spaces");
+            let fixture = Self {
+                root,
+                paths: vec![
+                    text_file.to_string_lossy().into_owned(),
+                    binary_file.to_string_lossy().into_owned(),
+                    folder.to_string_lossy().into_owned(),
+                ],
+            };
+            std::fs::write(&text_file, fixture_file_text()).map_err(|error| error.to_string())?;
+            std::fs::write(&binary_file, fixture_binary()).map_err(|error| error.to_string())?;
+            std::fs::create_dir(&folder).map_err(|error| error.to_string())?;
+
+            Ok(fixture)
+        }
+    }
+
+    impl Drop for PhysicalFileFixture {
+        fn drop(&mut self) {
+            if let Err(error) = std::fs::remove_dir_all(&self.root) {
+                eprintln!(
+                    "failed to remove physical file fixture {}: {error}",
+                    self.root.display()
+                );
+            }
+        }
+    }
+
+    fn fixture_file_text() -> &'static [u8] {
+        b"  line one\r\nline two\r\n  "
     }
 
     fn fixture_rtf() -> &'static str {
@@ -805,13 +854,58 @@ mod windows_probe {
             }
             "files" => {
                 let files = clipboard.get_files().map_err(|error| error.to_string())?;
-                if files != fixture_file_paths() {
-                    return Err(format!("file list differed: {files:?}"));
-                }
+                validate_physical_file_fixture(&files)?;
             }
             "binary" => assert_clipboard_buffer(&clipboard, BINARY_FORMAT, &fixture_binary())?,
             _ => return Err(format!("unknown fixture {name}")),
         }
+        Ok(())
+    }
+
+    fn validate_physical_file_fixture(files: &[String]) -> Result<(), String> {
+        if files.len() != 3 {
+            return Err(format!("expected 3 physical targets, got {files:?}"));
+        }
+
+        let text_file = std::path::Path::new(&files[0]);
+        let binary_file = std::path::Path::new(&files[1]);
+        let folder = std::path::Path::new(&files[2]);
+
+        if text_file.file_name() != Some(std::ffi::OsStr::new(" leading and trailing.txt"))
+            || binary_file.file_name() != Some(std::ffi::OsStr::new("Unicode-文档.bin"))
+            || folder.file_name() != Some(std::ffi::OsStr::new("Folder with spaces"))
+        {
+            return Err(format!(
+                "physical target order or names differed: {files:?}"
+            ));
+        }
+        if std::fs::read(text_file).map_err(|error| error.to_string())? != fixture_file_text() {
+            return Err("physical text file bytes differed".to_string());
+        }
+        if std::fs::read(binary_file).map_err(|error| error.to_string())? != fixture_binary() {
+            return Err("physical binary file bytes differed".to_string());
+        }
+        if !folder.is_dir() {
+            return Err("physical folder target was missing or not a directory".to_string());
+        }
+
+        let parent = text_file
+            .parent()
+            .ok_or_else(|| "physical text target had no parent".to_string())?;
+        if binary_file.parent() != Some(parent) || folder.parent() != Some(parent) {
+            return Err("physical targets did not share the fixture root".to_string());
+        }
+        if !parent
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("cubby-clipboard-probe-files-"))
+        {
+            return Err(format!(
+                "unexpected physical fixture root: {}",
+                parent.display()
+            ));
+        }
+
         Ok(())
     }
 
@@ -952,7 +1046,10 @@ mod windows_probe {
 
     #[cfg(test)]
     mod tests {
-        use super::{cf_html_payload, fixture_binary, fixture_html_fragment};
+        use super::{
+            cf_html_payload, fixture_binary, fixture_html_fragment, validate_physical_file_fixture,
+            PhysicalFileFixture,
+        };
 
         #[test]
         fn cf_html_offsets_are_byte_accurate_for_unicode() {
@@ -985,6 +1082,28 @@ mod windows_probe {
             assert!(bytes.contains(&0));
             assert!(bytes.iter().any(|byte| *byte >= 0x80));
             assert!(std::str::from_utf8(&bytes).is_err());
+        }
+
+        #[test]
+        fn physical_file_fixture_validates_and_cleans_up() {
+            let fixture = PhysicalFileFixture::create().expect("physical fixture");
+            let root = fixture.root.clone();
+
+            validate_physical_file_fixture(&fixture.paths).expect("valid physical fixture");
+            assert!(root.is_dir());
+
+            drop(fixture);
+            assert!(!root.exists());
+        }
+
+        #[test]
+        fn physical_file_fixture_detects_changed_bytes() {
+            let fixture = PhysicalFileFixture::create().expect("physical fixture");
+            std::fs::write(&fixture.paths[0], b"changed").expect("change fixture file");
+
+            let error = validate_physical_file_fixture(&fixture.paths)
+                .expect_err("changed fixture should fail validation");
+            assert_eq!(error, "physical text file bytes differed");
         }
     }
 }


### PR DESCRIPTION
## What changed

- replace placeholder `CF_HDROP` paths with real temporary Windows files and a folder
- verify target order, Unicode and whitespace-sensitive names, file types, and exact bytes
- keep targets alive through clipboard observation and clean the isolated directory afterward
- add unit coverage for successful validation, corruption detection, and cleanup
- update the SOU-217 reliability evidence

## Why

The initial compatibility slice proved ordered file-path transport but did not establish that advertised targets existed or retained their contents. This adds deterministic physical-file coverage while leaving delayed-rendered virtual files and the real application matrix for later SOU-217 work.

## Validation

- `cargo test --locked --all-targets` (97 passed)
- `cargo clippy --locked --all-targets -- -D warnings`
- `pnpm build`
- PowerShell parser check for `scripts/test-clipboard-formats.ps1`
- `scripts/test-clipboard-formats.ps1 -Runs 10` (30/30 fixture checks, zero read failures)
- confirmed no fixture temp directories remained
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard fixture reliability by retrying transient read and write contention errors.
  * Added clearer failure reporting when fixture creation cannot complete.
  * Strengthened validation of file names, ordering, types, and exact contents.

* **Tests**
  * Added coverage for temporary fixture creation, cleanup, and detection of modified files.

* **Documentation**
  * Updated clipboard reliability and probe-result documentation with expanded fixture details and refreshed Windows 11 run results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->