### PR TITLE
Publish Store installers through R2

### DIFF
--- a/.github/workflows/publish-store-packages.yml
+++ b/.github/workflows/publish-store-packages.yml
@@ -41,6 +41,18 @@ jobs:
             throw "Failed to download signed installers from $env:RELEASE_TAG."
           }
 
+          $expectedSignerSubject = "CN=Brandon South, O=Brandon South, L=Wilmore, S=ky, C=US"
+          foreach ($architecture in @("x64", "arm64")) {
+            $installerPath = "release-assets/Cubby.Clipboard_${version}_${architecture}-setup.exe"
+            $signature = Get-AuthenticodeSignature -LiteralPath $installerPath
+            if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
+              throw "$architecture installer has an invalid Authenticode signature: $($signature.StatusMessage)"
+            }
+            if ($signature.SignerCertificate.Subject -ne $expectedSignerSubject) {
+              throw "$architecture installer signer is unexpected: $($signature.SignerCertificate.Subject)"
+            }
+          }
+
           "version=$version" >> $env:GITHUB_OUTPUT
 
       - name: Publish x64 installer

--- a/.github/workflows/publish-store-packages.yml
+++ b/.github/workflows/publish-store-packages.yml
@@ -1,0 +1,70 @@
+name: Publish Microsoft Store packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing GitHub release tag to publish to Cloudflare R2
+        required: true
+        default: v1.2.1
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish signed installers
+    runs-on: windows-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Validate tag and download signed installers
+        id: release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          if ($env:RELEASE_TAG -notmatch '^v(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$') {
+            throw "Release tag must be a version such as v1.2.1."
+          }
+
+          $version = $Matches[1]
+          New-Item -ItemType Directory -Force -Path release-assets | Out-Null
+          gh release download $env:RELEASE_TAG `
+            --repo $env:GITHUB_REPOSITORY `
+            --dir release-assets `
+            --pattern "Cubby.Clipboard_${version}_x64-setup.exe" `
+            --pattern "Cubby.Clipboard_${version}_arm64-setup.exe"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to download signed installers from $env:RELEASE_TAG."
+          }
+
+          "version=$version" >> $env:GITHUB_OUTPUT
+
+      - name: Publish x64 installer
+        shell: pwsh
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_R2_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_R2_BUCKET: ${{ vars.CLOUDFLARE_R2_BUCKET }}
+        run: |
+          ./scripts/publish-store-installer.ps1 `
+            -Version "${{ steps.release.outputs.version }}" `
+            -Architecture x64 `
+            -InstallerPath "release-assets/Cubby.Clipboard_${{ steps.release.outputs.version }}_x64-setup.exe" `
+            -BucketName $env:CLOUDFLARE_R2_BUCKET
+
+      - name: Publish ARM64 installer
+        shell: pwsh
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_R2_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_R2_BUCKET: ${{ vars.CLOUDFLARE_R2_BUCKET }}
+        run: |
+          ./scripts/publish-store-installer.ps1 `
+            -Version "${{ steps.release.outputs.version }}" `
+            -Architecture arm64 `
+            -InstallerPath "release-assets/Cubby.Clipboard_${{ steps.release.outputs.version }}_arm64-setup.exe" `
+            -BucketName $env:CLOUDFLARE_R2_BUCKET

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,6 +276,30 @@ jobs:
         run: |
           gh release upload "$env:TAG" "${{ steps.installer.outputs.name }}.sig" --clobber
 
+      - name: Publish Microsoft Store installer to Cloudflare R2
+        if: github.event_name != 'workflow_dispatch'
+        shell: pwsh
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_R2_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_R2_BUCKET: ${{ vars.CLOUDFLARE_R2_BUCKET }}
+        run: |
+          foreach ($name in @(
+            "CLOUDFLARE_API_TOKEN",
+            "CLOUDFLARE_ACCOUNT_ID",
+            "CLOUDFLARE_R2_BUCKET"
+          )) {
+            if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
+              throw "The release environment is missing $name."
+            }
+          }
+
+          ./scripts/publish-store-installer.ps1 `
+            -Version "${{ needs.create-release.outputs.version }}" `
+            -Architecture "${{ matrix.arch }}" `
+            -InstallerPath "${{ steps.installer.outputs.path }}" `
+            -BucketName $env:CLOUDFLARE_R2_BUCKET
+
       - name: Assemble the portable package
         if: matrix.arch == 'x64'
         id: portable

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,5 +1,21 @@
 # Cubby Clipboard release checklist
 
