### PR TITLE
Add offline Microsoft Store installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,9 +225,46 @@ jobs:
             Write-Error "No NSIS installer was produced"
             exit 1
           }
-          # The signing action requires a rooted (absolute) path; $file.FullName is a Windows-rooted path.
-          "path=$($file.FullName)" >> $env:GITHUB_OUTPUT
-          "name=$($file.Name -replace ' ', '.')" >> $env:GITHUB_OUTPUT
+          $name = $file.Name -replace ' ', '.'
+          $stagedPath = Join-Path $env:RUNNER_TEMP $name
+          Copy-Item $file.FullName $stagedPath -Force
+          $binary = Resolve-Path "src-tauri/target/${{ matrix.target }}/release/cubby.exe"
+          $stagedBinary = Join-Path $env:RUNNER_TEMP "cubby-${{ matrix.arch }}.exe"
+          Copy-Item $binary $stagedBinary -Force
+          # Stage the slim installer before the Store build overwrites Tauri's
+          # default NSIS output path and app binary.
+          "path=$stagedPath" >> $env:GITHUB_OUTPUT
+          "name=$name" >> $env:GITHUB_OUTPUT
+          "binary_path=$stagedBinary" >> $env:GITHUB_OUTPUT
+
+      - name: Build offline Microsoft Store installer
+        shell: pwsh
+        run: |
+          pnpm tauri build `
+            --ci `
+            --target "${{ matrix.target }}" `
+            --features app-store `
+            --bundles nsis `
+            --config src-tauri/tauri.store.conf.json
+
+      - name: Locate the offline Store installer
+        id: store-installer
+        shell: pwsh
+        run: |
+          $file = Get-ChildItem "src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*-setup.exe" | Select-Object -First 1
+          if (-not $file) {
+            Write-Error "No offline NSIS installer was produced"
+            exit 1
+          }
+          $name = "Cubby.Clipboard_${{ needs.create-release.outputs.version }}_${{ matrix.arch }}-Store-setup.exe"
+          $stagedPath = Join-Path $env:RUNNER_TEMP $name
+          Copy-Item $file.FullName $stagedPath -Force
+          if ((Get-Item -LiteralPath $stagedPath).Length -lt 50MB) {
+            Write-Error "Store installer is too small to contain the offline WebView2 runtime"
+            exit 1
+          }
+          "path=$stagedPath" >> $env:GITHUB_OUTPUT
+          "name=$name" >> $env:GITHUB_OUTPUT
 
       - name: Sign in to Azure with GitHub OIDC
         uses: azure/login@v3
@@ -236,25 +273,31 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Sign the installer with Trusted Signing
+      - name: Sign the installers with Trusted Signing
         uses: Azure/artifact-signing-action@v2
         with:
           endpoint: ${{ vars.ARTIFACT_SIGNING_ENDPOINT }}
           signing-account-name: ${{ vars.ARTIFACT_SIGNING_ACCOUNT_NAME }}
           certificate-profile-name: ${{ vars.ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME }}
-          files: ${{ steps.installer.outputs.path }}
+          files: |
+            ${{ steps.installer.outputs.path }}
+            ${{ steps.store-installer.outputs.path }}
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
 
-      - name: Upload the signed installer
+      - name: Upload the signed installers
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.create-release.outputs.tag }}
         run: |
           Copy-Item "${{ steps.installer.outputs.path }}" "${{ steps.installer.outputs.name }}"
-          gh release upload "$env:TAG" "${{ steps.installer.outputs.name }}" --clobber
+          Copy-Item "${{ steps.store-installer.outputs.path }}" "${{ steps.store-installer.outputs.name }}"
+          gh release upload "$env:TAG" `
+            "${{ steps.installer.outputs.name }}" `
+            "${{ steps.store-installer.outputs.name }}" `
+            --clobber
 
       - name: Re-sign the installer for the updater (over the signed bytes)
         shell: pwsh
