### PR TITLE
Clean up Cubby Store release automation

### DIFF
--- a/.github/workflows/publish-store-packages.yml
+++ b/.github/workflows/publish-store-packages.yml
@@ -6,7 +6,6 @@ on:
       tag:
         description: Existing GitHub release tag to publish to Cloudflare R2
         required: true
-        default: v1.2.1
 
 permissions:
   contents: read
@@ -18,6 +17,11 @@ jobs:
     environment: release
     steps:
       - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          # Wrangler 4.113+ requires Node 22 for R2 publication.
+          node-version: 22
 
       - name: Validate tag and download signed installers
         id: release
@@ -35,15 +39,15 @@ jobs:
           gh release download $env:RELEASE_TAG `
             --repo $env:GITHUB_REPOSITORY `
             --dir release-assets `
-            --pattern "Cubby.Clipboard_${version}_x64-setup.exe" `
-            --pattern "Cubby.Clipboard_${version}_arm64-setup.exe"
+            --pattern "Cubby.Clipboard_${version}_x64-Store-setup.exe" `
+            --pattern "Cubby.Clipboard_${version}_arm64-Store-setup.exe"
           if ($LASTEXITCODE -ne 0) {
             throw "Failed to download signed installers from $env:RELEASE_TAG."
           }
 
           $expectedSignerSubject = "CN=Brandon South, O=Brandon South, L=Wilmore, S=ky, C=US"
           foreach ($architecture in @("x64", "arm64")) {
-            $installerPath = "release-assets/Cubby.Clipboard_${version}_${architecture}-setup.exe"
+            $installerPath = "release-assets/Cubby.Clipboard_${version}_${architecture}-Store-setup.exe"
             $signature = Get-AuthenticodeSignature -LiteralPath $installerPath
             if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
               throw "$architecture installer has an invalid Authenticode signature: $($signature.StatusMessage)"
@@ -65,7 +69,7 @@ jobs:
           ./scripts/publish-store-installer.ps1 `
             -Version "${{ steps.release.outputs.version }}" `
             -Architecture x64 `
-            -InstallerPath "release-assets/Cubby.Clipboard_${{ steps.release.outputs.version }}_x64-setup.exe" `
+            -InstallerPath "release-assets/Cubby.Clipboard_${{ steps.release.outputs.version }}_x64-Store-setup.exe" `
             -BucketName $env:CLOUDFLARE_R2_BUCKET
 
       - name: Publish ARM64 installer
@@ -78,5 +82,5 @@ jobs:
           ./scripts/publish-store-installer.ps1 `
             -Version "${{ steps.release.outputs.version }}" `
             -Architecture arm64 `
-            -InstallerPath "release-assets/Cubby.Clipboard_${{ steps.release.outputs.version }}_arm64-setup.exe" `
+            -InstallerPath "release-assets/Cubby.Clipboard_${{ steps.release.outputs.version }}_arm64-Store-setup.exe" `
             -BucketName $env:CLOUDFLARE_R2_BUCKET

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,9 @@ Always be truthful and face problems directly. Never fabricate, obscure, or work
 - Never claim something is working unless it has been confirmed to work.
 
 ### Changelog
-CHANGELOG.md includes both English and Chinese entries for every version. Always add both when writing a new version section.
+Write new Cubby changelog entries and public release notes in English. Historical
+Chinese entries inherited from the fork remain for attribution, but do not add
+translations unless Cubby explicitly ships and supports that locale.
 
 ### Worktrees
 Create task worktrees under `../.worktrees/<task-name>`, never beside the repo in the projects root. Sibling worktrees (`cubby-clipboard-<task>`) bury the real projects in a long directory listing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,6 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - Strengthen sensitive-content privacy gates, clipboard listener recovery, and rich clipboard-format compatibility coverage
 - Publish immutable Store packages through direct Cloudflare R2 URLs suitable for Microsoft certification
 
-### 新增
-- 为 x64 和 ARM64 提供独立签名的 Microsoft Store 安装程序，内置 WebView2 并支持完全离线安装，同时保留较小的 GitHub 和 Winget 安装程序
-- 新增“回收空间”操作，并根据 Cubby 历史记录的实际磁盘占用显示准确的存储用量
-
-### 变更
-- 在完整截图按保留规则过期后，继续保留识别文本和可搜索缩略图
-- 在捕获时保存 OCR 单词位置，使图片搜索结果无需重新识别即可高亮匹配内容
-- 加强敏感内容隐私保护、剪贴板监听恢复能力和富剪贴板格式兼容性测试
-- 通过适用于 Microsoft 认证的 Cloudflare R2 直链发布不可变的 Store 安装包
-
 ## v1.2.1
 
 ### Fixed

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -14,7 +14,9 @@ environment must define:
 Tag releases upload and verify both signed installers automatically. To backfill
 an existing GitHub release, run the `Publish Microsoft Store packages` workflow
 with its version tag. Submit the resulting immutable x64 and ARM64 URLs to
-Microsoft Partner Center.
+Microsoft Partner Center. Publishing a GitHub tag or uploading to R2 does not
+update the Store listing: each new version still needs a Partner Center
+submission, either manually or through Microsoft's MSI/EXE submission API.
 
 ## Automated gate
 


### PR DESCRIPTION
## Summary
- keep new Cubby changelog entries and public release notes English-only
- remove the accidental Chinese translation from the v1.2.2 changelog entry while retaining historical fork translations
- repair the manual R2 backfill workflow to download the signed offline Store packages
- run Wrangler on Node 22 and remove the stale hard-coded release tag default
- document that R2 publication does not update Partner Center automatically

## Root causes
Cubby's repository instructions incorrectly required every new release changelog to include English and Chinese even though Cubby currently ships in English. Separately, the backfill workflow still referenced the old slim installer filenames after Store-specific offline packages were introduced.

## Validation
- public v1.2.2 GitHub release notes corrected to English-only
- actionlint
- node scripts/check-release.mjs
- git diff --check