### PR TITLE
Forget clips when clipboard is auto-cleared (SOU-316)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -114,6 +114,7 @@ function App() {
         ignore_ghost_clips: true,
         skip_sensitive: true,
         skip_likely_secrets: false,
+        forget_on_clipboard_clear: true,
         has_completed_onboarding: true,
       });
       return;

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -1050,6 +1050,22 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
                         }
                       />
                       <Row
+                        title={t('settings.forgetOnClipboardClear')}
+                        desc={t('settings.forgetOnClipboardClearDesc')}
+                        control={
+                          <Toggle
+                            checked={settings.forget_on_clipboard_clear ?? true}
+                            onChange={() =>
+                              updateSetting(
+                                'forget_on_clipboard_clear',
+                                !(settings.forget_on_clipboard_clear ?? true)
+                              )
+                            }
+                            label={t('settings.forgetOnClipboardClear')}
+                          />
+                        }
+                      />
+                      <Row
                         title={t('settings.ignoreGhostClips')}
                         desc={t('settings.ignoreGhostClipsDesc')}
                         control={

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -66,6 +66,8 @@
     "roundCornersDesc": "Abgerundete Ecken für das Cubby-Fenster verwenden.",
     "ignoreGhostClips": "Geistereinträge ignorieren",
     "ignoreGhostClipsDesc": "Temporäre Zwischenablageeinträge ignorieren",
+    "forgetOnClipboardClear": "Gelöschte Kopien vergessen",
+    "forgetOnClipboardClearDesc": "Wenn etwas die Zwischenablage kurz nach dem Kopieren leert (typisch für Passwort-Manager-Erweiterungen), wird der letzte Eintrag aus dem Verlauf entfernt. Nur leere Clear-Events, kein normales nächstes Kopieren. Angeheftete bleiben.",
     "hotkey": "Globale Tastenkombination",
     "hotkeyDesc": "Tastenkombination zum Anzeigen oder Ausblenden von Cubby",
     "hotkeyRecording": "Tasten drücken...",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -127,6 +127,8 @@
     "skipSensitiveDesc": "When an app such as a password manager marks a copy as sensitive, Cubby won't save it (Windows' own clipboard history does the same). Turn this off to capture everything, including passwords.",
     "skipLikelySecrets": "Skip likely secrets in text",
     "skipLikelySecretsDesc": "Don't save text that looks like API tokens, private keys, or payment card numbers. Off by default. Turn it on if you'd rather keep these out of your history (the matching is conservative, but it can skip a clip you meant to keep).",
+    "forgetOnClipboardClear": "Forget copies the app clears",
+    "forgetOnClipboardClearDesc": "If something clears the clipboard soon after a copy (common for password manager browser extensions), remove that last item from history. Only empty clears count, not the next normal copy. Pinned items stay.",
     "ignoredAppsDesc": "Don't capture clipboard from these apps. Major password managers are added once by default; remove any you want Cubby to capture.",
     "privacy": "Privacy",
     "about": "About",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -66,6 +66,8 @@
     "roundCornersDesc": "Utiliser des coins arrondis pour la fenêtre Cubby.",
     "ignoreGhostClips": "Ignorer les éléments fantômes",
     "ignoreGhostClipsDesc": "Ignorer les éléments temporaires du presse-papiers",
+    "forgetOnClipboardClear": "Oublier les copies effacées",
+    "forgetOnClipboardClearDesc": "Si quelque chose vide le presse-papiers peu après une copie (extensions de gestionnaires de mots de passe), retire ce dernier élément de l'historique. Seuls les effacements vides comptent, pas la copie suivante. Les éléments épinglés restent.",
     "hotkey": "Raccourci global",
     "hotkeyDesc": "Raccourci pour afficher ou masquer Cubby",
     "hotkeyRecording": "Appuyez sur les touches...",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -66,6 +66,8 @@
     "roundCornersDesc": "Cubby ウィンドウに丸い角を使用します。",
     "ignoreGhostClips": "ゴーストクリップを無視",
     "ignoreGhostClipsDesc": "一時的なクリップボード項目を無視します",
+    "forgetOnClipboardClear": "クリアされたコピーを忘れる",
+    "forgetOnClipboardClearDesc": "コピー直後にクリップボードが空にされた場合（パスワードマネージャーの拡張機能など）、その直前の項目を履歴から削除します。空のクリアのみ対象で、次の通常コピーでは削除しません。ピン留めは残ります。",
     "hotkey": "グローバルホットキー",
     "hotkeyDesc": "Cubby を表示または非表示にするショートカット",
     "hotkeyRecording": "キーを押してください...",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -66,6 +66,8 @@
     "roundCornersDesc": "为 Cubby 窗口使用圆角。",
     "ignoreGhostClips": "忽略临时剪贴",
     "ignoreGhostClipsDesc": "忽略临时剪贴板项目",
+    "forgetOnClipboardClear": "忘记被清空的复制",
+    "forgetOnClipboardClearDesc": "若复制后很快清空剪贴板（密码管理器浏览器扩展常见做法），则从历史中删除上一条。仅识别清空，不会因下一次普通复制而删除。已置顶的项目会保留。",
     "hotkey": "全局快捷键",
     "hotkeyDesc": "显示/隐藏 Cubby 的快捷键",
     "hotkeyRecording": "按下按键...",

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -66,6 +66,7 @@ export interface Settings {
   ignore_ghost_clips: boolean;
   skip_sensitive?: boolean;
   skip_likely_secrets?: boolean;
+  forget_on_clipboard_clear?: boolean;
   has_completed_onboarding?: boolean;
 }
 

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -16,7 +16,7 @@ use std::ffi::OsStr;
 use std::os::windows::ffi::OsStrExt;
 use std::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use uuid::Uuid;
 #[cfg(target_os = "windows")]
 use windows::Win32::Foundation::MAX_PATH;
@@ -52,8 +52,30 @@ static IGNORE_HASH: Lazy<parking_lot::Mutex<Option<String>>> =
     Lazy::new(|| parking_lot::Mutex::new(None));
 static LAST_STABLE_HASH: Lazy<parking_lot::Mutex<Option<String>>> =
     Lazy::new(|| parking_lot::Mutex::new(None));
+/// Most recent accepted capture, used to forget extension password copies when
+/// the clipboard is auto-cleared shortly afterward (SOU-316).
+static LAST_ACCEPTED_CAPTURE: Lazy<parking_lot::Mutex<Option<RecentCapture>>> =
+    Lazy::new(|| parking_lot::Mutex::new(None));
 pub static CLIPBOARD_SYNC: Lazy<Arc<tokio::sync::Mutex<()>>> =
     Lazy::new(|| Arc::new(tokio::sync::Mutex::new(())));
+
+/// Password-manager extensions typically clear within tens of seconds. Keep this
+/// short so a deliberate later clear does not erase an intentional keep.
+const CLIPBOARD_CLEAR_FORGET_WINDOW: Duration = Duration::from_secs(90);
+
+#[derive(Clone, Debug)]
+struct RecentCapture {
+    uuid: String,
+    captured_at: Instant,
+}
+
+/// Pure helper for SOU-316 unit tests: only empty clears within the window
+/// forget the last clip. A later clear must leave history alone.
+fn should_forget_recent_capture(captured_at: Instant, cleared_at: Instant, window: Duration) -> bool {
+    cleared_at
+        .checked_duration_since(captured_at)
+        .is_some_and(|elapsed| elapsed <= window)
+}
 
 /// Capture-listener health (SOU-218). Values are diagnostics only — never clipboard content.
 ///
@@ -146,21 +168,37 @@ pub fn get_clipboard_capture_status() -> ClipboardCaptureStatus {
 
 pub fn init(app: &AppHandle, db: Arc<Database>) {
     crate::ocr_queue::init(app.clone(), db.clone());
-    let (snapshot_tx, mut snapshot_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
     let app_for_consumer = app.clone();
     let db_for_consumer = db.clone();
 
     tauri::async_runtime::spawn(async move {
-        while let Some(snapshot) = snapshot_rx.recv().await {
-            process_clipboard_snapshot(app_for_consumer.clone(), db_for_consumer.clone(), snapshot)
-                .await;
+        while let Some(event) = event_rx.recv().await {
+            match event {
+                ClipboardListenerEvent::Content(snapshot) => {
+                    process_clipboard_snapshot(
+                        app_for_consumer.clone(),
+                        db_for_consumer.clone(),
+                        snapshot,
+                    )
+                    .await;
+                }
+                ClipboardListenerEvent::Cleared { sequence } => {
+                    process_clipboard_clear(
+                        app_for_consumer.clone(),
+                        db_for_consumer.clone(),
+                        sequence,
+                    )
+                    .await;
+                }
+            }
         }
         log::error!("CLIPBOARD: Native snapshot queue closed unexpectedly");
     });
 
     std::thread::Builder::new()
         .name("cubby-clipboard-listener".to_string())
-        .spawn(move || run_native_listener(snapshot_tx))
+        .spawn(move || run_native_listener(event_tx))
         .unwrap_or_else(|error| panic!("failed to start native clipboard listener: {error}"));
 }
 
@@ -212,6 +250,12 @@ struct ClipboardSnapshot {
     /// The source application tagged this copy as sensitive (e.g. a password
     /// manager) so clipboard monitors should skip it. See `clipboard_marked_sensitive`.
     sensitive: bool,
+}
+
+enum ClipboardListenerEvent {
+    Content(ClipboardSnapshot),
+    /// Clipboard became empty (or empty-text) after a sequence advance.
+    Cleared { sequence: u32 },
 }
 
 /// Returns true when the current clipboard contents are tagged with the
@@ -304,12 +348,12 @@ fn spawn_listener_watchdog() {
 #[cfg(target_os = "windows")]
 fn run_listener_session(
     monitor: &mut Monitor,
-    snapshot_tx: &tokio::sync::mpsc::UnboundedSender<ClipboardSnapshot>,
+    event_tx: &tokio::sync::mpsc::UnboundedSender<ClipboardListenerEvent>,
 ) -> ListenerSessionExit {
     loop {
         match monitor.recv() {
             Ok(true) => {
-                let started = std::time::Instant::now();
+                let started = Instant::now();
                 let sequence =
                     unsafe { windows::Win32::System::DataExchange::GetClipboardSequenceNumber() };
                 // Always mark the notification as seen, even when the payload is
@@ -330,7 +374,20 @@ fn run_listener_session(
                         sensitive,
                     };
 
-                    if snapshot_tx.send(snapshot).is_err() {
+                    if event_tx
+                        .send(ClipboardListenerEvent::Content(snapshot))
+                        .is_err()
+                    {
+                        return ListenerSessionExit::ConsumerGone;
+                    }
+                } else if clipboard_is_cleared() {
+                    // Empty clipboard (or empty text with no image/files). This is
+                    // the password-manager auto-clear signal; never treat a new
+                    // non-empty copy as a clear.
+                    if event_tx
+                        .send(ClipboardListenerEvent::Cleared { sequence })
+                        .is_err()
+                    {
                         return ListenerSessionExit::ConsumerGone;
                     }
                 } else {
@@ -346,6 +403,61 @@ fn run_listener_session(
     }
 }
 
+/// True when the clipboard is empty or only holds empty text (and no image/files).
+/// Returns false when the clipboard cannot be opened (contention) so we never
+/// treat a lock miss as an auto-clear.
+fn clipboard_is_cleared() -> bool {
+    const ATTEMPTS: u32 = 5;
+
+    for attempt in 0..ATTEMPTS {
+        if let Ok(ctx) = ClipboardContext::new() {
+            if let Ok(files) = ctx.get_files() {
+                if !files.is_empty() {
+                    return false;
+                }
+            }
+            if ctx.get_image().is_ok() {
+                return false;
+            }
+            match ctx.get_text() {
+                Ok(text) if !text.is_empty() => return false,
+                Ok(_) => return true,
+                Err(_) => {
+                    // No readable text. If there are no formats at all, it is a clear;
+                    // otherwise something unsupported/custom remains — leave it alone.
+                    return clipboard_format_count_is_zero();
+                }
+            }
+        }
+
+        if attempt + 1 < ATTEMPTS {
+            std::thread::sleep(clipboard_retry_delay(attempt));
+        }
+    }
+
+    false
+}
+
+#[cfg(target_os = "windows")]
+fn clipboard_format_count_is_zero() -> bool {
+    use windows::Win32::System::DataExchange::{
+        CloseClipboard, CountClipboardFormats, OpenClipboard,
+    };
+
+    let opened = unsafe { OpenClipboard(None) };
+    if opened.is_err() {
+        return false;
+    }
+    let count = unsafe { CountClipboardFormats() };
+    let _ = unsafe { CloseClipboard() };
+    count == 0
+}
+
+#[cfg(not(target_os = "windows"))]
+fn clipboard_format_count_is_zero() -> bool {
+    true
+}
+
 /// Supervise the native clipboard listener so capture never silently stops.
 ///
 /// Tradeoffs (SOU-218):
@@ -356,7 +468,7 @@ fn run_listener_session(
 ///   surface area and toast spam.
 /// - Consumer channel close stops the supervisor (process teardown).
 #[cfg(target_os = "windows")]
-fn run_native_listener(snapshot_tx: tokio::sync::mpsc::UnboundedSender<ClipboardSnapshot>) {
+fn run_native_listener(event_tx: tokio::sync::mpsc::UnboundedSender<ClipboardListenerEvent>) {
     spawn_listener_watchdog();
 
     let mut backoff = INITIAL_LISTENER_BACKOFF;
@@ -384,7 +496,7 @@ fn run_native_listener(snapshot_tx: tokio::sync::mpsc::UnboundedSender<Clipboard
         set_capture_state(CAPTURE_STATE_LISTENING);
         log::info!("CLIPBOARD: Native WM_CLIPBOARDUPDATE listener started");
 
-        let exit = run_listener_session(&mut monitor, &snapshot_tx);
+        let exit = run_listener_session(&mut monitor, &event_tx);
         *LISTENER_SHUTDOWN.lock() = None;
         drop(monitor);
 
@@ -413,7 +525,7 @@ fn run_native_listener(snapshot_tx: tokio::sync::mpsc::UnboundedSender<Clipboard
 }
 
 #[cfg(not(target_os = "windows"))]
-fn run_native_listener(_snapshot_tx: tokio::sync::mpsc::UnboundedSender<ClipboardSnapshot>) {
+fn run_native_listener(_event_tx: tokio::sync::mpsc::UnboundedSender<ClipboardListenerEvent>) {
     set_capture_state(CAPTURE_STATE_STOPPED);
     record_capture_error("clipboard capture requires Windows");
 }
@@ -1009,7 +1121,13 @@ async fn process_clipboard_snapshot(
             .upsert(&emitted_id, clip_type, &clip_content, &clip_preview, None);
     }
 
-    let emit_started = std::time::Instant::now();
+    // Remember this capture so a short-lived auto-clear can forget it (SOU-316).
+    *LAST_ACCEPTED_CAPTURE.lock() = Some(RecentCapture {
+        uuid: emitted_id.clone(),
+        captured_at: Instant::now(),
+    });
+
+    let emit_started = Instant::now();
     let _ = app.emit(
         "clipboard-change",
         &serde_json::json!({
@@ -1035,6 +1153,135 @@ async fn process_clipboard_snapshot(
         db_write_ms,
         emit_ms,
         started.elapsed().as_millis()
+    );
+}
+
+/// Forget the last capture when the clipboard is cleared shortly afterward.
+///
+/// Password-manager browser extensions copy into chrome.exe/msedge.exe (so the
+/// ignored-apps list cannot help) and almost always empty the clipboard a few
+/// seconds later. Only empty/clear events trigger this — never a new non-empty
+/// copy. Pinned items are never removed.
+async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u32) {
+    use crate::settings_manager::SettingsManager;
+    use tauri::Manager;
+
+    let manager = app.state::<Arc<SettingsManager>>();
+    let settings = manager.get();
+    if !settings.forget_on_clipboard_clear {
+        return;
+    }
+
+    let recent = {
+        let mut lock = LAST_ACCEPTED_CAPTURE.lock();
+        let should_forget = lock.as_ref().is_some_and(|recent| {
+            should_forget_recent_capture(
+                recent.captured_at,
+                Instant::now(),
+                CLIPBOARD_CLEAR_FORGET_WINDOW,
+            )
+        });
+        if should_forget {
+            lock.take()
+        } else {
+            // Outside the window (or nothing tracked): drop any stale marker.
+            lock.take();
+            None
+        }
+    };
+
+    let Some(recent) = recent else {
+        log::debug!(
+            "CLIPBOARD: Clear sequence {} with no recent capture to forget",
+            sequence
+        );
+        return;
+    };
+
+    let _guard = CLIPBOARD_SYNC.lock().await;
+    let pool = &db.pool;
+
+    let row: Option<(i64, i64)> = sqlx::query_as(
+        r#"
+        SELECT is_pinned, is_deleted
+        FROM clips
+        WHERE uuid = ?
+        "#,
+    )
+    .bind(&recent.uuid)
+    .fetch_optional(pool)
+    .await
+    .unwrap_or(None);
+
+    let Some((is_pinned, is_deleted)) = row else {
+        log::debug!(
+            "CLIPBOARD: Clear sequence {} — recent capture {} already gone",
+            sequence,
+            recent.uuid
+        );
+        return;
+    };
+
+    if is_pinned != 0 {
+        log::info!(
+            "CLIPBOARD: Clear sequence {} — keeping pinned capture {}",
+            sequence,
+            recent.uuid
+        );
+        return;
+    }
+    if is_deleted != 0 {
+        return;
+    }
+
+    let mut transaction = match pool.begin().await {
+        Ok(tx) => tx,
+        Err(error) => {
+            log::error!("CLIPBOARD: Failed to begin clear-forget transaction: {error}");
+            return;
+        }
+    };
+
+    let file_path: Option<String> =
+        sqlx::query_scalar(r#"SELECT file_path FROM clip_images WHERE clip_uuid = ?"#)
+            .bind(&recent.uuid)
+            .fetch_optional(&mut *transaction)
+            .await
+            .unwrap_or(None);
+
+    if let Err(error) = sqlx::query(r#"DELETE FROM clips WHERE uuid = ? AND is_pinned = 0"#)
+        .bind(&recent.uuid)
+        .execute(&mut *transaction)
+        .await
+    {
+        log::error!(
+            "CLIPBOARD: Failed to forget cleared capture {}: {error}",
+            recent.uuid
+        );
+        return;
+    }
+
+    if let Err(error) = transaction.commit().await {
+        log::error!("CLIPBOARD: Failed to commit clear-forget for {}: {error}", recent.uuid);
+        return;
+    }
+
+    crate::commands::remove_clip_image_files(&db.image_dir, file_path.into_iter().collect());
+    db.search_index.remove(&recent.uuid);
+
+    log::info!(
+        "CLIPBOARD: Forgot capture {} after clipboard clear (sequence {}, within {}s window)",
+        recent.uuid,
+        sequence,
+        CLIPBOARD_CLEAR_FORGET_WINDOW.as_secs()
+    );
+
+    let _ = app.emit(
+        "clipboard-change",
+        &serde_json::json!({
+            "id": recent.uuid,
+            "forgotten_on_clear": true,
+        }),
     );
 }
 pub(crate) fn calculate_hash(content: &[u8]) -> String {
@@ -1459,10 +1706,49 @@ unsafe fn extract_icon(path: &str) -> Option<String> {
 mod tests {
     use super::{
         calculate_hash, capture_state_name, capture_text, clipboard_retry_delay,
-        next_listener_backoff, CapturedContent, CAPTURE_STATE_LISTENING, CAPTURE_STATE_RESTARTING,
-        CAPTURE_STATE_STOPPED,
+        next_listener_backoff, should_forget_recent_capture, CapturedContent,
+        CAPTURE_STATE_LISTENING, CAPTURE_STATE_RESTARTING, CAPTURE_STATE_STOPPED,
+        CLIPBOARD_CLEAR_FORGET_WINDOW,
     };
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn forget_window_accepts_clears_within_bound() {
+        let captured = Instant::now();
+        let cleared = captured + Duration::from_secs(30);
+        assert!(should_forget_recent_capture(
+            captured,
+            cleared,
+            CLIPBOARD_CLEAR_FORGET_WINDOW
+        ));
+        assert!(should_forget_recent_capture(
+            captured,
+            captured + CLIPBOARD_CLEAR_FORGET_WINDOW,
+            CLIPBOARD_CLEAR_FORGET_WINDOW
+        ));
+    }
+
+    #[test]
+    fn forget_window_rejects_late_clears() {
+        let captured = Instant::now();
+        let cleared = captured + CLIPBOARD_CLEAR_FORGET_WINDOW + Duration::from_millis(1);
+        assert!(!should_forget_recent_capture(
+            captured,
+            cleared,
+            CLIPBOARD_CLEAR_FORGET_WINDOW
+        ));
+    }
+
+    #[test]
+    fn forget_window_rejects_inverted_timestamps() {
+        let captured = Instant::now();
+        let cleared = captured - Duration::from_secs(1);
+        assert!(!should_forget_recent_capture(
+            captured,
+            cleared,
+            CLIPBOARD_CLEAR_FORGET_WINDOW
+        ));
+    }
 
     #[test]
     fn capture_text_preserves_exact_whitespace() {

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -71,7 +71,11 @@ struct RecentCapture {
 
 /// Pure helper for SOU-316 unit tests: only empty clears within the window
 /// forget the last clip. A later clear must leave history alone.
-fn should_forget_recent_capture(captured_at: Instant, cleared_at: Instant, window: Duration) -> bool {
+fn should_forget_recent_capture(
+    captured_at: Instant,
+    cleared_at: Instant,
+    window: Duration,
+) -> bool {
     cleared_at
         .checked_duration_since(captured_at)
         .is_some_and(|elapsed| elapsed <= window)
@@ -255,7 +259,9 @@ struct ClipboardSnapshot {
 enum ClipboardListenerEvent {
     Content(ClipboardSnapshot),
     /// Clipboard became empty (or empty-text) after a sequence advance.
-    Cleared { sequence: u32 },
+    Cleared {
+        sequence: u32,
+    },
 }
 
 /// Returns true when the current clipboard contents are tagged with the
@@ -418,6 +424,18 @@ fn clipboard_is_cleared() -> bool {
             }
             if ctx.get_image().is_ok() {
                 return false;
+            }
+            // Empty plain text must not count as a clear if HTML/RTF still hold
+            // content (materialize can miss those when get_text is empty).
+            if let Ok(html) = ctx.get_html() {
+                if !html.is_empty() {
+                    return false;
+                }
+            }
+            if let Ok(rtf) = ctx.get_rich_text() {
+                if !rtf.is_empty() {
+                    return false;
+                }
             }
             match ctx.get_text() {
                 Ok(text) if !text.is_empty() => return false,
@@ -775,8 +793,15 @@ async fn process_clipboard_snapshot(
     let manager = app.state::<Arc<SettingsManager>>();
     let settings = manager.get();
 
+    // Skipped captures must not leave an older clip as the clear-forget target.
+    // Otherwise: copy note → skip password → auto-clear would delete the note.
+    let discard_clear_target = || {
+        *LAST_ACCEPTED_CAPTURE.lock() = None;
+    };
+
     if settings.skip_sensitive && sensitive {
         log::info!("CLIPBOARD: Skipping content the source app marked as sensitive");
+        discard_clear_target();
         return;
     }
 
@@ -785,6 +810,7 @@ async fn process_clipboard_snapshot(
             if let Some(kind) = crate::secrets::classify_secret(text) {
                 // Category only — never log the matched clipboard bytes.
                 log::info!("CLIPBOARD: Skipping likely secret ({})", kind.as_str());
+                discard_clear_target();
                 return;
             }
         }
@@ -792,6 +818,7 @@ async fn process_clipboard_snapshot(
 
     if settings.ignore_ghost_clips && !is_explicit_owner {
         log::info!("CLIPBOARD: Ignoring ghost clip (unknown owner)");
+        discard_clear_target();
         return;
     }
 
@@ -807,6 +834,7 @@ async fn process_clipboard_snapshot(
     if let Some(ref path) = full_path {
         if is_ignored(path) {
             log::info!("CLIPBOARD: Ignoring content from configured application (path match)");
+            discard_clear_target();
             return;
         }
     }
@@ -816,6 +844,7 @@ async fn process_clipboard_snapshot(
             log::info!(
                 "CLIPBOARD: Ignoring content from configured application (executable match)"
             );
+            discard_clear_target();
             return;
         }
     }
@@ -1198,6 +1227,14 @@ async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u3
         return;
     };
 
+    let restore_marker = |recent: RecentCapture| {
+        let mut lock = LAST_ACCEPTED_CAPTURE.lock();
+        // Only restore if nothing newer was captured while we held the marker.
+        if lock.is_none() {
+            *lock = Some(recent);
+        }
+    };
+
     let _guard = CLIPBOARD_SYNC.lock().await;
     let pool = &db.pool;
 
@@ -1228,6 +1265,8 @@ async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u3
             sequence,
             recent.uuid
         );
+        // Keep tracking so a later clear after unpin is not required; pinned
+        // items stay forever under this policy.
         return;
     }
     if is_deleted != 0 {
@@ -1238,6 +1277,7 @@ async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u3
         Ok(tx) => tx,
         Err(error) => {
             log::error!("CLIPBOARD: Failed to begin clear-forget transaction: {error}");
+            restore_marker(recent);
             return;
         }
     };
@@ -1258,11 +1298,16 @@ async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u3
             "CLIPBOARD: Failed to forget cleared capture {}: {error}",
             recent.uuid
         );
+        restore_marker(recent);
         return;
     }
 
     if let Err(error) = transaction.commit().await {
-        log::error!("CLIPBOARD: Failed to commit clear-forget for {}: {error}", recent.uuid);
+        log::error!(
+            "CLIPBOARD: Failed to commit clear-forget for {}: {error}",
+            recent.uuid
+        );
+        restore_marker(recent);
         return;
     }
 

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -1289,16 +1289,33 @@ async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u3
             .await
             .unwrap_or(None);
 
-    if let Err(error) = sqlx::query(r#"DELETE FROM clips WHERE uuid = ? AND is_pinned = 0"#)
+    // Guarded delete: re-check is_pinned in the same statement so a pin that
+    // lands between the earlier SELECT and this DELETE cannot leave orphan
+    // file/index cleanup for a still-present clip (TOCTOU).
+    let deleted = match sqlx::query(r#"DELETE FROM clips WHERE uuid = ? AND is_pinned = 0"#)
         .bind(&recent.uuid)
         .execute(&mut *transaction)
         .await
     {
-        log::error!(
-            "CLIPBOARD: Failed to forget cleared capture {}: {error}",
+        Ok(result) => result.rows_affected(),
+        Err(error) => {
+            log::error!(
+                "CLIPBOARD: Failed to forget cleared capture {}: {error}",
+                recent.uuid
+            );
+            restore_marker(recent);
+            return;
+        }
+    };
+
+    if deleted == 0 {
+        log::info!(
+            "CLIPBOARD: Clear sequence {} — capture {} not deleted (pinned or already gone)",
+            sequence,
             recent.uuid
         );
-        restore_marker(recent);
+        // No restore: either pinned now or already removed. Either way the
+        // clear-forget target should not fire again for this uuid.
         return;
     }
 

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -32,6 +32,11 @@ pub struct AppSettings {
     // payment cards). Off by default (opt-in): heuristic sniffing can drop a
     // clip the user meant to keep. Never logs matched content when enabled.
     pub skip_likely_secrets: bool,
+    // When the clipboard is cleared shortly after a capture (typical of password
+    // manager browser extensions that auto-clear), forget that last clip. On by
+    // default: closes the browser-extension gap that ignored-apps cannot cover.
+    // Only empty/clear events qualify — a normal next copy never deletes the previous item.
+    pub forget_on_clipboard_clear: bool,
     // True after the built-in password-manager ignore list has been seeded once.
     // Clearing an entry in Settings must stick across restarts.
     pub default_sensitive_apps_seeded: bool,
@@ -66,6 +71,9 @@ impl Default for AppSettings {
             // reliable protections (OS sensitive tag + seeded password-manager
             // ignore list) stay on by default and cover the important cases.
             skip_likely_secrets: false,
+            // Default on: browser-extension password copies cannot be filtered by
+            // executable name, and managers almost always auto-clear within seconds.
+            forget_on_clipboard_clear: true,
             default_sensitive_apps_seeded: false,
             ignored_apps: HashSet::new(),
         }
@@ -261,10 +269,13 @@ mod tests {
             .expect("settings without the new fields should stay readable");
         assert!(!migrated.skip_likely_secrets);
         assert!(!migrated.default_sensitive_apps_seeded);
+        // Auto-clear forget is default-on even for upgrades (browser-extension gap).
+        assert!(migrated.forget_on_clipboard_clear);
 
         let fresh = AppSettings::default();
         assert!(!fresh.skip_likely_secrets);
         assert!(!fresh.default_sensitive_apps_seeded);
+        assert!(fresh.forget_on_clipboard_clear);
 
         // The deterministic protection stays on regardless.
         assert!(fresh.skip_sensitive);
@@ -277,12 +288,14 @@ mod tests {
         let settings: AppSettings = serde_json::from_str(
             r#"{
                 "skip_likely_secrets": true,
-                "default_sensitive_apps_seeded": true
+                "default_sensitive_apps_seeded": true,
+                "forget_on_clipboard_clear": false
             }"#,
         )
         .expect("explicitly persisted privacy flags should round-trip");
 
         assert!(settings.skip_likely_secrets);
         assert!(settings.default_sensitive_apps_seeded);
+        assert!(!settings.forget_on_clipboard_clear);
     }
 }


### PR DESCRIPTION
## What changed

- Detect verified clipboard **empty/clear** events (empty text or zero formats; never lock-contention false positives)
- If the last accepted capture is within a **90s** window, hard-delete it (pinned items kept)
- Setting `forget_on_clipboard_clear` (**default on**) with Privacy UI toggle + i18n
- Unit tests for the forget window and settings defaults

## Why

Password-manager browser extensions copy via chrome.exe/msedge.exe, so the ignored-apps list cannot catch them, and they often do not set `ExcludeClipboardContentFromMonitorProcessing`. They almost always auto-clear the clipboard seconds later. Treating that clear as a transient signal closes the gap without content heuristics.

## Validation

- `cargo test --locked --lib` (81 passed)
- `cargo clippy --locked --all-targets -- -D warnings`
- `pnpm exec tsc --noEmit` (frontend)

Linear: https://linear.app/southforge-ai/issue/SOU-316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a privacy setting to optionally forget the most recent clipboard entry when the clipboard is cleared shortly after copying.
  * Pinned items remain protected, and only qualifying clipboard-clear events trigger removal.
  * The setting is enabled by default and available in supported languages.
* **Bug Fixes**
  * Improved clipboard-clear handling to reliably remove the correct recent entry and clean up associated saved data when the setting is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->