@@ -297,7 +340,7 @@ jobs:
           ./scripts/publish-store-installer.ps1 `
             -Version "${{ needs.create-release.outputs.version }}" `
             -Architecture "${{ matrix.arch }}" `
-            -InstallerPath "${{ steps.installer.outputs.path }}" `
+            -InstallerPath "${{ steps.store-installer.outputs.path }}" `
             -BucketName $env:CLOUDFLARE_R2_BUCKET
 
       - name: Assemble the portable package
@@ -307,7 +350,7 @@ jobs:
         run: |
           $stage = Join-Path (Get-Location) "portable"
           New-Item -ItemType Directory -Force -Path $stage | Out-Null
-          Copy-Item "src-tauri/target/${{ matrix.target }}/release/cubby.exe" (Join-Path $stage "Cubby Clipboard.exe")
+          Copy-Item "${{ steps.installer.outputs.binary_path }}" (Join-Path $stage "Cubby Clipboard.exe")
           # The marker's presence next to the exe switches Cubby to portable mode.
           Set-Content -Path (Join-Path $stage "portable.txt") -Value @(
             "This file makes Cubby run in portable mode. Keep it next to Cubby Clipboard.exe.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable Cubby Clipboard changes are documented here. PastePaw entries below Cubby's first beta are retained as upstream history and attribution.
 
+## v1.2.2
+
+### Added
+- Separate signed Microsoft Store installers for x64 and ARM64 that include WebView2 and install fully offline, while the smaller GitHub and Winget installers remain available
+- A Reclaim space action and an accurate storage readout based on Cubby's true on-disk history size
+
+### Changed
+- Keep recognized text and a searchable thumbnail after full screenshot images expire under retention rules
+- Store OCR word positions at capture time so image-search matches can be highlighted without repeating recognition work
+- Strengthen sensitive-content privacy gates, clipboard listener recovery, and rich clipboard-format compatibility coverage
+- Publish immutable Store packages through direct Cloudflare R2 URLs suitable for Microsoft certification
+
+### 新增
+- 为 x64 和 ARM64 提供独立签名的 Microsoft Store 安装程序，内置 WebView2 并支持完全离线安装，同时保留较小的 GitHub 和 Winget 安装程序
+- 新增“回收空间”操作，并根据 Cubby 历史记录的实际磁盘占用显示准确的存储用量
+
+### 变更
+- 在完整截图按保留规则过期后，继续保留识别文本和可搜索缩略图
+- 在捕获时保存 OCR 单词位置，使图片搜索结果无需重新识别即可高亮匹配内容
+- 加强敏感内容隐私保护、剪贴板监听恢复能力和富剪贴板格式兼容性测试
+- 通过适用于 Microsoft 认证的 Cloudflare R2 直链发布不可变的 Store 安装包
+
 ## v1.2.1
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cubby-clipboard",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A native-feeling clipboard history replacement for Windows 11",
   "license": "GPL-3.0",
   "type": "module",

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -9,6 +9,7 @@ const read = (relativePath) => readFile(new URL(relativePath, root), 'utf8');
 const [
   packageText,
   tauriText,
+  storeTauriText,
   cargoText,
   changelog,
   releaseWorkflow,
@@ -24,6 +25,7 @@ const [
 ] = await Promise.all([
   read('package.json'),
   read('src-tauri/tauri.conf.json'),
+  read('src-tauri/tauri.store.conf.json'),
   read('src-tauri/Cargo.toml'),
   read('CHANGELOG.md'),
   read('.github/workflows/release.yml'),
@@ -40,6 +42,7 @@ const [
 
 const packageVersion = JSON.parse(packageText).version;
 const tauriConfig = JSON.parse(tauriText);
+const storeTauriConfig = JSON.parse(storeTauriText);
 const capability = JSON.parse(capabilityText);
 const cargoVersion = cargoText.match(/^version = "([^"]+)"/m)?.[1];
 const versions = new Map([
@@ -63,6 +66,24 @@ if (!changelogHeading.test(changelog)) {
 
 if (JSON.stringify(tauriConfig.bundle.targets) !== JSON.stringify(['nsis'])) {
   throw new Error('Release bundles must be limited to the Windows NSIS installer');
+}
+
+if (
+  storeTauriConfig.bundle?.windows?.webviewInstallMode?.type !== 'offlineInstaller'
+) {
+  throw new Error('Microsoft Store installers must embed the offline WebView2 installer');
+}
+
+if (storeTauriConfig.bundle?.createUpdaterArtifacts !== false) {
+  throw new Error('Microsoft Store builds must not generate updater artifacts');
+}
+
+if (!releaseWorkflow.includes('--config src-tauri/tauri.store.conf.json')) {
+  throw new Error('Release workflow must build the Microsoft Store installer with its offline configuration');
+}
+
+if (!releaseWorkflow.includes('--features app-store')) {
+  throw new Error('Microsoft Store builds must disable Cubby self-update and autostart integration');
 }
 
 const csp = tauriConfig.app?.security?.csp;

--- a/scripts/publish-store-installer.ps1
+++ b/scripts/publish-store-installer.ps1
@@ -14,6 +14,7 @@ param(
     [string]$BucketName = "cubby-downloads",
     [string]$DownloadOrigin = "https://downloads.cubbyclipboard.com",
     [string]$WranglerVersion = "4.113.0",
+    [string]$ExpectedSigner = "CN=Brandon South",
     [switch]$SkipPublicVerification
 )
 
@@ -21,11 +22,27 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 $resolvedInstallerPath = (Resolve-Path -LiteralPath $InstallerPath).Path
-$installerName = "Cubby.Clipboard_${Version}_${Architecture}-setup.exe"
+$installerName = "Cubby.Clipboard_${Version}_${Architecture}-Store-setup.exe"
 $hashName = "$installerName.sha256"
 $objectPrefix = "releases/v$Version"
 $localHash = (Get-FileHash -LiteralPath $resolvedInstallerPath -Algorithm SHA256).Hash.ToLowerInvariant()
 $hashPath = Join-Path ([System.IO.Path]::GetTempPath()) "$hashName-$([guid]::NewGuid().ToString('N')).txt"
+
+$installer = Get-Item -LiteralPath $resolvedInstallerPath
+if ($installer.Length -lt 50MB) {
+    throw "Store installer is only $($installer.Length) bytes. Expected an offline installer containing WebView2."
+}
+
+$signature = Get-AuthenticodeSignature -FilePath $resolvedInstallerPath
+if ($signature.Status -ne "Valid") {
+    throw "Store installer Authenticode signature is not valid. Status: $($signature.Status)"
+}
+if ($signature.SignerCertificate.Subject -notlike "*$ExpectedSigner*") {
+    throw "Unexpected Store installer signer: $($signature.SignerCertificate.Subject)"
+}
+if ($null -eq $signature.TimeStamperCertificate) {
+    throw "Store installer is missing an RFC 3161 timestamp."
+}
 
 function Test-R2ObjectRequiresUpload {
     param(

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "cubby"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubby"
-version = "1.2.1"
+version = "1.2.2"
 description = "A native-feeling clipboard history replacement for Windows 11"
 authors = ["SouthForge AI", "PastePaw contributors"]
 license = "GPL-3.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "Cubby Clipboard",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "identifier": "ai.southforge.cubbyclipboard",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.store.conf.json
+++ b/src-tauri/tauri.store.conf.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "createUpdaterArtifacts": false,
+    "windows": {
+      "webviewInstallMode": {
+        "type": "offlineInstaller"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add dedicated x64 and ARM64 Store builds that embed the WebView2 offline runtime
- keep the existing smaller GitHub/Winget installer and portable build unchanged
- sign and publish immutable Store-specific packages to GitHub Releases and Cloudflare R2
- add release checks that prevent future Store builds from reverting to a downloader
- release the accumulated changes as v1.2.2 with bilingual changelog notes

## Why
Microsoft Store policy 10.2.9.3 requires a standalone/offline installer. Tauri's default NSIS configuration uses the WebView2 download bootstrapper, so the current Cubby package would have the same certification issue as Ceiling.

## Validation
- real x64 offline NSIS build: 199.94 MiB
- cargo test --manifest-path src-tauri/Cargo.toml (99 passed)
- pnpm run format:check
- pnpm run release:check
- actionlint
- git diff --check