### PR TITLE
Fix immutable R2 package checks

### DIFF
--- a/scripts/publish-store-installer.ps1
+++ b/scripts/publish-store-installer.ps1
@@ -53,27 +53,22 @@ function Test-R2ObjectRequiresUpload {
         [string]$Path
     )
 
-    $accountId = $env:CLOUDFLARE_ACCOUNT_ID
-    $apiToken = $env:CLOUDFLARE_API_TOKEN
-    if ([string]::IsNullOrWhiteSpace($accountId) -or [string]::IsNullOrWhiteSpace($apiToken)) {
-        throw "CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required to check immutable R2 objects."
-    }
-
     $objectKey = "$objectPrefix/$ObjectName"
-    $objectUrl = "https://api.cloudflare.com/client/v4/accounts/$accountId/r2/buckets/$BucketName/objects/$objectKey"
+    $origin = $DownloadOrigin.TrimEnd('/')
+    $encodedObjectName = [uri]::EscapeDataString($ObjectName)
+    $objectUrl = "$origin/$objectPrefix/$encodedObjectName"
+    $probeUrl = "$objectUrl`?immutable-probe=$([guid]::NewGuid().ToString('N'))"
     $probePath = Join-Path ([System.IO.Path]::GetTempPath()) "cubby-r2-probe-$([guid]::NewGuid().ToString('N'))"
     try {
         $statusCode = & curl.exe `
             --silent `
             --show-error `
-            --location `
             --max-redirs 0 `
             --connect-timeout 10 `
-            --max-time 60 `
-            --header "Authorization: Bearer $apiToken" `
+            --max-time 180 `
             --output $probePath `
             --write-out "%{http_code}" `
-            $objectUrl
+            $probeUrl
         if ($LASTEXITCODE -ne 0) {
             throw "Could not check whether $objectUrl already exists."
         }
@@ -83,7 +78,7 @@ function Test-R2ObjectRequiresUpload {
             if ($existingHash -ne $candidateHash) {
                 throw "Refusing to overwrite immutable release object with different bytes: $objectKey"
             }
-            Write-Output "Immutable release object already has the expected bytes; skipping upload: $objectKey"
+            Write-Host "Immutable release object already has the expected bytes; skipping upload: $objectKey"
             return $false
         }
         if ($statusCode -ne "404") {


### PR DESCRIPTION
## Summary
- probe immutable Store packages through their real public R2 URLs instead of an unsupported Cloudflare REST object route
- cache-bust the probe while still rejecting redirects
- return a clean Boolean from the PowerShell probe so matching objects are actually skipped
- continue refusing to overwrite a versioned object when its existing hash differs

## Root cause
The old REST probe returned 404 for existing R2 objects. After switching to the public URL, an informational Write-Output still polluted the function's Boolean return and made a successful match truthy, so the upload path continued.

## Validation
- PowerShell parser
- node scripts/check-release.mjs
- git diff --check
- live signed v1.2.2 x64 validation: installer and SHA sidecar both reported matching immutable bytes and skipped upload; direct public download verification passed