+## Microsoft Store packages
+
+Versioned Microsoft Store installers are served without redirects from
+`https://downloads.cubbyclipboard.com/releases/v<version>/`. The `release`
+environment must define:
+
+- variable `CLOUDFLARE_ACCOUNT_ID`;
+- variable `CLOUDFLARE_R2_BUCKET` (`cubby-downloads`); and
+- secret `CLOUDFLARE_R2_API_TOKEN`, scoped to the Cubby bucket with R2 object
+  write access.
+
+Tag releases upload and verify both signed installers automatically. To backfill
+an existing GitHub release, run the `Publish Microsoft Store packages` workflow
+with its version tag. Submit the resulting immutable x64 and ARM64 URLs to
+Microsoft Partner Center.
+
 ## Automated gate
 
 Run from the repository root on Windows:

--- a/scripts/publish-store-installer.ps1
+++ b/scripts/publish-store-installer.ps1
@@ -1,0 +1,107 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$')]
+    [string]$Version,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("x64", "arm64")]
+    [string]$Architecture,
+
+    [Parameter(Mandatory = $true)]
+    [string]$InstallerPath,
+
+    [string]$BucketName = "cubby-downloads",
+    [string]$DownloadOrigin = "https://downloads.cubbyclipboard.com",
+    [string]$WranglerVersion = "4.113.0",
+    [switch]$SkipPublicVerification
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$resolvedInstallerPath = (Resolve-Path -LiteralPath $InstallerPath).Path
+$installerName = "Cubby.Clipboard_${Version}_${Architecture}-setup.exe"
+$hashName = "$installerName.sha256"
+$objectPrefix = "releases/v$Version"
+$localHash = (Get-FileHash -LiteralPath $resolvedInstallerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+$hashPath = Join-Path ([System.IO.Path]::GetTempPath()) "$hashName-$([guid]::NewGuid().ToString('N')).txt"
+
+function Publish-R2Object {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ObjectName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ContentType,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CacheControl
+    )
+
+    $objectPath = "$BucketName/$objectPrefix/$ObjectName"
+    & npx --yes "wrangler@$WranglerVersion" r2 object put $objectPath `
+        "--file=$Path" `
+        --remote `
+        --force `
+        "--content-type=$ContentType" `
+        "--cache-control=$CacheControl"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Wrangler failed to upload $ObjectName to R2."
+    }
+}
+
+try {
+    Set-Content -LiteralPath $hashPath -Value "$localHash  $installerName" -NoNewline
+
+    Publish-R2Object `
+        -Path $resolvedInstallerPath `
+        -ObjectName $installerName `
+        -ContentType "application/vnd.microsoft.portable-executable" `
+        -CacheControl "public, max-age=31536000, immutable"
+    Publish-R2Object `
+        -Path $hashPath `
+        -ObjectName $hashName `
+        -ContentType "text/plain; charset=utf-8" `
+        -CacheControl "public, max-age=31536000, immutable"
+
+    $installerUrl = "$($DownloadOrigin.TrimEnd('/'))/$objectPrefix/$installerName"
+    if ($SkipPublicVerification) {
+        Write-Output "Uploaded Microsoft Store installer: $installerUrl"
+        return
+    }
+
+    $downloadPath = Join-Path ([System.IO.Path]::GetTempPath()) "cubby-store-$Version-$Architecture-$([guid]::NewGuid().ToString('N')).exe"
+    try {
+        & curl.exe `
+            --fail `
+            --silent `
+            --show-error `
+            --location `
+            --max-redirs 0 `
+            --connect-timeout 10 `
+            --max-time 180 `
+            --retry 3 `
+            --retry-delay 5 `
+            --retry-connrefused `
+            --output $downloadPath `
+            $installerUrl
+        if ($LASTEXITCODE -ne 0) {
+            throw "Direct public download failed with curl exit code $LASTEXITCODE."
+        }
+
+        $downloadHash = (Get-FileHash -LiteralPath $downloadPath -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($downloadHash -ne $localHash) {
+            throw "Public installer SHA-256 mismatch. Expected $localHash, got $downloadHash."
+        }
+    } finally {
+        Remove-Item -LiteralPath $downloadPath -Force -ErrorAction SilentlyContinue
+    }
+
+    Write-Output "Verified direct Microsoft Store installer URL: $installerUrl"
+} finally {
+    Remove-Item -LiteralPath $hashPath -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/publish-store-installer.ps1
+++ b/scripts/publish-store-installer.ps1
@@ -27,6 +27,39 @@ $objectPrefix = "releases/v$Version"
 $localHash = (Get-FileHash -LiteralPath $resolvedInstallerPath -Algorithm SHA256).Hash.ToLowerInvariant()
 $hashPath = Join-Path ([System.IO.Path]::GetTempPath()) "$hashName-$([guid]::NewGuid().ToString('N')).txt"
 
+function Assert-R2ObjectDoesNotExist {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ObjectName
+    )
+
+    $objectUrl = "$($DownloadOrigin.TrimEnd('/'))/$objectPrefix/$ObjectName"
+    $probePath = Join-Path ([System.IO.Path]::GetTempPath()) "cubby-r2-probe-$([guid]::NewGuid().ToString('N'))"
+    try {
+        $statusCode = & curl.exe `
+            --silent `
+            --show-error `
+            --location `
+            --max-redirs 0 `
+            --connect-timeout 10 `
+            --max-time 60 `
+            --output $probePath `
+            --write-out "%{http_code}" `
+            $objectUrl
+        if ($LASTEXITCODE -ne 0) {
+            throw "Could not check whether $objectUrl already exists."
+        }
+        if ($statusCode -eq "200") {
+            throw "Refusing to overwrite immutable release object: $objectUrl"
+        }
+        if ($statusCode -ne "404") {
+            throw "Unexpected HTTP $statusCode while checking $objectUrl."
+        }
+    } finally {
+        Remove-Item -LiteralPath $probePath -Force -ErrorAction SilentlyContinue
+    }
+}
+
 function Publish-R2Object {
     param(
         [Parameter(Mandatory = $true)]
@@ -42,6 +75,7 @@ function Publish-R2Object {
         [string]$CacheControl
     )
 
+    Assert-R2ObjectDoesNotExist -ObjectName $ObjectName
     $objectPath = "$BucketName/$objectPrefix/$ObjectName"
     & npx --yes "wrangler@$WranglerVersion" r2 object put $objectPath `
         "--file=$Path" `


### PR DESCRIPTION
## Summary

- publish signed x64 and ARM64 Store installers to versioned Cloudflare R2 URLs during tagged releases
- add a manual backfill workflow for existing releases such as v1.2.1
- verify public downloads have no redirects and match the signed installer SHA-256
- document the required release-environment configuration

## Why

Microsoft Partner Center rejects the redirecting GitHub release URLs. These immutable `downloads.cubbyclipboard.com` URLs provide direct downloadable packages for Store ingestion.

## Validation

- `git diff --check`
- PowerShell parser validation for `scripts/publish-store-installer.ps1`
- YAML parse validation for both workflows

The live upload requires `CLOUDFLARE_R2_API_TOKEN` to be added to the Cubby `release` environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated publishing for signed Microsoft Store installers in both x64 and ARM64 formats.
  * Installer downloads now include SHA-256 checksums for integrity verification.
  * Published installers are validated after upload to ensure reliable downloads.

* **Documentation**
  * Added release checklist guidance for publishing and registering Microsoft Store packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->