### PR TITLE
Highlight matched OCR words on image search results (SOU-242 phase 2)

### DIFF
--- a/frontend/src/components/ClipCard.tsx
+++ b/frontend/src/components/ClipCard.tsx
@@ -116,6 +116,12 @@ export const ClipCard = memo(function ClipCard({
     formatBytes(imageMetadata.size_bytes),
   ].filter(Boolean);
   const isCompact = density === 'compact';
+  const highlights = clip.ocr_highlights ?? null;
+  const showHighlights = !!(imageSrc && highlights && highlights.boxes.length > 0);
+  // Aspect of the fixed thumbnail box; used to letterbox a highlighted image to
+  // its true aspect so the overlay rectangles line up in both densities.
+  const thumbAspect = isCompact ? 92 / 52 : 120 / 68;
+  const imageIsWide = highlights ? highlights.aspect >= thumbAspect : true;
 
   return (
     <article
@@ -171,20 +177,50 @@ export const ClipCard = memo(function ClipCard({
           <div className="flex min-w-0 items-center gap-3">
             <div
               className={clsx(
-                'relative shrink-0 overflow-hidden rounded-lg border border-white/10 bg-black/20',
+                'relative flex shrink-0 items-center justify-center overflow-hidden rounded-lg border border-white/10 bg-black/20',
                 isCompact ? 'h-[52px] w-[92px]' : 'h-[68px] w-[120px]'
               )}
             >
-              {imageSrc ? (
+              {!imageSrc ? (
+                <div className="flex h-full items-center justify-center">
+                  <ImageIcon size={20} className="text-muted-foreground" />
+                </div>
+              ) : showHighlights && highlights ? (
+                // Letterbox to the image's true aspect so the matched-word boxes
+                // (stored as fractions of the image) map straight to percentages
+                // here — nothing is cropped, so every match stays visible.
+                <div
+                  className={clsx('relative overflow-hidden', imageIsWide ? 'w-full' : 'h-full')}
+                  style={{ aspectRatio: String(highlights.aspect) }}
+                >
+                  <img
+                    src={imageSrc}
+                    alt=""
+                    className={clsx(
+                      'h-full w-full object-cover',
+                      clip.image_expired && 'opacity-60'
+                    )}
+                  />
+                  {highlights.boxes.map((box, index) => (
+                    <div
+                      key={index}
+                      data-el="ocr-highlight"
+                      className="pointer-events-none absolute rounded-[1px] bg-primary/30 ring-1 ring-primary/70"
+                      style={{
+                        left: `${box.x * 100}%`,
+                        top: `${box.y * 100}%`,
+                        width: `${box.width * 100}%`,
+                        height: `${box.height * 100}%`,
+                      }}
+                    />
+                  ))}
+                </div>
+              ) : (
                 <img
                   src={imageSrc}
                   alt=""
                   className={clsx('h-full w-full object-cover', clip.image_expired && 'opacity-60')}
                 />
-              ) : (
-                <div className="flex h-full items-center justify-center">
-                  <ImageIcon size={20} className="text-muted-foreground" />
-                </div>
               )}
               {clip.image_expired && (
                 <div

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -11,6 +11,9 @@ export interface ClipboardItem {
   metadata: string | null;
   has_ocr_text?: boolean;
   ocr_match: OcrMatch | null;
+  // Matched OCR word boxes to highlight on an image search result (SOU-242
+  // phase 2). Present only for image results whose OCR text matched the query.
+  ocr_highlights?: OcrHighlights | null;
   // Retention dropped this image's full-resolution blob but kept its thumbnail
   // and OCR text (SOU-244). It stays searchable; the full image can't be pasted.
   image_expired?: boolean;
@@ -20,6 +23,20 @@ export interface OcrMatch {
   before: string;
   matched: string;
   after: string;
+}
+
+export interface OcrHighlights {
+  // Image width/height ratio, so the thumbnail can be letterboxed to that shape.
+  aspect: number;
+  // Rectangles as fractions (0..1) of the image dimensions.
+  boxes: OcrRect[];
+}
+
+export interface OcrRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
 }
 
 export interface FolderItem {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,5 +1,5 @@
 use crate::database::Database;
-use crate::models::{Clip, ClipboardItem, Folder, FolderItem, OcrMatch};
+use crate::models::{Clip, ClipboardItem, Folder, FolderItem, OcrHighlights, OcrMatch, OcrRect};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use clipboard_rs::common::RustImage;
 use clipboard_rs::{Clipboard, ClipboardContent, ClipboardContext, RustImageData};
@@ -32,8 +32,53 @@ fn clip_to_list_item(clip: &Clip) -> ClipboardItem {
             .as_deref()
             .is_some_and(|text| !text.trim().is_empty()),
         ocr_match: None,
+        ocr_highlights: None,
         image_expired: clip.full_image_expired,
     }
+}
+
+/// Build the highlight overlay for an image search result: the word boxes whose
+/// text matches the query, expressed as fractions of the image plus its aspect
+/// ratio (SOU-242 phase 2). Returns None when nothing usable matches.
+fn build_ocr_highlights(ocr_words_json: &str, query: &str) -> Option<OcrHighlights> {
+    let tokens: Vec<String> = query
+        .split_whitespace()
+        .filter(|token| token.chars().count() >= 2)
+        .map(|token| token.to_lowercase())
+        .collect();
+    if tokens.is_empty() {
+        return None;
+    }
+
+    let layout: crate::ocr::OcrLayout = serde_json::from_str(ocr_words_json).ok()?;
+    if layout.image_width == 0 || layout.image_height == 0 {
+        return None;
+    }
+    let width = layout.image_width as f32;
+    let height = layout.image_height as f32;
+
+    let boxes: Vec<OcrRect> = layout
+        .words
+        .iter()
+        .filter(|word| {
+            let lowered = word.text.to_lowercase();
+            tokens.iter().any(|token| lowered.contains(token))
+        })
+        .map(|word| OcrRect {
+            x: (word.x / width).clamp(0.0, 1.0),
+            y: (word.y / height).clamp(0.0, 1.0),
+            width: (word.width / width).clamp(0.0, 1.0),
+            height: (word.height / height).clamp(0.0, 1.0),
+        })
+        .collect();
+
+    if boxes.is_empty() {
+        return None;
+    }
+    Some(OcrHighlights {
+        aspect: width / height,
+        boxes,
+    })
 }
 
 const OCR_SNIPPET_CHAR_LIMIT: usize = 96;
@@ -158,6 +203,10 @@ fn clip_to_search_item(clip: &Clip, query: &str) -> ClipboardItem {
             .ocr_text
             .as_deref()
             .and_then(|text| build_ocr_match(text, query));
+        item.ocr_highlights = clip
+            .ocr_words
+            .as_deref()
+            .and_then(|words| build_ocr_highlights(words, query));
     }
     item
 }
@@ -171,6 +220,14 @@ fn decrypt_clip_fields(db: &Database, clip: &mut Clip) -> Result<(), String> {
     // OCR text is auxiliary; never let a bad value block loading the clip.
     if db.crypto.decrypt_optional_text(&mut clip.ocr_text).is_err() {
         clip.ocr_text = None;
+    }
+    // OCR word boxes are likewise auxiliary (highlighting only).
+    if db
+        .crypto
+        .decrypt_optional_text(&mut clip.ocr_words)
+        .is_err()
+    {
+        clip.ocr_words = None;
     }
     Ok(())
 }
@@ -1764,10 +1821,10 @@ pub async fn import_from_ditto(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_ocr_match, clear_clips_in_pool, clipboard_contents_for_restore, directory_size_bytes,
-        enforce_retention_in_pool, load_recognized_text, migrate_clip_format_model,
-        migrate_encrypted_storage, remove_clip_image_files, restore_hash_material,
-        search_clips_in_database, toggle_clip_pin_in_pool, ClipboardContent,
+        build_ocr_highlights, build_ocr_match, clear_clips_in_pool, clipboard_contents_for_restore,
+        directory_size_bytes, enforce_retention_in_pool, load_recognized_text,
+        migrate_clip_format_model, migrate_encrypted_storage, remove_clip_image_files,
+        restore_hash_material, search_clips_in_database, toggle_clip_pin_in_pool, ClipboardContent,
         OCR_SNIPPET_CHAR_LIMIT,
     };
     use crate::clipboard::CapturedFormat;
@@ -2183,6 +2240,7 @@ mod tests {
             source_icon: None,
             metadata: None,
             ocr_text: None,
+            ocr_words: None,
             full_image_expired: false,
             created_at: chrono::Utc::now(),
             last_accessed: chrono::Utc::now(),
@@ -2552,5 +2610,56 @@ mod tests {
         assert_eq!(directory_size_bytes(&missing), 0);
 
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn ocr_highlights_selects_matching_words_as_image_fractions() {
+        use crate::ocr::{OcrLayout, OcrWordBox};
+        let layout = OcrLayout {
+            image_width: 100,
+            image_height: 50,
+            words: vec![
+                OcrWordBox {
+                    text: "Error".to_string(),
+                    x: 10.0,
+                    y: 5.0,
+                    width: 40.0,
+                    height: 10.0,
+                },
+                OcrWordBox {
+                    text: "Denied".to_string(),
+                    x: 60.0,
+                    y: 5.0,
+                    width: 30.0,
+                    height: 10.0,
+                },
+                OcrWordBox {
+                    text: "Ok".to_string(),
+                    x: 0.0,
+                    y: 30.0,
+                    width: 10.0,
+                    height: 8.0,
+                },
+            ],
+        };
+        let json = serde_json::to_string(&layout).expect("layout should serialize");
+
+        // Single-token, case-insensitive: one matched box, coordinates as fractions.
+        let hits = build_ocr_highlights(&json, "error").expect("should match a word");
+        assert_eq!(hits.aspect, 2.0);
+        assert_eq!(hits.boxes.len(), 1);
+        let rect = &hits.boxes[0];
+        assert!((rect.x - 0.10).abs() < 1e-6);
+        assert!((rect.y - 0.10).abs() < 1e-6);
+        assert!((rect.width - 0.40).abs() < 1e-6);
+        assert!((rect.height - 0.20).abs() < 1e-6);
+
+        // Every word matching any query token is highlighted.
+        let multi = build_ocr_highlights(&json, "error denied").expect("should match two words");
+        assert_eq!(multi.boxes.len(), 2);
+
+        // No matching word, and too-short tokens, both yield nothing.
+        assert!(build_ocr_highlights(&json, "zzz").is_none());
+        assert!(build_ocr_highlights(&json, "a").is_none());
     }
 }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -88,6 +88,9 @@ pub struct Clip {
     pub source_icon: Option<String>,
     pub metadata: Option<String>,
     pub ocr_text: Option<String>,
+    // Encrypted JSON of the OCR word layout (boxes + reference dimensions) for
+    // image clips (SOU-242). Used to highlight matched words on search results.
+    pub ocr_words: Option<String>,
     // True once retention has dropped this image clip's full-resolution blob but
     // kept its thumbnail + ocr_text (SOU-244). Only ever set for `image` clips.
     pub full_image_expired: bool,
@@ -112,6 +115,7 @@ impl<'r> FromRow<'r, SqliteRow> for Clip {
             source_icon: row.try_get("source_icon")?,
             metadata: row.try_get("metadata")?,
             ocr_text: row.try_get("ocr_text")?,
+            ocr_words: row.try_get("ocr_words")?,
             full_image_expired: row.try_get("full_image_expired")?,
             created_at: row.try_get("created_at")?,
             last_accessed: row.try_get("last_accessed")?,
@@ -173,6 +177,9 @@ pub struct ClipboardItem {
     pub metadata: Option<String>,
     pub has_ocr_text: bool,
     pub ocr_match: Option<OcrMatch>,
+    // Word boxes to highlight on an image search result whose OCR text matched
+    // the query (SOU-242 phase 2). None for non-image or non-matching results.
+    pub ocr_highlights: Option<OcrHighlights>,
     // True when this image's full-resolution blob was dropped by retention but
     // its thumbnail + OCR text were kept (SOU-244). The UI marks it and stops
     // offering the full image for paste/copy.
@@ -184,6 +191,25 @@ pub struct OcrMatch {
     pub before: String,
     pub matched: String,
     pub after: String,
+}
+
+/// Matched OCR word boxes for one image search result, ready to render as an
+/// overlay. `boxes` are fractions of the image (0..1); `aspect` is the image's
+/// width/height so the frontend can letterbox the thumbnail to that shape and
+/// place the rects with plain percentages.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OcrHighlights {
+    pub aspect: f32,
+    pub boxes: Vec<OcrRect>,
+}
+
+/// One highlight rectangle, as fractions of the image dimensions (0..1).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OcrRect {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Phase 2 of SOU-242, building on the phase 1 box capture (#83).

When a search matches an image's OCR text, Cubby now draws highlight rectangles over the matched words on the thumbnail — "search a word, see it lit up inside a screenshot from weeks ago."

## Changes
- **Backend** (`commands.rs`, `models.rs`): read back the encrypted `ocr_words` (new `Clip` field + best-effort decrypt mirroring `ocr_text`), and in the search path compute which word boxes match the query tokens. Delivered as **fractions of the image** (0..1) plus the image **aspect ratio** via a new `ClipboardItem.ocr_highlights`. The word *text* is never sent to the UI — only geometry.
- **Frontend** (`ClipCard.tsx`, `types`): a matched image result renders **letterboxed to its true aspect** so nothing is cropped off-frame, with `bg-primary/30` + ring rectangles positioned straight from the fractions (the wrapper *is* the image rect, so no cover/contain math). Normal (non-search) list images are unchanged.

## Design notes
- Highlights are computed **independently of the text snippet** (`ocr_match`), so an image that matched via the trigram index still lights up its words even when a clean contiguous snippet can't be formed.
- Works on **retention-expired (text-only) images** too — their thumbnail + boxes survive SOU-244 pruning, so you can still see *where* a match was.
- This is why phase 1 stored the OCR-image **dimensions**: the boxes are in that space, and the aspect lets the frontend place them without re-OCR.

## Scope
- Overlay is on the existing thumbnail only (the issue's "image preview"). A hover/enlarged view for legibility on the small thumbnail is a possible follow-up, not included here.

## Test
`build_ocr_highlights` selects matching words as image fractions, handles multi-token queries, and returns `None` for no-match / too-short tokens.

Verified locally: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test`, `tsc`, `prettier --check`, `pnpm run build`.