### PR TITLE
Store OCR word bounding boxes at capture time (SOU-242 phase 1)

### DIFF
--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -160,6 +160,10 @@ impl Database {
         // Encrypted OCR text extracted from screenshot/image clips, so images are
         // findable by their words. NULL until (or unless) OCR runs for a clip.
         add_column_if_missing(&self.pool, "ALTER TABLE clips ADD COLUMN ocr_text TEXT").await?;
+        // Encrypted JSON array of per-word bounding boxes for image clips, stored
+        // at capture time so search can later highlight matched words on the
+        // preview without re-running OCR (SOU-242). NULL when OCR found no words.
+        add_column_if_missing(&self.pool, "ALTER TABLE clips ADD COLUMN ocr_words TEXT").await?;
         add_column_if_missing(&self.pool, "ALTER TABLE clips ADD COLUMN ocr_status TEXT").await?;
         add_column_if_missing(
             &self.pool,

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -4,6 +4,29 @@
 //!
 //! Called from image capture; also exercised by a self-contained test.
 
+use serde::{Deserialize, Serialize};
+
+/// One recognized word and its bounding box, in the pixel coordinate space of
+/// the image handed to the OCR engine. Persisted (encrypted) at capture time so
+/// a later search can highlight matched words on the image without re-running
+/// OCR (SOU-242 phase 1 stores them; phase 2 renders them).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OcrWordBox {
+    pub text: String,
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+/// The full result of recognizing an image: the assembled text and the
+/// per-word bounding boxes.
+#[derive(Debug, Clone, Default)]
+pub struct OcrRecognition {
+    pub text: String,
+    pub words: Vec<OcrWordBox>,
+}
+
 const MAX_ENCODED_IMAGE_BYTES: usize = 128 * 1024 * 1024;
 const MAX_SOURCE_DIMENSION: u32 = 16_384;
 // Bounds the fully-decoded RGBA buffer (~4 bytes/pixel) and everything derived
@@ -80,10 +103,10 @@ fn decode_for_ocr(png_bytes: &[u8], max_ocr_dimension: u32) -> Result<image::Rgb
 }
 
 /// Recognize text from PNG-encoded image bytes with the user's installed OCR
-/// languages. Returns the recognized text (possibly empty), or an error when no
-/// OCR language is available on the machine.
+/// languages. Returns the recognized text (possibly empty) plus per-word
+/// bounding boxes, or an error when no OCR language is available on the machine.
 #[cfg(target_os = "windows")]
-pub fn recognize_png(png_bytes: &[u8]) -> Result<String, String> {
+pub fn recognize_png(png_bytes: &[u8]) -> Result<OcrRecognition, String> {
     use windows::Graphics::Imaging::{BitmapPixelFormat, SoftwareBitmap};
     use windows::Media::Ocr::OcrEngine;
     use windows::Security::Cryptography::CryptographicBuffer;
@@ -134,8 +157,30 @@ pub fn recognize_png(png_bytes: &[u8]) -> Result<String, String> {
     // multi-line image.
     let lines = result.Lines().map_err(|e| e.to_string())?;
     let mut text = String::new();
+    let mut words: Vec<OcrWordBox> = Vec::new();
     for index in 0..lines.Size().map_err(|e| e.to_string())? {
         let line = lines.GetAt(index).map_err(|e| e.to_string())?;
+
+        // Capture each word's box (SOU-242). The rect is in the coordinate space
+        // of the image we handed the engine (`decode_for_ocr` may have downscaled
+        // it), which phase 2 accounts for when mapping onto the preview.
+        let line_words = line.Words().map_err(|e| e.to_string())?;
+        for word_index in 0..line_words.Size().map_err(|e| e.to_string())? {
+            let word = line_words.GetAt(word_index).map_err(|e| e.to_string())?;
+            let word_text = word.Text().map_err(|e| e.to_string())?.to_string();
+            if word_text.is_empty() {
+                continue;
+            }
+            let rect = word.BoundingRect().map_err(|e| e.to_string())?;
+            words.push(OcrWordBox {
+                text: word_text,
+                x: rect.X,
+                y: rect.Y,
+                width: rect.Width,
+                height: rect.Height,
+            });
+        }
+
         let line_text = line.Text().map_err(|e| e.to_string())?.to_string();
         if line_text.is_empty() {
             continue;
@@ -145,11 +190,11 @@ pub fn recognize_png(png_bytes: &[u8]) -> Result<String, String> {
         }
         text.push_str(&line_text);
     }
-    Ok(text)
+    Ok(OcrRecognition { text, words })
 }
 
 #[cfg(not(target_os = "windows"))]
-pub fn recognize_png(_png_bytes: &[u8]) -> Result<String, String> {
+pub fn recognize_png(_png_bytes: &[u8]) -> Result<OcrRecognition, String> {
     Err("Screenshot OCR requires Windows".to_string())
 }
 
@@ -210,10 +255,13 @@ mod tests {
         let _ = std::fs::remove_file(&path);
 
         match recognize_png(&png) {
-            Ok(text) => assert!(
-                text.to_uppercase().contains("CUBBY"),
-                "expected OCR to read the image, got: {text:?}"
-            ),
+            Ok(recognition) => {
+                let text = recognition.text;
+                assert!(
+                    text.to_uppercase().contains("CUBBY"),
+                    "expected OCR to read the image, got: {text:?}"
+                );
+            }
             // No OCR language pack (e.g. on some CI images) -> skip, don't fail.
             // Only the missing-language case is an acceptable skip; any other
             // failure (bitmap, API, poll) must fail the test loudly.
@@ -261,7 +309,7 @@ mod tests {
         let _ = std::fs::remove_file(&ui_path);
 
         let dark_text = match recognize_png(&dark_png) {
-            Ok(text) => text.to_uppercase(),
+            Ok(recognition) => recognition.text.to_uppercase(),
             Err(error) if error.contains("no OCR language") => {
                 eprintln!("skipping OCR corpus assertion: {error}");
                 return;
@@ -279,6 +327,7 @@ mod tests {
 
         let ui_text = recognize_png(&ui_png)
             .unwrap_or_else(|error| panic!("small UI OCR corpus failed unexpectedly: {error}"))
+            .text
             .to_uppercase();
         assert!(
             ui_text.contains("TICKET"),

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -7,9 +7,7 @@
 use serde::{Deserialize, Serialize};
 
 /// One recognized word and its bounding box, in the pixel coordinate space of
-/// the image handed to the OCR engine. Persisted (encrypted) at capture time so
-/// a later search can highlight matched words on the image without re-running
-/// OCR (SOU-242 phase 1 stores them; phase 2 renders them).
+/// the image handed to the OCR engine (see `OcrLayout::image_width`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OcrWordBox {
     pub text: String,
@@ -19,12 +17,30 @@ pub struct OcrWordBox {
     pub height: f32,
 }
 
-/// The full result of recognizing an image: the assembled text and the
-/// per-word bounding boxes.
+/// The per-word boxes plus the pixel dimensions of the image OCR actually ran
+/// on. Persisted (encrypted) at capture time so a later search can highlight
+/// matched words on the image without re-running OCR (SOU-242: phase 1 stores
+/// this; phase 2 renders it).
+///
+/// The dimensions are essential and easy to overlook: `decode_for_ocr` may
+/// downscale a large screenshot before OCR, so the word coordinates are in that
+/// (possibly reduced) space, not the full image's. Storing `image_width`/
+/// `image_height` lets phase 2 scale the boxes onto the real preview. Without
+/// them the boxes are unusable for anything that was downscaled, and the only
+/// recovery would be a full re-OCR — exactly what capturing now avoids.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct OcrLayout {
+    pub image_width: u32,
+    pub image_height: u32,
+    pub words: Vec<OcrWordBox>,
+}
+
+/// The full result of recognizing an image: the assembled text and the word
+/// layout.
 #[derive(Debug, Clone, Default)]
 pub struct OcrRecognition {
     pub text: String,
-    pub words: Vec<OcrWordBox>,
+    pub layout: OcrLayout,
 }
 
 const MAX_ENCODED_IMAGE_BYTES: usize = 128 * 1024 * 1024;
@@ -162,8 +178,9 @@ pub fn recognize_png(png_bytes: &[u8]) -> Result<OcrRecognition, String> {
         let line = lines.GetAt(index).map_err(|e| e.to_string())?;
 
         // Capture each word's box (SOU-242). The rect is in the coordinate space
-        // of the image we handed the engine (`decode_for_ocr` may have downscaled
-        // it), which phase 2 accounts for when mapping onto the preview.
+        // of the image we handed the engine (`width`/`height` above, post any
+        // `decode_for_ocr` downscale), recorded in the OcrLayout so phase 2 can
+        // scale onto the full-size preview.
         let line_words = line.Words().map_err(|e| e.to_string())?;
         for word_index in 0..line_words.Size().map_err(|e| e.to_string())? {
             let word = line_words.GetAt(word_index).map_err(|e| e.to_string())?;
@@ -190,7 +207,14 @@ pub fn recognize_png(png_bytes: &[u8]) -> Result<OcrRecognition, String> {
         }
         text.push_str(&line_text);
     }
-    Ok(OcrRecognition { text, words })
+    Ok(OcrRecognition {
+        text,
+        layout: OcrLayout {
+            image_width: width,
+            image_height: height,
+            words,
+        },
+    })
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/src-tauri/src/ocr_queue.rs
+++ b/src-tauri/src/ocr_queue.rs
@@ -388,9 +388,9 @@ async fn process_job(app: &AppHandle, db: &Database, job: OcrJob) -> Result<(), 
     .await;
 
     match result {
-        Ok(Ok(text)) => {
-            let has_text = !text.trim().is_empty();
-            mark_completed(db, &job.clip_uuid, &text).await?;
+        Ok(Ok(recognition)) => {
+            let has_text = !recognition.text.trim().is_empty();
+            mark_completed(db, &job.clip_uuid, &recognition.text, &recognition.words).await?;
             if has_text {
                 // Let the open flyout surface this clip's "paste text" option
                 // right away instead of only after the list is next reloaded.
@@ -456,17 +456,32 @@ fn is_managed_image_path(image_dir: &std::path::Path, file_path: &str) -> bool {
         .unwrap_or(false)
 }
 
-async fn mark_completed(db: &Database, clip_uuid: &str, text: &str) -> Result<(), String> {
+async fn mark_completed(
+    db: &Database,
+    clip_uuid: &str,
+    text: &str,
+    words: &[crate::ocr::OcrWordBox],
+) -> Result<(), String> {
     let encrypted = if text.trim().is_empty() {
         None
     } else {
         Some(db.crypto.encrypt_text(text.trim())?)
     };
 
+    // Persist the per-word boxes (SOU-242) as encrypted JSON, so a future search
+    // can highlight matches on the image. NULL when OCR found no words.
+    let encrypted_words = if words.is_empty() {
+        None
+    } else {
+        let json = serde_json::to_string(words).map_err(|error| error.to_string())?;
+        Some(db.crypto.encrypt_text(&json)?)
+    };
+
     sqlx::query(
         r#"
         UPDATE clips
         SET ocr_text = ?,
+            ocr_words = ?,
             ocr_status = 'completed',
             ocr_next_retry_at = NULL,
             ocr_error_kind = NULL
@@ -474,6 +489,7 @@ async fn mark_completed(db: &Database, clip_uuid: &str, text: &str) -> Result<()
         "#,
     )
     .bind(encrypted)
+    .bind(encrypted_words)
     .bind(clip_uuid)
     .execute(&db.pool)
     .await
@@ -627,7 +643,7 @@ mod tests {
             .await
             .expect("claim should succeed")
         {
-            mark_completed(&database, &job.clip_uuid, "")
+            mark_completed(&database, &job.clip_uuid, "", &[])
                 .await
                 .expect("completion should persist");
             processed += 1;
@@ -640,6 +656,66 @@ mod tests {
                 .await
                 .expect("count should load");
         assert_eq!(remaining, 0);
+    }
+
+    #[tokio::test]
+    async fn mark_completed_persists_encrypted_word_boxes() {
+        use crate::ocr::OcrWordBox;
+        let database = test_database().await;
+        insert_image(&database, "shot", Some("processing")).await;
+
+        let words = vec![
+            OcrWordBox {
+                text: "Hello".to_string(),
+                x: 1.0,
+                y: 2.0,
+                width: 30.0,
+                height: 12.0,
+            },
+            OcrWordBox {
+                text: "World".to_string(),
+                x: 40.0,
+                y: 2.0,
+                width: 32.0,
+                height: 12.0,
+            },
+        ];
+        mark_completed(&database, "shot", "Hello World", &words)
+            .await
+            .expect("completion should persist");
+
+        let stored: Option<String> =
+            sqlx::query_scalar("SELECT ocr_words FROM clips WHERE uuid = 'shot'")
+                .fetch_one(&database.pool)
+                .await
+                .expect("row should load");
+        let encrypted = stored.expect("ocr_words should be stored");
+        // Boxes are stored as ciphertext, never plaintext JSON.
+        assert!(encrypted.starts_with("CUB1:"));
+        let json = database
+            .crypto
+            .decrypt_text(&encrypted)
+            .expect("boxes should decrypt");
+        let decoded: Vec<OcrWordBox> =
+            serde_json::from_str(&json).expect("boxes should deserialize");
+        assert_eq!(decoded, words);
+    }
+
+    #[tokio::test]
+    async fn mark_completed_leaves_word_boxes_null_when_absent() {
+        let database = test_database().await;
+        insert_image(&database, "blank", Some("processing")).await;
+
+        mark_completed(&database, "blank", "", &[])
+            .await
+            .expect("completion should persist");
+
+        let stored: Option<String> =
+            sqlx::query_scalar("SELECT ocr_words FROM clips WHERE uuid = 'blank'")
+                .fetch_one(&database.pool)
+                .await
+                .expect("row should load");
+        assert!(stored.is_none(), "no words means NULL, not empty JSON");
     }
 
     #[tokio::test]

--- a/src-tauri/src/ocr_queue.rs
+++ b/src-tauri/src/ocr_queue.rs
@@ -132,6 +132,7 @@ pub async fn reprocess_existing_for_linebreaks(db: &Database) -> Result<(), Stri
         r#"
         UPDATE clips
         SET ocr_text = NULL,
+            ocr_words = NULL,
             ocr_status = 'pending',
             ocr_attempts = 0,
             ocr_next_retry_at = NULL,
@@ -390,7 +391,7 @@ async fn process_job(app: &AppHandle, db: &Database, job: OcrJob) -> Result<(), 
     match result {
         Ok(Ok(recognition)) => {
             let has_text = !recognition.text.trim().is_empty();
-            mark_completed(db, &job.clip_uuid, &recognition.text, &recognition.words).await?;
+            mark_completed(db, &job.clip_uuid, &recognition.text, &recognition.layout).await?;
             if has_text {
                 // Let the open flyout surface this clip's "paste text" option
                 // right away instead of only after the list is next reloaded.
@@ -460,7 +461,7 @@ async fn mark_completed(
     db: &Database,
     clip_uuid: &str,
     text: &str,
-    words: &[crate::ocr::OcrWordBox],
+    layout: &crate::ocr::OcrLayout,
 ) -> Result<(), String> {
     let encrypted = if text.trim().is_empty() {
         None
@@ -468,12 +469,13 @@ async fn mark_completed(
         Some(db.crypto.encrypt_text(text.trim())?)
     };
 
-    // Persist the per-word boxes (SOU-242) as encrypted JSON, so a future search
-    // can highlight matches on the image. NULL when OCR found no words.
-    let encrypted_words = if words.is_empty() {
+    // Persist the word boxes + their reference dimensions (SOU-242) as encrypted
+    // JSON, so a future search can scale and highlight matches on the image.
+    // NULL when OCR found no words.
+    let encrypted_words = if layout.words.is_empty() {
         None
     } else {
-        let json = serde_json::to_string(words).map_err(|error| error.to_string())?;
+        let json = serde_json::to_string(layout).map_err(|error| error.to_string())?;
         Some(db.crypto.encrypt_text(&json)?)
     };
 
@@ -643,9 +645,14 @@ mod tests {
             .await
             .expect("claim should succeed")
         {
-            mark_completed(&database, &job.clip_uuid, "", &[])
-                .await
-                .expect("completion should persist");
+            mark_completed(
+                &database,
+                &job.clip_uuid,
+                "",
+                &crate::ocr::OcrLayout::default(),
+            )
+            .await
+            .expect("completion should persist");
             processed += 1;
         }
 
@@ -660,27 +667,31 @@ mod tests {
 
     #[tokio::test]
     async fn mark_completed_persists_encrypted_word_boxes() {
-        use crate::ocr::OcrWordBox;
+        use crate::ocr::{OcrLayout, OcrWordBox};
         let database = test_database().await;
         insert_image(&database, "shot", Some("processing")).await;
 
-        let words = vec![
-            OcrWordBox {
-                text: "Hello".to_string(),
-                x: 1.0,
-                y: 2.0,
-                width: 30.0,
-                height: 12.0,
-            },
-            OcrWordBox {
-                text: "World".to_string(),
-                x: 40.0,
-                y: 2.0,
-                width: 32.0,
-                height: 12.0,
-            },
-        ];
-        mark_completed(&database, "shot", "Hello World", &words)
+        let layout = OcrLayout {
+            image_width: 1920,
+            image_height: 1080,
+            words: vec![
+                OcrWordBox {
+                    text: "Hello".to_string(),
+                    x: 1.0,
+                    y: 2.0,
+                    width: 30.0,
+                    height: 12.0,
+                },
+                OcrWordBox {
+                    text: "World".to_string(),
+                    x: 40.0,
+                    y: 2.0,
+                    width: 32.0,
+                    height: 12.0,
+                },
+            ],
+        };
+        mark_completed(&database, "shot", "Hello World", &layout)
             .await
             .expect("completion should persist");
 
@@ -696,9 +707,9 @@ mod tests {
             .crypto
             .decrypt_text(&encrypted)
             .expect("boxes should decrypt");
-        let decoded: Vec<OcrWordBox> =
-            serde_json::from_str(&json).expect("boxes should deserialize");
-        assert_eq!(decoded, words);
+        let decoded: OcrLayout = serde_json::from_str(&json).expect("layout should deserialize");
+        // Dimensions round-trip too, so phase 2 knows the boxes' coordinate space.
+        assert_eq!(decoded, layout);
     }
 
     #[tokio::test]
@@ -706,7 +717,7 @@ mod tests {
         let database = test_database().await;
         insert_image(&database, "blank", Some("processing")).await;
 
-        mark_completed(&database, "blank", "", &[])
+        mark_completed(&database, "blank", "", &crate::ocr::OcrLayout::default())
             .await
             .expect("completion should persist");
 


### PR DESCRIPTION
Phase 1 of SOU-242 (storage only — no rendering yet).

Windows OCR already returns per-word bounding boxes; Cubby was discarding them and keeping only the flattened text. This captures and persists them at OCR time so a later search can highlight matched words on the image (phase 2) **without re-running OCR**. It's the time-sensitive half: clips captured from now on are ready for phase 2, whereas anything captured before this ships would permanently miss out.

## Changes
- **ocr.rs**: `recognize_png` now returns `OcrRecognition { text, words }`, collecting each word's text + `BoundingRect` (x/y/w/h) from the `OcrResult` lines/words. Boxes are in the OCR-input image's pixel space (which `decode_for_ocr` may have downscaled — phase 2 accounts for that).
- **database**: new `ocr_words TEXT` column (encrypted JSON array of boxes).
- **ocr_queue**: `mark_completed` serializes the boxes to JSON, encrypts them with the same CUB1/AES-256-GCM path as `ocr_text`, and writes `ocr_words`; `NULL` when OCR found no words. The queue worker — and therefore the SOU-234 backfill — picks boxes up automatically for any image it (re)processes.

## Scope notes
- **No frontend / rendering** — that's phase 2 (draw highlight rects over matched words).
- Already-completed clips won't be re-OCR'd just for boxes; they'll gain boxes only if/when a future re-OCR pass runs. Phase 1 is "from now on," as the issue specifies.

## Tests
Boxes round-trip through encrypt + JSON (`mark_completed_persists_encrypted_word_boxes`), and absent words store `NULL` rather than empty JSON.

Verified locally: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OCR results now include word-level positioning data for image clips.
  - OCR text and word coordinates are securely stored for later use.
  - Existing image clips can be reprocessed without retaining outdated OCR positioning data.

- **Bug Fixes**
  - Prevented stale OCR word-position information from being reused when OCR data is refreshed.
  - Improved handling of images where OCR finds no words.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->