### PR TITLE
Add safe database quarantine and rolling backup (SOU-218)

### DIFF
--- a/docs/CLIPBOARD_RELIABILITY.md
+++ b/docs/CLIPBOARD_RELIABILITY.md
@@ -17,6 +17,9 @@ Clipboard capture is Cubby's primary product promise. A polished history UI is n
 - Keep a supervised native listener that restarts on failure instead of exiting the process thread silently.
 - Detect silent listener death with a clipboard-sequence watchdog (recreate when the sequence advances but no `WM_CLIPBOARDUPDATE` arrives for several seconds).
 - Expose lightweight capture health via `get_clipboard_capture_status` (state, restart count, last error) without clipboard payloads.
+- Keep local history durable: on startup, run SQLite `PRAGMA quick_check` on the existing `cubby.db`. If the file cannot be opened or fails the check, quarantine it (and any `-wal`/`-shm` sidecars) under a timestamped `*.corrupt-*` name and start a fresh empty database so capture never blocks on a broken store.
+- Refresh a rolling `cubby.db.bak` snapshot of a healthy database at most once per 24 hours (after a WAL checkpoint) so operators have a recent recovery point without copying on every launch.
+- Never log clipboard content, previews, or decryptable payloads during recovery; logs may include paths and short structural diagnostics only. The DPAPI-protected `storage.key` and image blobs are left in place when the DB is quarantined.
 
 ## Format baseline
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -55,6 +55,54 @@ After the automated gate is green, install the draft NSIS package on a clean Win
 10. Uninstall removes the app cleanly; document whether local history remains on disk.
 11. Record SHA-256 hashes for the final installers.
 
+## Lifecycle / recovery acceptance (SOU-218 remainder)
+
+Capture-listener restart and the sequence watchdog already shipped. Confirm the
+storage and session slices below on a daily-driver or VM before closing the
+issue. Do not paste clipboard contents into bug reports or logs.
+
+### Database repair / backup
+
+1. Fresh install: `%AppData%` (or portable data dir) has no `cubby.db`; first
+   launch creates it and capture works.
+2. After history exists, quit Cubby and confirm a `cubby.db.bak` appears within
+   one successful launch (rolling backup; may skip if a backup younger than
+   24h already exists).
+3. With Cubby quit, replace `cubby.db` with garbage bytes (or truncate mid-file).
+   Relaunch: app must start, capture must work, and the bad file must be renamed
+   to something like `cubby.db.corrupt-YYYYMMDD-HHMMSS`. `storage.key` must
+   still be present. History is empty (expected after quarantine).
+4. Logs under the app log dir mention quarantine/structural failure only; no
+   clip text or image payloads.
+
+### Single-instance and autostart
+
+1. With Cubby running, start a second process (installer shortcut or
+   `Cubby.exe`): only one process remains; the existing flyout shows near the
+   cursor.
+2. Enable autostart in Settings (installed build), sign out/in or reboot, confirm
+   tray icon returns and a new copy appears in history.
+3. Portable build: autostart control is unavailable / does not write Run-key
+   entries.
+
+### Display and session (verification; no required code change yet)
+
+1. Copy text, then sleep/resume Windows; within ~10s another copy is captured
+   (watchdog may take 5–7s after silent listener death).
+2. Lock and unlock the session; capture still works.
+3. Change display scale (100% ↔ 150%) or unplug a monitor with the flyout open
+   or closed; next hotkey show positions on the active work area without
+   crashing.
+4. Move the taskbar (bottom ↔ side); flyout still clamps to the work area.
+5. Optional: switch virtual desktop and invoke the hotkey; window appears on the
+   current desktop.
+
+### Capture health API
+
+From a dev build or tooling, invoke `get_clipboard_capture_status` and confirm
+fields are present (`state`, restart counters, last error) with no clipboard
+payload. A Settings/About surface for this status is still optional.
+
 ## Public-release decisions
 
 - Installers are signed with Azure Trusted Signing in CI; confirm SmartScreen reputation is acceptable for the channel you are announcing.

