### PR TITLE
Use Node 22 for R2 publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,8 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          # Wrangler 4.113+ requires Node 22 for R2 publication.
+          node-version: 22
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 


### PR DESCRIPTION
Wrangler 4.113 requires Node 22. The v1.2.2 release successfully built and signed both offline Store installers, then failed only when the Node 20 runner invoked Wrangler for R2 upload. This updates the installer jobs to the supported Node LTS version.

Validation: actionlint and git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release build environment to Node.js 22 for improved compatibility with current publishing tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->