### PR TITLE
Automate Microsoft Store submissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -428,11 +428,101 @@ jobs:
             > latest.json
           gh release upload "$TAG" latest.json --clobber
 
+  submit-store:
+    name: Submit Microsoft Store update
+    if: github.event_name != 'workflow_dispatch'
+    needs: [create-release, build-installers]
+    runs-on: windows-latest
+    timeout-minutes: 30
+    environment: release
+    permissions:
+      contents: read
+    steps:
+      - name: Check out release tag
+        if: vars.MICROSOFT_STORE_SUBMISSION_ENABLED == 'true'
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Microsoft Store Developer CLI
+        if: vars.MICROSOFT_STORE_SUBMISSION_ENABLED == 'true'
+        uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0 # v1.4
+
+      - name: Configure Partner Center credentials
+        if: vars.MICROSOFT_STORE_SUBMISSION_ENABLED == 'true'
+        shell: pwsh
+        env:
+          PARTNER_CENTER_TENANT_ID: ${{ secrets.PARTNER_CENTER_TENANT_ID }}
+          PARTNER_CENTER_SELLER_ID: ${{ secrets.PARTNER_CENTER_SELLER_ID }}
+          PARTNER_CENTER_CLIENT_ID: ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
+          PARTNER_CENTER_CLIENT_SECRET: ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
+        run: |
+          foreach ($name in @(
+            "PARTNER_CENTER_TENANT_ID",
+            "PARTNER_CENTER_SELLER_ID",
+            "PARTNER_CENTER_CLIENT_ID",
+            "PARTNER_CENTER_CLIENT_SECRET"
+          )) {
+            if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
+              throw "The release environment is missing secret $name."
+            }
+          }
+          msstore settings --enableTelemetry false
+          msstore reconfigure `
+            --tenantId $env:PARTNER_CENTER_TENANT_ID `
+            --sellerId $env:PARTNER_CENTER_SELLER_ID `
+            --clientId $env:PARTNER_CENTER_CLIENT_ID `
+            --clientSecret $env:PARTNER_CENTER_CLIENT_SECRET
+          if ($LASTEXITCODE -ne 0) {
+            throw "Microsoft Store CLI authentication failed."
+          }
+
+      - name: Prepare Microsoft Store package update
+        if: vars.MICROSOFT_STORE_SUBMISSION_ENABLED == 'true'
+        shell: pwsh
+        env:
+          PARTNER_CENTER_PRODUCT_ID: ${{ vars.PARTNER_CENTER_PRODUCT_ID }}
+          STORE_VERSION: ${{ needs.create-release.outputs.version }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:PARTNER_CENTER_PRODUCT_ID)) {
+            throw "The release environment is missing variable PARTNER_CENTER_PRODUCT_ID."
+          }
+          $currentPath = Join-Path $env:RUNNER_TEMP "store-packages-current.json"
+          $preparedPath = Join-Path $env:RUNNER_TEMP "store-packages-prepared.json"
+          msstore submission get $env:PARTNER_CENTER_PRODUCT_ID > $currentPath
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not retrieve Cubby's current Microsoft Store packages."
+          }
+          & .\scripts\prepare-store-submission.ps1 `
+            -CurrentPackagePath $currentPath `
+            -Version $env:STORE_VERSION `
+            -OutputPath $preparedPath
+          "STORE_PACKAGE_PATH=$preparedPath" |
+            Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Submit update to Microsoft Store
+        if: vars.MICROSOFT_STORE_SUBMISSION_ENABLED == 'true'
+        shell: pwsh
+        env:
+          PARTNER_CENTER_PRODUCT_ID: ${{ vars.PARTNER_CENTER_PRODUCT_ID }}
+        run: |
+          $package = Get-Content -LiteralPath $env:STORE_PACKAGE_PATH -Raw
+          msstore submission update $env:PARTNER_CENTER_PRODUCT_ID $package
+          if ($LASTEXITCODE -ne 0) {
+            throw "Microsoft Store package update failed."
+          }
+          msstore submission publish $env:PARTNER_CENTER_PRODUCT_ID
+          if ($LASTEXITCODE -ne 0) {
+            throw "Microsoft Store submission failed."
+          }
+          "### Submitted Cubby Clipboard to Microsoft Store" |
+            Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
   publish-release:
     name: Publish validated release
     if: github.event_name != 'workflow_dispatch'
     # Gate publishing on validate too, since create-release/build no longer do.
-    needs: [validate, create-release, build-installers, updater-manifest]
+    needs: [validate, create-release, build-installers, updater-manifest, submit-store]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/validate-store-submission.yml
+++ b/.github/workflows/validate-store-submission.yml
@@ -1,0 +1,156 @@
+name: Validate Microsoft Store submission
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Existing Cubby version already published to R2 (for example, 1.2.3)
+        required: true
+        type: string
+      publish:
+        description: Submit this version to Microsoft Store after validation
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: microsoft-store-submission
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate Store access and packages
+    runs-on: windows-latest
+    timeout-minutes: 30
+    environment: store-validation
+
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Validate version
+        shell: pwsh
+        env:
+          STORE_VERSION: ${{ inputs.version }}
+        run: |
+          if ($env:STORE_VERSION -notmatch '^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$') {
+            throw "Version must look like 1.2.3 (without the v prefix)."
+          }
+
+      - name: Verify immutable R2 installers and checksums
+        shell: pwsh
+        env:
+          STORE_VERSION: ${{ inputs.version }}
+        run: |
+          foreach ($architecture in @("x64", "arm64")) {
+            $name = "Cubby.Clipboard_$env:STORE_VERSION`_$architecture-Store-setup.exe"
+            $url = "https://downloads.cubbyclipboard.com/releases/v$env:STORE_VERSION/$name"
+            $installerPath = Join-Path $env:RUNNER_TEMP $name
+            $hashPath = "$installerPath.sha256"
+            & curl.exe --fail --silent --show-error --location --max-redirs 0 `
+              --retry 3 --output $installerPath $url
+            if ($LASTEXITCODE -ne 0) {
+              throw "Could not download $url"
+            }
+            & curl.exe --fail --silent --show-error --location --max-redirs 0 `
+              --retry 3 --output $hashPath "$url.sha256"
+            if ($LASTEXITCODE -ne 0) {
+              throw "Could not download $url.sha256"
+            }
+            $expectedText = Get-Content -LiteralPath $hashPath -Raw
+            if ($expectedText -notmatch '(?i)\b([0-9a-f]{64})\b') {
+              throw "$url.sha256 does not contain a SHA-256 value."
+            }
+            $expected = $Matches[1].ToLowerInvariant()
+            $actual = (Get-FileHash -LiteralPath $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+            if ($actual -ne $expected) {
+              throw "$architecture R2 installer SHA-256 mismatch. Expected $expected, got $actual."
+            }
+            Write-Host "Verified immutable R2 installer: $url"
+          }
+
+      - name: Set up Microsoft Store Developer CLI
+        uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0 # v1.4
+
+      - name: Configure Partner Center credentials
+        shell: pwsh
+        env:
+          PARTNER_CENTER_TENANT_ID: ${{ secrets.PARTNER_CENTER_TENANT_ID }}
+          PARTNER_CENTER_SELLER_ID: ${{ secrets.PARTNER_CENTER_SELLER_ID }}
+          PARTNER_CENTER_CLIENT_ID: ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
+          PARTNER_CENTER_CLIENT_SECRET: ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
+        run: |
+          foreach ($name in @(
+            "PARTNER_CENTER_TENANT_ID",
+            "PARTNER_CENTER_SELLER_ID",
+            "PARTNER_CENTER_CLIENT_ID",
+            "PARTNER_CENTER_CLIENT_SECRET"
+          )) {
+            if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
+              throw "The store-validation environment is missing secret $name."
+            }
+          }
+          msstore settings --enableTelemetry false
+          msstore reconfigure `
+            --tenantId $env:PARTNER_CENTER_TENANT_ID `
+            --sellerId $env:PARTNER_CENTER_SELLER_ID `
+            --clientId $env:PARTNER_CENTER_CLIENT_ID `
+            --clientSecret $env:PARTNER_CENTER_CLIENT_SECRET
+          if ($LASTEXITCODE -ne 0) {
+            throw "Microsoft Store CLI authentication failed."
+          }
+
+      - name: Read and prepare current Store packages
+        shell: pwsh
+        env:
+          PARTNER_CENTER_PRODUCT_ID: ${{ vars.PARTNER_CENTER_PRODUCT_ID }}
+          STORE_VERSION: ${{ inputs.version }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:PARTNER_CENTER_PRODUCT_ID)) {
+            throw "The store-validation environment is missing variable PARTNER_CENTER_PRODUCT_ID."
+          }
+          $currentPath = Join-Path $env:RUNNER_TEMP "store-packages-current.json"
+          $preparedPath = Join-Path $env:RUNNER_TEMP "store-packages-prepared.json"
+          msstore submission get $env:PARTNER_CENTER_PRODUCT_ID > $currentPath
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not retrieve Cubby's current Microsoft Store packages."
+          }
+          & .\scripts\prepare-store-submission.ps1 `
+            -CurrentPackagePath $currentPath `
+            -Version $env:STORE_VERSION `
+            -OutputPath $preparedPath
+          "STORE_PACKAGE_PATH=$preparedPath" |
+            Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Publish Microsoft Store submission
+        if: inputs.publish
+        shell: pwsh
+        env:
+          PARTNER_CENTER_PRODUCT_ID: ${{ vars.PARTNER_CENTER_PRODUCT_ID }}
+        run: |
+          $package = Get-Content -LiteralPath $env:STORE_PACKAGE_PATH -Raw
+          msstore submission update $env:PARTNER_CENTER_PRODUCT_ID $package
+          if ($LASTEXITCODE -ne 0) {
+            throw "Microsoft Store package update failed."
+          }
+          msstore submission publish $env:PARTNER_CENTER_PRODUCT_ID
+          if ($LASTEXITCODE -ne 0) {
+            throw "Microsoft Store submission failed."
+          }
+          "### Submitted Cubby Clipboard to Microsoft Store" |
+            Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+      - name: Report validation-only result
+        if: ${{ !inputs.publish }}
+        shell: pwsh
+        run: |
+          "### Microsoft Store validation passed" |
+            Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "Credentials, product access, both package architectures, and R2 URLs were validated. No submission was changed." |
+            Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -13,10 +13,29 @@ environment must define:
 
 Tag releases upload and verify both signed installers automatically. To backfill
 an existing GitHub release, run the `Publish Microsoft Store packages` workflow
-with its version tag. Submit the resulting immutable x64 and ARM64 URLs to
-Microsoft Partner Center. Publishing a GitHub tag or uploading to R2 does not
-update the Store listing: each new version still needs a Partner Center
-submission, either manually or through Microsoft's MSI/EXE submission API.
+with its version tag.
+
+Microsoft Store submission is disabled until Partner Center onboarding has
+been validated. The GitHub `release` environment must also define:
+
+- variable `PARTNER_CENTER_PRODUCT_ID`;
+- variable `MICROSOFT_STORE_SUBMISSION_ENABLED` (`false` during onboarding);
+- secrets `PARTNER_CENTER_TENANT_ID`, `PARTNER_CENTER_SELLER_ID`,
+  `PARTNER_CENTER_CLIENT_ID`, and `PARTNER_CENTER_CLIENT_SECRET`.
+
+The manual **Validate Microsoft Store submission** workflow uses a separate
+`store-validation` environment containing the same five Partner Center values.
+It verifies both R2 installers and checksums, authenticates to Partner Center,
+and maps the existing x64 and ARM64 Store packages to their new versioned URLs
+without changing a submission unless `publish` is explicitly selected.
+
+After a validation-only run passes, set
+`MICROSOFT_STORE_SUBMISSION_ENABLED=true`. Future tag releases wait for both
+architecture uploads, update both package URLs together, and create one Store
+submission before the GitHub release is published. Reruns skip existing R2
+objects only when their bytes match; a different build must use a new version
+instead of replacing an existing versioned URL, even while the GitHub release
+is still a draft.
 
 ## Automated gate
 

--- a/scripts/prepare-store-submission.ps1
+++ b/scripts/prepare-store-submission.ps1
@@ -1,0 +1,93 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$CurrentPackagePath,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$')]
+    [string]$Version,
+
+    [string]$DownloadOrigin = "https://downloads.cubbyclipboard.com",
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path -LiteralPath $CurrentPackagePath -PathType Leaf)) {
+    throw "Current Microsoft Store package JSON not found: $CurrentPackagePath"
+}
+
+try {
+    $current = Get-Content -LiteralPath $CurrentPackagePath -Raw | ConvertFrom-Json
+} catch {
+    throw "Microsoft Store CLI did not return valid package JSON: $($_.Exception.Message)"
+}
+
+$packagesProperty = $current.PSObject.Properties |
+    Where-Object { $_.Name -ieq "packages" } |
+    Select-Object -First 1
+if (-not $packagesProperty) {
+    throw "Microsoft Store package JSON does not contain a Packages array."
+}
+
+$packages = @($packagesProperty.Value)
+if ($packages.Count -ne 2) {
+    throw "Expected exactly two Microsoft Store packages for Cubby, but found $($packages.Count)."
+}
+
+$origin = $DownloadOrigin.TrimEnd('/')
+$expectedArchitectures = @("x64", "arm64")
+foreach ($architecture in $expectedArchitectures) {
+    $storeArchitecture = if ($architecture -eq "x64") { "X64" } else { "Arm64" }
+    $matches = @($packages | Where-Object {
+        $architecturesProperty = $_.PSObject.Properties |
+            Where-Object { $_.Name -ieq "architectures" } |
+            Select-Object -First 1
+        $architecturesProperty -and
+            @($architecturesProperty.Value | ForEach-Object { "$_" }) -icontains $storeArchitecture
+    })
+    if ($matches.Count -ne 1) {
+        throw "Expected exactly one $storeArchitecture Microsoft Store package, but found $($matches.Count)."
+    }
+
+    $packageUrlProperty = $matches[0].PSObject.Properties |
+        Where-Object { $_.Name -ieq "packageUrl" } |
+        Select-Object -First 1
+    if (-not $packageUrlProperty) {
+        throw "The $storeArchitecture Microsoft Store package does not contain a PackageUrl field."
+    }
+
+    $installerName = "Cubby.Clipboard_${Version}_${architecture}-Store-setup.exe"
+    $packageUrlProperty.Value = "$origin/releases/v$Version/$installerName"
+}
+
+$outputDirectory = Split-Path -Parent $OutputPath
+if ($outputDirectory -and -not (Test-Path -LiteralPath $outputDirectory)) {
+    New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+}
+
+$current | ConvertTo-Json -Depth 100 | Set-Content -LiteralPath $OutputPath -Encoding utf8
+
+$prepared = Get-Content -LiteralPath $OutputPath -Raw | ConvertFrom-Json
+$preparedPackagesProperty = $prepared.PSObject.Properties |
+    Where-Object { $_.Name -ieq "packages" } |
+    Select-Object -First 1
+$preparedPackages = @($preparedPackagesProperty.Value)
+foreach ($architecture in $expectedArchitectures) {
+    $installerName = "Cubby.Clipboard_${Version}_${architecture}-Store-setup.exe"
+    $expectedUrl = "$origin/releases/v$Version/$installerName"
+    $matchingUrls = @($preparedPackages | ForEach-Object {
+        $urlProperty = $_.PSObject.Properties |
+            Where-Object { $_.Name -ieq "packageUrl" } |
+            Select-Object -First 1
+        if ($urlProperty) { "$($urlProperty.Value)" }
+    } | Where-Object { $_ -eq $expectedUrl })
+    if ($matchingUrls.Count -ne 1) {
+        throw "Prepared Microsoft Store submission does not contain exactly one expected $architecture URL."
+    }
+}
+
+Write-Host "Prepared Microsoft Store package update for Cubby $Version (x64 and ARM64)."

--- a/scripts/publish-store-installer.ps1
+++ b/scripts/publish-store-installer.ps1
@@ -80,27 +80,7 @@ function Test-R2ObjectRequiresUpload {
                 return $false
             }
 
-            # A published release must stay byte-stable for Store certification URLs.
-            # A still-draft tag can be rebuilt (failed validate, retag, etc.); replace
-            # the orphan so R2 matches the GitHub draft assets.
-            $isDraft = $false
-            if (-not [string]::IsNullOrWhiteSpace($env:GH_TOKEN)) {
-                $releaseJson = & gh release view "v$Version" --json isDraft 2>$null
-                if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($releaseJson)) {
-                    $isDraft = ($releaseJson | ConvertFrom-Json).isDraft -eq $true
-                }
-            }
-            if (-not $isDraft) {
-                throw "Refusing to overwrite immutable release object with different bytes: $objectKey"
-            }
-
-            Write-Warning "Draft release has different bytes at $objectKey; replacing orphan R2 object."
-            $objectPath = "$BucketName/$objectPrefix/$ObjectName"
-            & npx --yes "wrangler@$WranglerVersion" r2 object delete $objectPath --remote
-            if ($LASTEXITCODE -ne 0) {
-                throw "Failed to delete draft orphan object $objectKey before re-upload."
-            }
-            return $true
+            throw "Refusing to overwrite immutable release object with different bytes: $objectKey"
         }
         if ($statusCode -ne "404") {
             throw "Unexpected HTTP $statusCode while checking $objectUrl."


### PR DESCRIPTION
## Summary

- submit Cubby's verified x64 and ARM64 R2 installers through Microsoft Store Developer CLI after tagged releases
- wait for both architecture builds and update both Store package URLs in one submission
- add an isolated validation-only workflow for onboarding and safe package-schema checks
- make versioned R2 installer URLs strictly immutable, including while GitHub releases are drafts
- document Partner Center and GitHub environment configuration

## Why

Cubby already builds, signs, publishes, and verifies two offline Store installers. Partner Center submission is the remaining manual release step. This automates it without allowing the matrix builds to race the same Store draft.

## Safety

- automatic submission is gated by `MICROSOFT_STORE_SUBMISSION_ENABLED == true`
- manual onboarding defaults to validation only
- validation credentials are isolated from signing and R2 credentials
- the Microsoft publisher action is pinned to its exact v1.4 commit
- package preparation requires exactly one X64 and one Arm64 Store package
- existing versioned R2 objects with different bytes are never overwritten

## Validation

- `actionlint` 1.7.12
- PowerShell parser checks for both Store scripts
- sample two-architecture package transformation preserving existing fields
- `git diff --check`