--- a/docs/SOU-218-ACCEPTANCE.md
+++ b/docs/SOU-218-ACCEPTANCE.md
@@ -1,0 +1,83 @@
+# SOU-218 acceptance matrix
+
+**Issue:** [SOU-218](https://linear.app/southforge-ai/issue/SOU-218/harden-lifecycle-display-and-recovery-behavior)  
+**Goal:** Cubby must not silently stop capturing; recovery and diagnostics must stay content-free.
+
+Status key: **Pass** (automated or verified) · **Pending** (needs human session) · **Out of scope** (explicitly deferred)
+
+## Shipped implementation
+
+| Slice | Evidence | Status |
+|-------|----------|--------|
+| Supervised clipboard listener + restart forever | PR #74, `clipboard.rs` | Pass |
+| Sequence watchdog (2s poll, 5s stale) | PR #74 | Pass |
+| `get_clipboard_capture_status` (no payloads) | PR #74, command registered in `lib.rs` | Pass |
+| Startup `PRAGMA quick_check` | PR #113, `database.rs` | Pass |
+| Quarantine corrupt DB (+ WAL/SHM) and start fresh | PR #113 + unit tests | Pass |
+| Rolling `cubby.db.bak` (max once / 24h) | PR #113 + unit tests | Pass |
+| Content-free recovery diagnostics | PR #113 unit test on sanitize | Pass |
+
+## Automated / code-review acceptance
+
+| Check | How verified | Status |
+|-------|--------------|--------|
+| Missing DB is created on first open | `missing_database_file_is_ready_for_create` | Pass |
+| Healthy DB gets rolling backup | `healthy_database_gets_a_rolling_backup` | Pass |
+| Fresh backup is not rewritten | `fresh_rolling_backup_is_not_rewritten` | Pass |
+| Garbage DB is quarantined; fresh open works | `garbage_database_is_quarantined_and_fresh_open_succeeds` | Pass |
+| Structural corruption is quarantined | `structurally_corrupt_sqlite_is_quarantined` | Pass |
+| `storage.key` survives quarantine | `quarantine_rename_preserves_sibling_key_file` | Pass |
+| Encrypted DB without key still fails closed | `encrypted_database_without_its_key_fails_closed` | Pass |
+| Single-instance plugin shows existing window | Code: `tauri_plugin_single_instance` → `position_window_near_cursor` in `lib.rs` | Pass (code review) |
+| Portable builds skip autostart registry | Code: portable path in `settings_commands.rs` | Pass (code review) |
+| Flyout clamps to monitor work area | Code: `position_window_near_cursor` / work-area clamp in `lib.rs` | Pass (code review) |
+
+## Human session acceptance (still required to close SOU-218)
+
+Run on a daily-driver or clean Windows 11 VM. Do not paste clipboard contents into notes or issues.
+
+### Database (manual smoke after PR #113 merges)
+
+| # | Step | Status |
+|---|------|--------|
+| D1 | First launch creates `cubby.db`; copy appears in history | Pending |
+| D2 | After history exists, `cubby.db.bak` present (or skipped if &lt;24h old) | Pending |
+| D3 | Quit; replace `cubby.db` with garbage; relaunch → `*.corrupt-*`, empty history, capture works, `storage.key` remains | Pending |
+| D4 | App logs show quarantine/structural text only (no clip bodies) | Pending |
+
+### Single-instance and autostart
+
+| # | Step | Status |
+|---|------|--------|
+| S1 | Second process while Cubby runs: one process, flyout near cursor | Pending |
+| S2 | Installed build: enable autostart, reboot/sign-in, tray + capture | Pending |
+| S3 | Portable build: no Run-key autostart writes | Pending (code review Pass; optional re-check on portable artifact) |
+
+### Display and session
+
+| # | Step | Status |
+|---|------|--------|
+| L1 | Sleep/resume; copy within ~10s is captured | Pending |
+| L2 | Lock/unlock; capture still works | Pending |
+| L3 | DPI 100%↔150% or unplug monitor; next hotkey positions without crash | Pending |
+| L4 | Move taskbar; flyout clamps to work area | Pending |
+| L5 | Optional: virtual desktop switch + hotkey on current desktop | Pending |
+
+### Capture health
+
+| # | Step | Status |
+|---|------|--------|
+| H1 | Invoke `get_clipboard_capture_status`; fields present, no payload | Pending (dev build) |
+
+## Explicitly deferred (not blocking SOU-218 close)
+
+| Item | Why |
+|------|-----|
+| Explicit power/session Win32 callbacks | Watchdog covers common silent-death cases; add only if L1/L2 fail in the field |
+| Settings/About capture-health UI | API is enough for diagnostics; UI is product polish |
+
+When D1–D4, S1–S2, L1–L4, and H1 are marked Pass (or waived with reason), SOU-218 can move to Done.
+
+## How to record results
+
+Edit this file (or leave a Linear comment on SOU-218) with date, machine, and Pass/Fail per row. Keep notes free of clipboard content.

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -1,9 +1,15 @@
 use sqlx::SqlitePool;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::crypto::CryptoManager;
 use crate::search_index::SearchIndex;
+
+/// How often a healthy on-disk history file is snapshotted to `cubby.db.bak`.
+/// Startup stays cheap while still giving a recent recovery point after bad
+/// migrations or abrupt power loss.
+const ROLLING_BACKUP_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 
 #[derive(Clone)]
 pub struct Database {
@@ -15,12 +21,17 @@ pub struct Database {
 
 impl Database {
     pub async fn new(db_path: &str) -> Result<Self, String> {
-        let image_dir = Path::new(db_path)
+        let path = Path::new(db_path);
+        // Fail open for capture: a corrupt history is quarantined and replaced
+        // with an empty database rather than blocking the app (SOU-218).
+        prepare_database_file(path).await?;
+
+        let image_dir = path
             .parent()
             .unwrap_or_else(|| Path::new("."))
             .join("images");
         let options = sqlx::sqlite::SqliteConnectOptions::new()
-            .filename(db_path)
+            .filename(path)
             .create_if_missing(true)
             .foreign_keys(true);
 
@@ -48,7 +59,7 @@ impl Database {
             None
         };
         let crypto = Arc::new(CryptoManager::load_or_create(
-            Path::new(db_path),
+            path,
             encryption_version.as_deref() != Some("1"),
         )?);
 
@@ -261,6 +272,224 @@ impl Database {
     }
 }
 
+/// Ensure `db_path` is either absent (will be created) or a healthy SQLite file.
+///
+/// On open/integrity failure the existing `cubby.db` (+ WAL/SHM) is renamed to a
+/// timestamped quarantine name and startup continues with a fresh file. The
+/// DPAPI-protected `storage.key` and image blobs are left alone so a future
+/// manual recovery from the quarantine file can still decrypt.
+async fn prepare_database_file(db_path: &Path) -> Result<(), String> {
+    if !db_path.exists() {
+        return Ok(());
+    }
+
+    match verify_database_quick_check(db_path).await {
+        Ok(()) => {
+            if let Err(error) = refresh_rolling_backup(db_path).await {
+                // Backup is best-effort; a full disk must not block capture.
+                log::warn!("STORAGE: Could not refresh history backup: {error}");
+            }
+            Ok(())
+        }
+        Err(reason) => {
+            // Structural diagnostics only: never log row contents.
+            log::error!(
+                "STORAGE: Clipboard history database is unusable ({}); quarantining and starting fresh",
+                sanitize_storage_diagnostic(&reason)
+            );
+            quarantine_database_files(db_path)?;
+            Ok(())
+        }
+    }
+}
+
+async fn verify_database_quick_check(db_path: &Path) -> Result<(), String> {
+    use sqlx::Connection;
+
+    let options = sqlx::sqlite::SqliteConnectOptions::new()
+        .filename(db_path)
+        .create_if_missing(false)
+        .foreign_keys(true);
+
+    // One connection (not a pool) so Windows releases the file handle before
+    // quarantine rename runs.
+    let mut conn = sqlx::SqliteConnection::connect_with(&options)
+        .await
+        .map_err(|e| format!("open failed: {e}"))?;
+
+    // quick_check catches most corruption at startup without a full page walk.
+    let result: Result<String, sqlx::Error> = sqlx::query_scalar("PRAGMA quick_check")
+        .fetch_one(&mut conn)
+        .await;
+
+    // Checkpoint so a subsequent file copy of the main DB is consistent.
+    let _ = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+        .execute(&mut conn)
+        .await;
+
+    // Always close before returning so quarantine can rename on Windows.
+    conn.close()
+        .await
+        .map_err(|e| format!("close failed: {e}"))?;
+
+    match result {
+        Ok(text) if text.eq_ignore_ascii_case("ok") => Ok(()),
+        Ok(text) => Err(format!("quick_check: {text}")),
+        Err(e) => Err(format!("quick_check failed: {e}")),
+    }
+}
+
+async fn refresh_rolling_backup(db_path: &Path) -> Result<(), String> {
+    use sqlx::Connection;
+
+    let backup = rolling_backup_path(db_path);
+    if backup_is_fresh(&backup) {
+        return Ok(());
+    }
+
+    // Always checkpoint here so the backup path is safe to invoke alone in tests.
+    let options = sqlx::sqlite::SqliteConnectOptions::new()
+        .filename(db_path)
+        .create_if_missing(false);
+    let mut conn = sqlx::SqliteConnection::connect_with(&options)
+        .await
+        .map_err(|e| format!("backup open failed: {e}"))?;
+    sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+        .execute(&mut conn)
+        .await
+        .map_err(|e| format!("backup checkpoint failed: {e}"))?;
+    conn.close()
+        .await
+        .map_err(|e| format!("backup close failed: {e}"))?;
+
+    let temporary = db_path.with_file_name(format!(
+        "{}.bak.{}.{}.tmp",
+        file_stem_lossy(db_path),
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::copy(db_path, &temporary).map_err(|e| format!("backup copy failed: {e}"))?;
+    std::fs::rename(&temporary, &backup).map_err(|e| {
+        let _ = std::fs::remove_file(&temporary);
+        format!("backup install failed: {e}")
+    })?;
+    log::info!(
+        "STORAGE: Refreshed rolling history backup at {}",
+        backup.display()
+    );
+    Ok(())
+}
+
+fn backup_is_fresh(backup: &Path) -> bool {
+    let Ok(metadata) = std::fs::metadata(backup) else {
+        return false;
+    };
+    let Ok(modified) = metadata.modified() else {
+        return false;
+    };
+    modified
+        .elapsed()
+        .map(|age| age < ROLLING_BACKUP_MAX_AGE)
+        .unwrap_or(false)
+}
+
+fn rolling_backup_path(db_path: &Path) -> PathBuf {
+    // `cubby.db` → `cubby.db.bak` (keep the original name readable).
+    let name = db_path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "cubby.db".to_string());
+    db_path.with_file_name(format!("{name}.bak"))
+}
+
+fn quarantine_database_files(db_path: &Path) -> Result<(), String> {
+    let stamp = chrono::Local::now().format("%Y%m%d-%H%M%S");
+    let parent = db_path.parent().unwrap_or_else(|| Path::new("."));
+
+    // SQLite names WAL/SHM as `{main}-wal` / `{main}-shm` (suffix on full name).
+    let candidates = [
+        db_path.to_path_buf(),
+        PathBuf::from(format!("{}-wal", db_path.display())),
+        PathBuf::from(format!("{}-shm", db_path.display())),
+    ];
+
+    let mut moved_any = false;
+    for source in candidates {
+        if !source.exists() {
+            continue;
+        }
+        let file_name = source
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "cubby.db".to_string());
+        let destination = parent.join(format!("{file_name}.corrupt-{stamp}"));
+        rename_with_share_retry(&source, &destination).map_err(|e| {
+            format!(
+                "failed to quarantine unusable history file {}: {e}",
+                source.display()
+            )
+        })?;
+        log::warn!(
+            "STORAGE: Quarantined unusable history file to {}",
+            destination.display()
+        );
+        moved_any = true;
+    }
+
+    if !moved_any {
+        return Err(
+            "clipboard history database is unusable, but no files could be quarantined".to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn file_stem_lossy(path: &Path) -> String {
+    path.file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "cubby".to_string())
+}
+
+/// Windows can keep a SQLite handle briefly after close/failed open (ERROR_SHARING_VIOLATION).
+fn rename_with_share_retry(source: &Path, destination: &Path) -> Result<(), String> {
+    const ATTEMPTS: u32 = 12;
+    let mut last_error = None;
+    for attempt in 0..ATTEMPTS {
+        match std::fs::rename(source, destination) {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                let sharing = error.raw_os_error() == Some(32)
+                    || error.kind() == std::io::ErrorKind::PermissionDenied;
+                last_error = Some(error);
+                if !sharing || attempt + 1 == ATTEMPTS {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(25 * u64::from(attempt + 1)));
+            }
+        }
+    }
+    Err(last_error
+        .map(|e| e.to_string())
+        .unwrap_or_else(|| "rename failed".to_string()))
+}
+
+/// Strip/truncate integrity diagnostics so logs never become a dump of page
+/// payloads. SQLite messages are structural, but we still bound them.
+fn sanitize_storage_diagnostic(message: &str) -> String {
+    const MAX: usize = 180;
+    let flat: String = message
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect();
+    let flat = flat.split_whitespace().collect::<Vec<_>>().join(" ");
+    if flat.chars().count() <= MAX {
+        flat
+    } else {
+        let truncated: String = flat.chars().take(MAX).collect();
+        format!("{truncated}…")
+    }
+}
+
 async fn add_column_if_missing(pool: &SqlitePool, sql: &str) -> Result<(), sqlx::Error> {
     match sqlx::query(sql).execute(pool).await {
         Ok(_) => Ok(()),
@@ -277,10 +506,20 @@ async fn add_column_if_missing(pool: &SqlitePool, sql: &str) -> Result<(), sqlx:
 
 #[cfg(test)]
 mod tests {
-    use super::Database;
+    use super::{
+        prepare_database_file, quarantine_database_files, rolling_backup_path,
+        sanitize_storage_diagnostic, Database,
+    };
     use crate::crypto::CryptoManager;
     use sqlx::sqlite::SqlitePoolOptions;
     use std::sync::Arc;
+
+    fn temp_dir() -> std::path::PathBuf {
+        let directory =
+            std::env::temp_dir().join(format!("cubby-db-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&directory).unwrap();
+        directory
+    }
 
     #[tokio::test]
     async fn migration_adds_pin_state_to_existing_clip_tables() {
@@ -364,6 +603,155 @@ mod tests {
         assert!(!directory.join("storage.key").exists());
         // SQLx may release the failed constructor's SQLite handle just after the
         // error is returned on Windows, so cleanup is deliberately best effort.
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    #[tokio::test]
+    async fn missing_database_file_is_ready_for_create() {
+        let directory = temp_dir();
+        let database_path = directory.join("cubby.db");
+        prepare_database_file(&database_path)
+            .await
+            .expect("missing file should not need recovery");
+        assert!(!database_path.exists());
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    #[tokio::test]
+    async fn healthy_database_gets_a_rolling_backup() {
+        let directory = temp_dir();
+        let database_path = directory.join("cubby.db");
+        let options = sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&database_path)
+            .create_if_missing(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        pool.close().await;
+
+        prepare_database_file(&database_path)
+            .await
+            .expect("healthy database should pass recovery");
+        assert!(database_path.exists());
+        assert!(
+            rolling_backup_path(&database_path).exists(),
+            "first healthy open should write cubby.db.bak"
+        );
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    #[tokio::test]
+    async fn garbage_database_is_quarantined_and_fresh_open_succeeds() {
+        let directory = temp_dir();
+        let database_path = directory.join("cubby.db");
+        let wal_path = std::path::PathBuf::from(format!("{}-wal", database_path.display()));
+        std::fs::write(&database_path, b"this is not a sqlite database").unwrap();
+        std::fs::write(&wal_path, b"wal-garbage").unwrap();
+
+        prepare_database_file(&database_path)
+            .await
+            .expect("corrupt history should be quarantined");
+
+        assert!(!database_path.exists(), "main DB should be moved aside");
+        assert!(!wal_path.exists(), "WAL sidecar should be moved aside");
+
+        let quarantined: Vec<_> = std::fs::read_dir(&directory)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains("corrupt-"))
+            .collect();
+        assert!(
+            quarantined
+                .iter()
+                .any(|name| name.starts_with("cubby.db.corrupt-")),
+            "expected quarantined main file, got {quarantined:?}"
+        );
+        // WAL is quarantined when still present; SQLite may also drop a junk
+        // `-wal` during a failed open, which is fine as long as it is gone.
+        assert!(
+            !wal_path.exists()
+                || quarantined
+                    .iter()
+                    .any(|name| name.starts_with("cubby.db-wal.corrupt-")),
+            "WAL should be gone or quarantined, got {quarantined:?}"
+        );
+
+        // Fresh open after quarantine must create a usable database.
+        let db = Database::new(database_path.to_str().unwrap())
+            .await
+            .expect("fresh database should open after quarantine");
+        db.migrate().await.expect("fresh schema should apply");
+        db.pool.close().await;
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    #[tokio::test]
+    async fn structurally_corrupt_sqlite_is_quarantined() {
+        let directory = temp_dir();
+        let database_path = directory.join("cubby.db");
+        let options = sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&database_path)
+            .create_if_missing(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE t (id INTEGER PRIMARY KEY, payload BLOB)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO t (payload) VALUES (?)")
+            .bind(vec![7_u8; 4096])
+            .execute(&pool)
+            .await
+            .unwrap();
+        pool.close().await;
+
+        // Punch a hole in the file body while keeping the SQLite header so open
+        // may succeed but quick_check should fail.
+        let mut bytes = std::fs::read(&database_path).unwrap();
+        assert!(bytes.len() > 200, "fixture should be larger than the header");
+        for byte in bytes.iter_mut().skip(100).take(80) {
+            *byte = 0xFF;
+        }
+        std::fs::write(&database_path, bytes).unwrap();
+
+        prepare_database_file(&database_path)
+            .await
+            .expect("corrupt sqlite should quarantine rather than fail startup");
+        assert!(!database_path.exists());
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    #[test]
+    fn storage_diagnostics_are_bounded_and_flattened() {
+        let noisy = format!("page {}\x07\n{}", "x".repeat(400), "y".repeat(400));
+        let clean = sanitize_storage_diagnostic(&noisy);
+        assert!(!clean.contains('\n'));
+        assert!(!clean.contains('\u{7}'));
+        assert!(clean.chars().count() <= 181);
+    }
+
+    #[test]
+    fn quarantine_rename_preserves_sibling_key_file() {
+        let directory = temp_dir();
+        let database_path = directory.join("cubby.db");
+        std::fs::write(&database_path, b"broken").unwrap();
+        std::fs::write(directory.join("storage.key"), b"key-bytes").unwrap();
+        quarantine_database_files(&database_path).unwrap();
+        assert!(!database_path.exists());
+        assert_eq!(
+            std::fs::read(directory.join("storage.key")).unwrap(),
+            b"key-bytes"
+        );
         let _ = std::fs::remove_dir_all(directory);
     }
 }

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -297,7 +297,10 @@ async fn prepare_database_file(db_path: &Path) -> Result<(), String> {
                 "STORAGE: Clipboard history database is unusable ({}); quarantining and starting fresh",
                 sanitize_storage_diagnostic(&reason)
             );
-            quarantine_database_files(db_path)?;
+            let path = db_path.to_path_buf();
+            tokio::task::spawn_blocking(move || quarantine_database_files(&path))
+                .await
+                .map_err(|e| format!("quarantine task failed: {e}"))??;
             Ok(())
         }
     }
@@ -328,9 +331,11 @@ async fn verify_database_quick_check(db_path: &Path) -> Result<(), String> {
         .await;
 
     // Always close before returning so quarantine can rename on Windows.
-    conn.close()
-        .await
-        .map_err(|e| format!("close failed: {e}"))?;
+    // Close failure is not an integrity verdict: never quarantine a healthy DB
+    // just because the check connection failed to close cleanly.
+    if let Err(error) = conn.close().await {
+        log::warn!("STORAGE: Failed to close integrity-check connection: {error}");
+    }
 
     match result {
         Ok(text) if text.eq_ignore_ascii_case("ok") => Ok(()),
@@ -358,9 +363,9 @@ async fn refresh_rolling_backup(db_path: &Path) -> Result<(), String> {
         .execute(&mut conn)
         .await
         .map_err(|e| format!("backup checkpoint failed: {e}"))?;
-    conn.close()
-        .await
-        .map_err(|e| format!("backup close failed: {e}"))?;
+    if let Err(error) = conn.close().await {
+        log::warn!("STORAGE: Failed to close backup checkpoint connection: {error}");
+    }
 
     let temporary = db_path.with_file_name(format!(
         "{}.bak.{}.{}.tmp",
@@ -368,11 +373,24 @@ async fn refresh_rolling_backup(db_path: &Path) -> Result<(), String> {
         std::process::id(),
         uuid::Uuid::new_v4()
     ));
-    std::fs::copy(db_path, &temporary).map_err(|e| format!("backup copy failed: {e}"))?;
-    std::fs::rename(&temporary, &backup).map_err(|e| {
-        let _ = std::fs::remove_file(&temporary);
-        format!("backup install failed: {e}")
-    })?;
+    let source = db_path.to_path_buf();
+    let temporary_for_copy = temporary.clone();
+    tokio::task::spawn_blocking(move || std::fs::copy(&source, &temporary_for_copy))
+        .await
+        .map_err(|e| format!("backup copy task failed: {e}"))?
+        .map_err(|e| format!("backup copy failed: {e}"))?;
+
+    let temporary_for_rename = temporary.clone();
+    let backup_for_rename = backup.clone();
+    tokio::task::spawn_blocking(move || {
+        std::fs::rename(&temporary_for_rename, &backup_for_rename).inspect_err(|_| {
+            let _ = std::fs::remove_file(&temporary_for_rename);
+        })
+    })
+    .await
+    .map_err(|e| format!("backup install task failed: {e}"))?
+    .map_err(|e| format!("backup install failed: {e}"))?;
+
     log::info!(
         "STORAGE: Refreshed rolling history backup at {}",
         backup.display()
@@ -402,6 +420,13 @@ fn rolling_backup_path(db_path: &Path) -> PathBuf {
     db_path.with_file_name(format!("{name}.bak"))
 }
 
+fn sqlite_sidecar_path(db_path: &Path, suffix: &str) -> PathBuf {
+    // Append `-wal` / `-shm` to the full path bytes (not via Display, which is lossy).
+    let mut name = db_path.as_os_str().to_os_string();
+    name.push(suffix);
+    PathBuf::from(name)
+}
+
 fn quarantine_database_files(db_path: &Path) -> Result<(), String> {
     let stamp = chrono::Local::now().format("%Y%m%d-%H%M%S");
     let parent = db_path.parent().unwrap_or_else(|| Path::new("."));
@@ -409,8 +434,8 @@ fn quarantine_database_files(db_path: &Path) -> Result<(), String> {
     // SQLite names WAL/SHM as `{main}-wal` / `{main}-shm` (suffix on full name).
     let candidates = [
         db_path.to_path_buf(),
-        PathBuf::from(format!("{}-wal", db_path.display())),
-        PathBuf::from(format!("{}-shm", db_path.display())),
+        sqlite_sidecar_path(db_path, "-wal"),
+        sqlite_sidecar_path(db_path, "-shm"),
     ];
 
     let mut moved_any = false;
@@ -486,7 +511,7 @@ fn sanitize_storage_diagnostic(message: &str) -> String {
         flat
     } else {
         let truncated: String = flat.chars().take(MAX).collect();
-        format!("{truncated}…")
+        format!("{truncated}...")
     }
 }
 
@@ -647,6 +672,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fresh_rolling_backup_is_not_rewritten() {
+        let directory = temp_dir();
+        let database_path = directory.join("cubby.db");
+        let options = sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&database_path)
+            .create_if_missing(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        pool.close().await;
+
+        let backup = rolling_backup_path(&database_path);
+        let marker = b"preexisting-fresh-backup";
+        std::fs::write(&backup, marker).unwrap();
+        let before_meta = std::fs::metadata(&backup).unwrap();
+        let before_modified = before_meta.modified().unwrap();
+
+        prepare_database_file(&database_path)
+            .await
+            .expect("healthy database with fresh backup should pass");
+
+        assert_eq!(std::fs::read(&backup).unwrap(), marker);
+        let after_modified = std::fs::metadata(&backup).unwrap().modified().unwrap();
+        assert_eq!(
+            before_modified, after_modified,
+            "backup younger than 24h must not be rewritten"
+        );
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    #[tokio::test]
     async fn garbage_database_is_quarantined_and_fresh_open_succeeds() {
         let directory = temp_dir();
         let database_path = directory.join("cubby.db");
@@ -718,7 +780,10 @@ mod tests {
         // Punch a hole in the file body while keeping the SQLite header so open
         // may succeed but quick_check should fail.
         let mut bytes = std::fs::read(&database_path).unwrap();
-        assert!(bytes.len() > 200, "fixture should be larger than the header");
+        assert!(
+            bytes.len() > 200,
+            "fixture should be larger than the header"
+        );
         for byte in bytes.iter_mut().skip(100).take(80) {
             *byte = 0xFF;
         }
@@ -737,7 +802,7 @@ mod tests {
         let clean = sanitize_storage_diagnostic(&noisy);
         assert!(!clean.contains('\n'));
         assert!(!clean.contains('\u{7}'));
-        assert!(clean.chars().count() <= 181);
+        assert!(clean.chars().count() <= 183);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- On startup, run SQLite `PRAGMA quick_check` on the existing history DB; quarantine unusable `cubby.db` (+ WAL/SHM) as timestamped `*.corrupt-*` files and start fresh so capture never blocks (SOU-218).
- Refresh a rolling `cubby.db.bak` at most once per 24 hours after a WAL checkpoint; leave `storage.key` and image blobs in place for possible manual recovery.
- Document recovery behavior and the remaining lifecycle acceptance matrix (display/session/autostart/capture-health) in the reliability and release docs.

## Test plan
- [x] `cargo test --locked --lib database::` passes
- [x] `cargo clippy --locked --lib -- -D warnings` passes
- [ ] Manual: with Cubby quit, replace `cubby.db` with garbage; relaunch; confirm quarantine rename + empty history + capture still works
- [ ] Manual: confirm `cubby.db.bak` appears after a healthy launch (if no backup younger than 24h)
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup recovery when local clipboard storage is missing or corrupted.
  * Automatically isolates damaged storage and starts with a fresh database so clipboard capture can continue.
  * Added rolling backups of healthy clipboard storage for improved recovery options.
  * Preserved encryption keys and image data during database recovery.

* **Documentation**
  * Added recovery, backup, single-instance, display, session, and capture-health verification steps.
  * Clarified that recovery diagnostics must not expose clipboard content or sensitive payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->