### PR TITLE
Fix seven reliability defects in capture, restore, paste, and flyout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ pnpm install && pnpm dev
 | `Escape` | Close window / clear search |
 | `Enter` | Paste selected item |
 | `Delete` | Delete selected item |
-| `P` | Pin/Unpin selected item |
+| `Ctrl+P` | Pin/Unpin selected item (bare letters go to type-to-search) |
 | `↑` / `↓` | Navigate items |
 
 ## Tech Stack

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,21 @@ const assetCaptureEnabled = import.meta.env.DEV && import.meta.env.VITE_CUBBY_AS
 const IMAGE_EXPIRED_MESSAGE =
   "This screenshot's full image expired. Only its recognized text remains.";
 
+// Startup shortcut recovery result (see shortcuts.rs). Fetched once on mount
+// and surfaced as a toast the first time the flyout gains focus.
+interface HotkeyStartupNotice {
+  kind: 'fallback_hotkey' | 'win_v_disabled' | 'failed' | string;
+  requested_hotkey: string;
+  active_hotkey: string | null;
+}
+
+const matchesContentFilter = (clip: AppClipboardItem, filter: ContentFilter) => {
+  if (filter === 'images') return clip.clip_type === 'image';
+  if (filter === 'text') return clip.clip_type === 'text';
+  if (filter === 'files') return clip.clip_type === 'file' || clip.clip_type === 'files';
+  return true;
+};
+
 function App() {
   const [clips, setClips] = useState<AppClipboardItem[]>(() =>
     assetCaptureEnabled ? generateDemoClips().map((clip) => ({ ...clip, ocr_match: null })) : []
@@ -155,6 +170,37 @@ function App() {
     };
   }, []);
 
+  // Startup shortcut recovery happens before the webview loads, so pull the
+  // notice instead of listening for an event, and hold it until the flyout is
+  // actually visible — a toast fired into a hidden window would expire unseen.
+  const pendingHotkeyNotice = useRef<HotkeyStartupNotice | null>(null);
+  useEffect(() => {
+    if (assetCaptureEnabled) return;
+    invoke<HotkeyStartupNotice | null>('get_hotkey_startup_notice')
+      .then((notice) => {
+        pendingHotkeyNotice.current = notice;
+      })
+      .catch(console.error);
+  }, []);
+
+  const showPendingHotkeyNotice = useCallback(() => {
+    const notice = pendingHotkeyNotice.current;
+    if (!notice) return;
+    pendingHotkeyNotice.current = null;
+    const message =
+      notice.kind === 'fallback_hotkey'
+        ? t('notifications.hotkeyFallback', {
+            requested: notice.requested_hotkey,
+            active: notice.active_hotkey,
+          })
+        : notice.kind === 'win_v_disabled'
+          ? t('notifications.hotkeyWinVDisabled', {
+              hotkey: notice.active_hotkey ?? notice.requested_hotkey,
+            })
+          : t('notifications.hotkeyFailed');
+    toast.warning(message, { duration: 10000 });
+  }, [t]);
+
   const refreshPasteContext = useCallback(() => {
     if (assetCaptureEnabled) {
       setPasteContext({ target_kind: 'standard', remote_paste_mode: 'copy_then_paste' });
@@ -175,25 +221,27 @@ function App() {
   // every dismissal path (Esc, click-away, and post-paste hide).
   useEffect(() => {
     const unlisten = appWindow.onFocusChanged(({ payload: focused }) => {
-      if (!focused) {
-        setSearchQuery('');
-        setContentFilter('all');
-        setSelectedFolder(null);
-        // Reset selection and scroll the list back to the top, so reopening
-        // always shows your most-recent copy instead of wherever you'd scrolled.
-        setSelectedClipId(null);
-        setClipListResetToken((prev) => prev + 1);
-        // Dismiss any transient overlays so reopening lands on the clean list.
-        setContextMenu(null);
-        setClearRequest(null);
-        setShowAddFolderModal(false);
-        setNewFolderName('');
+      if (focused) {
+        showPendingHotkeyNotice();
+        return;
       }
+      setSearchQuery('');
+      setContentFilter('all');
+      setSelectedFolder(null);
+      // Reset selection and scroll the list back to the top, so reopening
+      // always shows your most-recent copy instead of wherever you'd scrolled.
+      setSelectedClipId(null);
+      setClipListResetToken((prev) => prev + 1);
+      // Dismiss any transient overlays so reopening lands on the clean list.
+      setContextMenu(null);
+      setClearRequest(null);
+      setShowAddFolderModal(false);
+      setNewFolderName('');
     });
     return () => {
       unlisten.then((dispose) => dispose()).catch(() => undefined);
     };
-  }, [appWindow]);
+  }, [appWindow, showPendingHotkeyNotice]);
 
   const openSettings = useCallback(async () => {
     // Check if settings window already exists
@@ -236,7 +284,12 @@ function App() {
   }, []);
 
   const loadClips = useCallback(
-    async (folderId: string | null, append: boolean = false, searchQuery: string = '') => {
+    async (
+      folderId: string | null,
+      append: boolean = false,
+      searchQuery: string = '',
+      filter: ContentFilter = 'all'
+    ) => {
       const perfId = ++loadPerfIdRef.current;
       const loadStart = perfLogEnabled ? performance.now() : 0;
       let invokeStart = 0;
@@ -267,7 +320,8 @@ function App() {
                 .toLocaleLowerCase();
               return searchable.includes(query);
             })
-            .map((clip) => ({ ...clip, ocr_match: query ? clip.ocr_match : null }));
+            .map((clip) => ({ ...clip, ocr_match: query ? clip.ocr_match : null }))
+            .filter((clip) => matchesContentFilter(clip, filter));
           invokeStart = performance.now();
           invokeEnd = invokeStart;
         } else if (searchQuery.trim()) {
@@ -277,6 +331,7 @@ function App() {
             filterId: folderId,
             limit: 20,
             offset: currentOffset,
+            contentFilter: filter,
           });
           if (perfLogEnabled) invokeEnd = performance.now();
         } else {
@@ -286,6 +341,7 @@ function App() {
             limit: 20,
             offset: currentOffset,
             previewOnly: true,
+            contentFilter: filter,
           });
           if (perfLogEnabled) invokeEnd = performance.now();
         }
@@ -367,8 +423,8 @@ function App() {
   }, []);
 
   const refreshCurrentFolder = useCallback(() => {
-    loadClips(selectedFolderRef.current, false, searchQuery);
-  }, [loadClips, searchQuery]);
+    loadClips(selectedFolderRef.current, false, searchQuery, contentFilter);
+  }, [loadClips, searchQuery, contentFilter]);
 
   const handleSearch = useCallback((query: string) => {
     setSearchQuery(query);
@@ -383,13 +439,9 @@ function App() {
 
   useEffect(() => {
     loadFolders();
-    if (searchQuery.trim()) {
-      loadClips(selectedFolder, false, searchQuery);
-    } else {
-      loadClips(selectedFolder);
-    }
+    loadClips(selectedFolder, false, searchQuery.trim() ? searchQuery : '', contentFilter);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedFolder, searchQuery]);
+  }, [selectedFolder, searchQuery, contentFilter]);
 
   // Total History Count
   const [totalClipCount, setTotalClipCount] = useState(0);
@@ -583,18 +635,9 @@ function App() {
     [setClips]
   );
 
-  // Keyboard navigation handlers
-  const visibleClips = useMemo(
-    () =>
-      clips.filter((clip) => {
-        if (contentFilter === 'images') return clip.clip_type === 'image';
-        if (contentFilter === 'text') return clip.clip_type === 'text';
-        if (contentFilter === 'files')
-          return clip.clip_type === 'file' || clip.clip_type === 'files';
-        return true;
-      }),
-    [clips, contentFilter]
-  );
+  // Content tabs are filtered by the backend query (paging stays correct that
+  // way), so every loaded clip is visible.
+  const visibleClips = clips;
 
   const emptyState = useMemo(() => {
     if (searchQuery.trim()) {
@@ -632,27 +675,6 @@ function App() {
       description: t('clipList.emptyDesc'),
     };
   }, [contentFilter, searchQuery, selectedFolder, t]);
-
-  useEffect(() => {
-    if (
-      contentFilter !== 'all' &&
-      clips.length > 0 &&
-      visibleClips.length === 0 &&
-      hasMore &&
-      !isLoading
-    ) {
-      loadClips(selectedFolder, true, searchQuery);
-    }
-  }, [
-    clips.length,
-    contentFilter,
-    hasMore,
-    isLoading,
-    loadClips,
-    searchQuery,
-    selectedFolder,
-    visibleClips.length,
-  ]);
 
   useEffect(() => {
     if (visibleClips.length === 0) {
@@ -792,9 +814,9 @@ function App() {
 
   const loadMore = useCallback(() => {
     if (hasMore && !isLoading) {
-      loadClips(selectedFolder, true, searchQuery);
+      loadClips(selectedFolder, true, searchQuery, contentFilter);
     }
-  }, [hasMore, isLoading, selectedFolder, loadClips, searchQuery]);
+  }, [hasMore, isLoading, selectedFolder, loadClips, searchQuery, contentFilter]);
 
   // New Folder Modal Rename Mode
   const [folderModalMode, setFolderModalMode] = useState<'create' | 'rename'>('create');
@@ -876,7 +898,7 @@ function App() {
       setSelectedClipId(null);
       setClipListResetToken((token) => token + 1);
       await Promise.all([
-        loadClips(selectedFolder, false, searchQuery),
+        loadClips(selectedFolder, false, searchQuery, contentFilter),
         loadFolders(),
         refreshTotalCount(),
       ]);

--- a/frontend/src/components/ClipCard.tsx
+++ b/frontend/src/components/ClipCard.tsx
@@ -10,10 +10,9 @@ interface ClipCardProps {
   clip: ClipboardItem;
   density: 'compact' | 'comfortable';
   isSelected: boolean;
-  /** Fired on mouse enter AND move; the list ignores events whose pointer
-   *  position hasn't changed (a card sliding under a stationary cursor when
-   *  arrow-key navigation scrolls the list must not steal the selection). */
-  onHover: (event: React.MouseEvent) => void;
+  /** Fired only on real mouse movement. A card sliding under a stationary
+   *  cursor during keyboard navigation must not steal selection. */
+  onHover: () => void;
   onPaste: () => void;
   onCopy: () => void;
   onTogglePin: () => void;
@@ -133,7 +132,6 @@ export const ClipCard = memo(function ClipCard({
       data-selected={isSelected}
       role="listitem"
       aria-current={isSelected ? 'true' : undefined}
-      onMouseEnter={onHover}
       onMouseMove={onHover}
       onClick={onPaste}
       onContextMenu={(event) => {

--- a/frontend/src/components/ClipCard.tsx
+++ b/frontend/src/components/ClipCard.tsx
@@ -10,7 +10,10 @@ interface ClipCardProps {
   clip: ClipboardItem;
   density: 'compact' | 'comfortable';
   isSelected: boolean;
-  onSelect: () => void;
+  /** Fired on mouse enter AND move; the list ignores events whose pointer
+   *  position hasn't changed (a card sliding under a stationary cursor when
+   *  arrow-key navigation scrolls the list must not steal the selection). */
+  onHover: (event: React.MouseEvent) => void;
   onPaste: () => void;
   onCopy: () => void;
   onTogglePin: () => void;
@@ -70,7 +73,7 @@ export const ClipCard = memo(function ClipCard({
   clip,
   density,
   isSelected,
-  onSelect,
+  onHover,
   onPaste,
   onCopy,
   onTogglePin,
@@ -130,7 +133,8 @@ export const ClipCard = memo(function ClipCard({
       data-selected={isSelected}
       role="listitem"
       aria-current={isSelected ? 'true' : undefined}
-      onMouseEnter={onSelect}
+      onMouseEnter={onHover}
+      onMouseMove={onHover}
       onClick={onPaste}
       onContextMenu={(event) => {
         event.preventDefault();

--- a/frontend/src/components/ClipList.tsx
+++ b/frontend/src/components/ClipList.tsx
@@ -43,6 +43,20 @@ export function ClipList({
 }: ClipListProps) {
   const { t } = useTranslation();
   const listRef = useRef<HTMLDivElement>(null);
+  // Last pointer position seen over a card. Arrow-key navigation calls
+  // scrollIntoView, which slides cards under a stationary cursor and fires
+  // mouseenter without any real mouse movement — acting on those would yank
+  // the selection (and the next Enter) back to whatever landed under the
+  // cursor. Only a pointer that actually moved may change the selection.
+  const lastPointer = useRef<{ x: number; y: number } | null>(null);
+
+  const handleCardHover = (clipId: string) => (event: React.MouseEvent) => {
+    const previous = lastPointer.current;
+    const moved =
+      previous !== null && (previous.x !== event.clientX || previous.y !== event.clientY);
+    lastPointer.current = { x: event.clientX, y: event.clientY };
+    if (moved) onSelectClip(clipId);
+  };
 
   useEffect(() => {
     listRef.current?.scrollTo({ top: 0 });
@@ -113,7 +127,7 @@ export function ClipList({
             clip={clip}
             density={density}
             isSelected={selectedClipId === clip.id}
-            onSelect={() => onSelectClip(clip.id)}
+            onHover={handleCardHover(clip.id)}
             onPaste={() => onPaste(clip.id)}
             onCopy={() => onCopy(clip.id)}
             onTogglePin={() => onTogglePin(clip.id)}

--- a/frontend/src/components/ClipList.tsx
+++ b/frontend/src/components/ClipList.tsx
@@ -43,20 +43,10 @@ export function ClipList({
 }: ClipListProps) {
   const { t } = useTranslation();
   const listRef = useRef<HTMLDivElement>(null);
-  // Last pointer position seen over a card. Arrow-key navigation calls
-  // scrollIntoView, which slides cards under a stationary cursor and fires
-  // mouseenter without any real mouse movement — acting on those would yank
-  // the selection (and the next Enter) back to whatever landed under the
-  // cursor. Only a pointer that actually moved may change the selection.
-  const lastPointer = useRef<{ x: number; y: number } | null>(null);
-
-  const handleCardHover = (clipId: string) => (event: React.MouseEvent) => {
-    const previous = lastPointer.current;
-    const moved =
-      previous !== null && (previous.x !== event.clientX || previous.y !== event.clientY);
-    lastPointer.current = { x: event.clientX, y: event.clientY };
-    if (moved) onSelectClip(clipId);
-  };
+  // Arrow-key navigation can scroll a card under a stationary cursor and fire
+  // mouseenter. A mousemove, including the first one after opening the flyout,
+  // is direct evidence of pointer intent and may safely change selection.
+  const handleCardHover = (clipId: string) => () => onSelectClip(clipId);
 
   useEffect(() => {
     listRef.current?.scrollTo({ top: 0 });

--- a/frontend/src/hooks/useKeyboard.ts
+++ b/frontend/src/hooks/useKeyboard.ts
@@ -53,7 +53,10 @@ export function useKeyboard(options: KeyboardOptions) {
         return;
       }
 
-      if (!isEditing && e.key === 'p' && !e.metaKey && !e.ctrlKey && current.onPin) {
+      // Ctrl+P, not bare "p": every printable key is claimed by type-to-search
+      // (App's focusSearchOnTyping), so a bare-letter binding here would fire
+      // alongside it — typing "password" used to toggle pin state.
+      if (canNavigateHistory && (e.ctrlKey || e.metaKey) && e.key === 'p' && current.onPin) {
         e.preventDefault();
         current.onPin();
         return;

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -191,7 +191,10 @@
     "clearUnpinnedSuccess_one": "Cleared {{count}} unpinned item",
     "clearUnpinnedSuccess_other": "Cleared {{count}} unpinned items",
     "clearAllSuccess": "Clipboard history cleared",
-    "clearFailed": "Failed to clear clipboard history"
+    "clearFailed": "Failed to clear clipboard history",
+    "hotkeyFallback": "{{requested}} is in use by another app. Using {{active}} for this session — your setting is unchanged.",
+    "hotkeyWinVDisabled": "Win+V replacement is unavailable right now. Open Cubby with {{hotkey}} for this session.",
+    "hotkeyFailed": "No global hotkey could be registered. Open Cubby from the tray icon and try a different hotkey in Settings."
   },
   "clearHistory": {
     "unpinnedTitle": "Clear unpinned items?",

--- a/src-tauri/src/cf_html.rs
+++ b/src-tauri/src/cf_html.rs
@@ -1,0 +1,140 @@
+//! CF_HTML assembly for clipboard writes.
+//!
+//! Capture stores the *document* part of a CF_HTML payload (clipboard-rs
+//! `get_html` returns the StartHTML..EndHTML slice, header stripped). Writing
+//! that document back raw produces an invalid "HTML Format" entry that
+//! Office-class apps reject, so every restore must re-attach a header with
+//! correct byte offsets.
+//!
+//! Restores must hash the exact bytes a re-capture of our own write will read
+//! back, so [`document`] (the normalized StartHTML..EndHTML slice) feeds the
+//! ignore-hash material and [`to_cf_html`] produces the clipboard payload.
+
+const START_FRAGMENT_MARKER: &str = "<!--StartFragment-->";
+const END_FRAGMENT_MARKER: &str = "<!--EndFragment-->";
+
+/// True when the payload already carries a CF_HTML header. Stored rows never
+/// should, but never double-wrap if one slips through.
+fn is_cf_html(payload: &str) -> bool {
+    payload.starts_with("Version:") && payload.contains("StartHTML:")
+}
+
+/// Normalize stored HTML into the document that will sit between StartHTML and
+/// EndHTML. HTML that already looks like a document (fragment markers or an
+/// `<html>` root) passes through byte-for-byte; bare fragments get the standard
+/// container so fragment offsets exist.
+pub(crate) fn document(html: &str) -> String {
+    if is_cf_html(html) {
+        if let Some(document_start) = html.find('<') {
+            return html[document_start..].to_string();
+        }
+        return html.to_string();
+    }
+    if html.contains(START_FRAGMENT_MARKER)
+        || html
+            .trim_start()
+            .get(..5)
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("<html"))
+    {
+        return html.to_string();
+    }
+    format!(
+        "<html>\r\n<body>\r\n{START_FRAGMENT_MARKER}{html}{END_FRAGMENT_MARKER}\r\n</body>\r\n</html>"
+    )
+}
+
+/// Wrap HTML into a complete CF_HTML payload (Version/StartHTML/EndHTML/
+/// StartFragment/EndFragment with zero-padded byte offsets).
+pub(crate) fn to_cf_html(html: &str) -> String {
+    if is_cf_html(html) {
+        return html.to_string();
+    }
+    let document = document(html);
+
+    // Fixed-width offsets keep the header length independent of the values.
+    const PLACEHOLDER: &str = "0000000000";
+    let header_len = format!(
+        "Version:0.9\r\nStartHTML:{PLACEHOLDER}\r\nEndHTML:{PLACEHOLDER}\r\nStartFragment:{PLACEHOLDER}\r\nEndFragment:{PLACEHOLDER}\r\n"
+    )
+    .len();
+
+    let start_html = header_len;
+    let end_html = header_len + document.len();
+    let start_fragment = header_len
+        + document
+            .find(START_FRAGMENT_MARKER)
+            .map(|position| position + START_FRAGMENT_MARKER.len())
+            .unwrap_or(0);
+    let end_fragment = header_len
+        + document
+            .rfind(END_FRAGMENT_MARKER)
+            .unwrap_or(document.len());
+
+    format!(
+        "Version:0.9\r\nStartHTML:{start_html:010}\r\nEndHTML:{end_html:010}\r\nStartFragment:{start_fragment:010}\r\nEndFragment:{end_fragment:010}\r\n{document}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{document, to_cf_html};
+
+    fn header_offset(payload: &str, key: &str) -> usize {
+        payload
+            .lines()
+            .find_map(|line| line.strip_prefix(key)?.strip_prefix(':'))
+            .expect("header present")
+            .parse()
+            .expect("numeric offset")
+    }
+
+    #[test]
+    fn wraps_bare_fragment_with_valid_offsets() {
+        let fragment = "<b>héllo</b>";
+        let payload = to_cf_html(fragment);
+
+        let start_html = header_offset(&payload, "StartHTML");
+        let end_html = header_offset(&payload, "EndHTML");
+        let start_fragment = header_offset(&payload, "StartFragment");
+        let end_fragment = header_offset(&payload, "EndFragment");
+
+        assert!(payload.as_bytes()[start_html..].starts_with(b"<html>"));
+        assert_eq!(end_html, payload.len());
+        assert_eq!(&payload[start_fragment..end_fragment], fragment);
+    }
+
+    #[test]
+    fn preserves_captured_document_bytes() {
+        // What get_html hands back for a typical browser copy: full document
+        // including fragment markers, header already stripped.
+        let captured =
+            "<html>\r\n<body>\r\n<!--StartFragment--><p>from chrome</p><!--EndFragment-->\r\n</body>\r\n</html>";
+        assert_eq!(document(captured), captured);
+
+        let payload = to_cf_html(captured);
+        let start_html = header_offset(&payload, "StartHTML");
+        assert_eq!(&payload[start_html..], captured);
+        let start_fragment = header_offset(&payload, "StartFragment");
+        let end_fragment = header_offset(&payload, "EndFragment");
+        assert_eq!(&payload[start_fragment..end_fragment], "<p>from chrome</p>");
+    }
+
+    #[test]
+    fn does_not_double_wrap_existing_cf_html() {
+        let existing = to_cf_html("<i>once</i>");
+        assert_eq!(to_cf_html(&existing), existing);
+        assert_eq!(document(&existing), document("<i>once</i>"));
+    }
+
+    #[test]
+    fn document_without_markers_keeps_html_root() {
+        let doc = "<HTML><body><p>no markers</p></body></HTML>";
+        assert_eq!(document(doc), doc);
+
+        let payload = to_cf_html(doc);
+        let start_fragment = header_offset(&payload, "StartFragment");
+        let end_fragment = header_offset(&payload, "EndFragment");
+        // No markers: the whole document is the fragment.
+        assert_eq!(&payload[start_fragment..end_fragment], doc);
+    }
+}

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -351,6 +351,117 @@ fn spawn_listener_watchdog() {
     }
 }
 
+/// Outcome of trying to ingest the clipboard for one sequence number.
+#[cfg(target_os = "windows")]
+enum CaptureAttempt {
+    /// A snapshot or clear event was queued (or the payload is unsupported);
+    /// the sequence was marked handled.
+    Handled,
+    /// Supported content is present but every clipboard open lost the race.
+    /// The sequence stays unhandled so the watchdog retries it.
+    Deferred,
+}
+
+/// Try to materialize and queue the clipboard content behind `sequence`.
+///
+/// The sequence is marked handled only after a successful materialize (or a
+/// confirmed clear / unsupported payload). A contended read leaves it
+/// unhandled: the watchdog then sees it stale after [`STALE_LISTENER_AFTER`]
+/// and restarts the listener, whose session start retries this capture instead
+/// of silently dropping the copy.
+///
+/// `Err(())` means the snapshot consumer is gone (process teardown).
+#[cfg(target_os = "windows")]
+fn capture_clipboard_update(
+    sequence: u32,
+    event_tx: &tokio::sync::mpsc::UnboundedSender<ClipboardListenerEvent>,
+) -> Result<CaptureAttempt, ()> {
+    let started = Instant::now();
+    let source_app_identity = get_clipboard_owner_identity();
+    let sensitive = clipboard_marked_sensitive();
+
+    if let Some((content, formats)) = materialize_clipboard_content() {
+        note_clipboard_event(sequence);
+        let snapshot = ClipboardSnapshot {
+            sequence,
+            source_app_identity,
+            content,
+            formats,
+            materialize_ms: started.elapsed().as_millis(),
+            sensitive,
+        };
+        return event_tx
+            .send(ClipboardListenerEvent::Content(snapshot))
+            .map(|_| CaptureAttempt::Handled)
+            .map_err(|_| ());
+    }
+
+    if clipboard_is_cleared() {
+        // Empty clipboard (or empty text with no image/files). This is
+        // the password-manager auto-clear signal; never treat a new
+        // non-empty copy as a clear.
+        note_clipboard_event(sequence);
+        return event_tx
+            .send(ClipboardListenerEvent::Cleared { sequence })
+            .map(|_| CaptureAttempt::Handled)
+            .map_err(|_| ());
+    }
+
+    if clipboard_has_supported_format() {
+        log::warn!(
+            "CLIPBOARD: Could not materialize sequence {} (clipboard contended); deferring for watchdog retry",
+            sequence
+        );
+        return Ok(CaptureAttempt::Deferred);
+    }
+
+    // Nothing we support (custom/private formats only). Mark handled so the
+    // watchdog does not treat an ignored format as a dead listener.
+    note_clipboard_event(sequence);
+    log::debug!(
+        "CLIPBOARD: Sequence {} contained no supported text or image payload",
+        sequence
+    );
+    Ok(CaptureAttempt::Handled)
+}
+
+/// True when the clipboard advertises a format `materialize_clipboard_content`
+/// can read (text, files, or an image). Used to tell "unsupported payload"
+/// (mark handled) apart from "supported but contended" (defer and retry).
+#[cfg(target_os = "windows")]
+fn clipboard_has_supported_format() -> bool {
+    use windows::core::PCWSTR;
+    use windows::Win32::System::DataExchange::{
+        IsClipboardFormatAvailable, RegisterClipboardFormatW,
+    };
+
+    const CF_TEXT: u32 = 1;
+    const CF_BITMAP: u32 = 2;
+    const CF_DIB: u32 = 8;
+    const CF_UNICODETEXT: u32 = 13;
+    const CF_HDROP: u32 = 15;
+    const CF_DIBV5: u32 = 17;
+
+    if [
+        CF_UNICODETEXT,
+        CF_TEXT,
+        CF_HDROP,
+        CF_DIB,
+        CF_DIBV5,
+        CF_BITMAP,
+    ]
+    .into_iter()
+    .any(|format| unsafe { IsClipboardFormatAvailable(format) }.is_ok())
+    {
+        return true;
+    }
+
+    // Some producers put only a registered "PNG" entry on the clipboard.
+    let name: Vec<u16> = "PNG".encode_utf16().chain(std::iter::once(0)).collect();
+    let png_format = unsafe { RegisterClipboardFormatW(PCWSTR(name.as_ptr())) };
+    png_format != 0 && unsafe { IsClipboardFormatAvailable(png_format) }.is_ok()
+}
+
 #[cfg(target_os = "windows")]
 fn run_listener_session(
     monitor: &mut Monitor,
@@ -359,48 +470,10 @@ fn run_listener_session(
     loop {
         match monitor.recv() {
             Ok(true) => {
-                let started = Instant::now();
                 let sequence =
                     unsafe { windows::Win32::System::DataExchange::GetClipboardSequenceNumber() };
-                // Always mark the notification as seen, even when the payload is
-                // unsupported — otherwise the watchdog would treat ignored formats
-                // as a silent listener death.
-                note_clipboard_event(sequence);
-
-                let source_app_identity = get_clipboard_owner_identity();
-                let sensitive = clipboard_marked_sensitive();
-
-                if let Some((content, formats)) = materialize_clipboard_content() {
-                    let snapshot = ClipboardSnapshot {
-                        sequence,
-                        source_app_identity,
-                        content,
-                        formats,
-                        materialize_ms: started.elapsed().as_millis(),
-                        sensitive,
-                    };
-
-                    if event_tx
-                        .send(ClipboardListenerEvent::Content(snapshot))
-                        .is_err()
-                    {
-                        return ListenerSessionExit::ConsumerGone;
-                    }
-                } else if clipboard_is_cleared() {
-                    // Empty clipboard (or empty text with no image/files). This is
-                    // the password-manager auto-clear signal; never treat a new
-                    // non-empty copy as a clear.
-                    if event_tx
-                        .send(ClipboardListenerEvent::Cleared { sequence })
-                        .is_err()
-                    {
-                        return ListenerSessionExit::ConsumerGone;
-                    }
-                } else {
-                    log::debug!(
-                        "CLIPBOARD: Sequence {} contained no supported text or image payload",
-                        sequence
-                    );
+                if capture_clipboard_update(sequence, event_tx).is_err() {
+                    return ListenerSessionExit::ConsumerGone;
                 }
             }
             Ok(false) => return ListenerSessionExit::RestartRequested,
@@ -481,15 +554,19 @@ fn clipboard_format_count_is_zero() -> bool {
 /// Tradeoffs (SOU-218):
 /// - Forever-restart + capped backoff prefers availability over giving up.
 /// - Watchdog recreates the monitor when the clipboard sequence advances but no
-///   event arrives for [`STALE_LISTENER_AFTER`]. That can miss copies for up to
-///   ~5–7s after a silent death (sleep/Explorer), but avoids power-session Win32
+///   event arrives for [`STALE_LISTENER_AFTER`]. Capture can lag up to ~5–7s
+///   after a silent death (sleep/Explorer), but avoids power-session Win32
 ///   surface area and toast spam.
+/// - Every session start after the first catches up on a sequence the previous
+///   session missed (restart window) or deferred (contended materialize), so
+///   those copies are ingested late rather than lost.
 /// - Consumer channel close stops the supervisor (process teardown).
 #[cfg(target_os = "windows")]
 fn run_native_listener(event_tx: tokio::sync::mpsc::UnboundedSender<ClipboardListenerEvent>) {
     spawn_listener_watchdog();
 
     let mut backoff = INITIAL_LISTENER_BACKOFF;
+    let mut first_session = true;
     loop {
         set_capture_state(CAPTURE_STATE_RESTARTING);
 
@@ -510,7 +587,25 @@ fn run_native_listener(event_tx: tokio::sync::mpsc::UnboundedSender<ClipboardLis
 
         let current_sequence =
             unsafe { windows::Win32::System::DataExchange::GetClipboardSequenceNumber() };
-        note_clipboard_event(current_sequence);
+        if first_session {
+            // Don't ingest whatever was on the clipboard before Cubby started;
+            // only copies made while running belong in history.
+            note_clipboard_event(current_sequence);
+            first_session = false;
+        } else if current_sequence != LAST_HANDLED_SEQUENCE.load(Ordering::SeqCst) {
+            // A copy landed while the listener was down, or a previous
+            // materialize was deferred under contention. Catch up now instead
+            // of stamping the sequence handled and losing the copy.
+            log::info!(
+                "CLIPBOARD: Catching up on clipboard sequence {} missed during listener restart",
+                current_sequence
+            );
+            if capture_clipboard_update(current_sequence, &event_tx).is_err() {
+                record_capture_error("snapshot consumer stopped; capture supervisor exiting");
+                set_capture_state(CAPTURE_STATE_STOPPED);
+                return;
+            }
+        }
         set_capture_state(CAPTURE_STATE_LISTENING);
         log::info!("CLIPBOARD: Native WM_CLIPBOARDUPDATE listener started");
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -575,10 +575,13 @@ fn clipboard_contents_for_restore(
     if !plain_text {
         for (format, content) in formats {
             match format.as_str() {
-                "html" => contents.push(ClipboardContent::Html(
-                    String::from_utf8(content.clone())
+                // Stored HTML is the header-stripped document (see cf_html.rs);
+                // clipboard-rs's multi-content set() writes it raw, so re-attach
+                // a valid CF_HTML header or Office-class apps reject the paste.
+                "html" => contents.push(ClipboardContent::Html(crate::cf_html::to_cf_html(
+                    &String::from_utf8(content.clone())
                         .map_err(|_| "stored HTML is not UTF-8".to_string())?,
-                )),
+                ))),
                 "rtf" => contents.push(ClipboardContent::Rtf(
                     String::from_utf8(content.clone())
                         .map_err(|_| "stored RTF is not UTF-8".to_string())?,
@@ -594,12 +597,25 @@ fn clipboard_contents_for_restore(
     Ok(contents)
 }
 
+/// SQL restriction for the flyout's content tabs. Filtering must happen in the
+/// query — the list pages 20 rows at a time, and filtering a page client-side
+/// hides matching items that live on unfetched pages.
+fn content_filter_clause(content_filter: Option<&str>) -> &'static str {
+    match content_filter {
+        Some("images") => " AND clip_type = 'image'",
+        Some("text") => " AND clip_type = 'text'",
+        Some("files") => " AND clip_type IN ('file', 'files')",
+        _ => "",
+    }
+}
+
 #[tauri::command]
 pub async fn get_clips(
     filter_id: Option<String>,
     limit: i64,
     offset: i64,
     preview_only: Option<bool>,
+    content_filter: Option<String>,
     db: tauri::State<'_, Arc<Database>>,
 ) -> Result<Vec<ClipboardItem>, String> {
     let pool = &db.pool;
@@ -607,23 +623,23 @@ pub async fn get_clips(
     let started = Instant::now();
 
     log::info!(
-        "get_clips called with filter_id: {:?}, preview_only: {}",
+        "get_clips called with filter_id: {:?}, preview_only: {}, content_filter: {:?}",
         filter_id,
-        preview_only
+        preview_only,
+        content_filter
     );
 
+    let type_clause = content_filter_clause(content_filter.as_deref());
     let sql_started = Instant::now();
     let mut clips: Vec<Clip> = match filter_id.as_deref() {
         Some(id) => {
             let folder_id_num = id.parse::<i64>().ok();
             if let Some(numeric_id) = folder_id_num {
                 log::info!("Querying for folder_id: {}", numeric_id);
-                sqlx::query_as(
-                    r#"
-                    SELECT * FROM clips WHERE is_deleted = 0 AND folder_id = ?
-                    ORDER BY is_pinned DESC, created_at DESC LIMIT ? OFFSET ?
-                "#,
-                )
+                sqlx::query_as(&format!(
+                    "SELECT * FROM clips WHERE is_deleted = 0 AND folder_id = ?{type_clause} \
+                     ORDER BY is_pinned DESC, created_at DESC LIMIT ? OFFSET ?"
+                ))
                 .bind(numeric_id)
                 .bind(limit)
                 .bind(offset)
@@ -637,12 +653,10 @@ pub async fn get_clips(
         }
         None => {
             log::info!("Querying for items, offset: {}, limit: {}", offset, limit);
-            sqlx::query_as(
-                r#"
-                SELECT * FROM clips WHERE is_deleted = 0
-                ORDER BY is_pinned DESC, created_at DESC LIMIT ? OFFSET ?
-            "#,
-            )
+            sqlx::query_as(&format!(
+                "SELECT * FROM clips WHERE is_deleted = 0{type_clause} \
+                 ORDER BY is_pinned DESC, created_at DESC LIMIT ? OFFSET ?"
+            ))
             .bind(limit)
             .bind(offset)
             .fetch_all(pool)
@@ -751,7 +765,22 @@ async fn restore_clip(
             // Synchronize clipboard access across the app
             let _guard = crate::clipboard::CLIPBOARD_SYNC.lock().await;
 
-            let formats = load_clip_formats(db, &clip.uuid).await?;
+            // Normalize HTML to the document form a re-capture of our own
+            // clipboard write reads back (bare legacy fragments gain the
+            // standard container), so the ignore hash below matches it.
+            let formats = load_clip_formats(db, &clip.uuid)
+                .await?
+                .into_iter()
+                .map(|(format, content)| {
+                    if format == "html" {
+                        if let Ok(html) = std::str::from_utf8(&content) {
+                            let document = crate::cf_html::document(html);
+                            return (format, document.into_bytes());
+                        }
+                    }
+                    (format, content)
+                })
+                .collect::<Vec<_>>();
             let full_image = if clip.clip_type == "image" {
                 Some(load_full_image_content(db, &mut clip).await?)
             } else {
@@ -1108,9 +1137,10 @@ pub async fn search_clips(
     filter_id: Option<String>,
     limit: i64,
     offset: i64,
+    content_filter: Option<String>,
     db: tauri::State<'_, Arc<Database>>,
 ) -> Result<Vec<ClipboardItem>, String> {
-    search_clips_in_database(query, filter_id, limit, offset, db.inner()).await
+    search_clips_in_database(query, filter_id, limit, offset, content_filter, db.inner()).await
 }
 
 async fn search_clips_in_database(
@@ -1118,6 +1148,7 @@ async fn search_clips_in_database(
     filter_id: Option<String>,
     limit: i64,
     offset: i64,
+    content_filter: Option<String>,
     db: &Database,
 ) -> Result<Vec<ClipboardItem>, String> {
     let pool = &db.pool;
@@ -1145,27 +1176,22 @@ async fn search_clips_in_database(
     // Ordering, pinning, folder filtering, and pagination remain authoritative
     // in SQLite. Only UUIDs are scanned here; encrypted payloads are fetched and
     // decrypted for the final result page.
+    let type_clause = content_filter_clause(content_filter.as_deref());
     let sql_started = Instant::now();
     let ordered_ids: Vec<String> = if let Some(folder_id) = folder_id {
-        sqlx::query_scalar(
-            r#"
-            SELECT uuid FROM clips
-            WHERE is_deleted = 0 AND folder_id = ?
-            ORDER BY is_pinned DESC, created_at DESC
-            "#,
-        )
+        sqlx::query_scalar(&format!(
+            "SELECT uuid FROM clips WHERE is_deleted = 0 AND folder_id = ?{type_clause} \
+             ORDER BY is_pinned DESC, created_at DESC"
+        ))
         .bind(folder_id)
         .fetch_all(pool)
         .await
         .map_err(|error| error.to_string())?
     } else {
-        sqlx::query_scalar(
-            r#"
-            SELECT uuid FROM clips
-            WHERE is_deleted = 0
-            ORDER BY is_pinned DESC, created_at DESC
-            "#,
-        )
+        sqlx::query_scalar(&format!(
+            "SELECT uuid FROM clips WHERE is_deleted = 0{type_clause} \
+             ORDER BY is_pinned DESC, created_at DESC"
+        ))
         .fetch_all(pool)
         .await
         .map_err(|error| error.to_string())?
@@ -1943,7 +1969,7 @@ mod tests {
         )
         .await;
 
-        let first = search_clips_in_database("ALPHA".into(), None, 1, 0, &database)
+        let first = search_clips_in_database("ALPHA".into(), None, 1, 0, None, &database)
             .await
             .unwrap();
         assert_eq!(first[0].id, "ocr-result");
@@ -1954,7 +1980,7 @@ mod tests {
             "Alpha receipt 8372"
         );
 
-        let second = search_clips_in_database("alpha".into(), None, 1, 1, &database)
+        let second = search_clips_in_database("alpha".into(), None, 1, 1, None, &database)
             .await
             .unwrap();
         assert_eq!(second[0].id, "text-result");
@@ -1964,12 +1990,34 @@ mod tests {
             Some(folder_id.to_string()),
             10,
             0,
+            None,
             &database,
         )
         .await
         .unwrap();
         assert_eq!(folder.len(), 1);
         assert_eq!(folder[0].id, "text-result");
+
+        // Content tabs filter in the query itself so pagination stays correct.
+        let images_only = search_clips_in_database(
+            "alpha".into(),
+            None,
+            10,
+            0,
+            Some("images".into()),
+            &database,
+        )
+        .await
+        .unwrap();
+        assert_eq!(images_only.len(), 1);
+        assert_eq!(images_only[0].id, "ocr-result");
+
+        let text_only =
+            search_clips_in_database("alpha".into(), None, 10, 0, Some("text".into()), &database)
+                .await
+                .unwrap();
+        assert_eq!(text_only.len(), 1);
+        assert_eq!(text_only[0].id, "text-result");
 
         let persisted_search_tables: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM sqlite_master WHERE lower(name) LIKE '%search%' OR lower(sql) LIKE '%fts%'",
@@ -2252,7 +2300,14 @@ mod tests {
 
         let rich = clipboard_contents_for_restore(&clip, None, &formats, false).unwrap();
         assert!(matches!(&rich[0], ClipboardContent::Text(text) if text == "Hello"));
-        assert!(matches!(&rich[1], ClipboardContent::Html(html) if html == "<b>Hello</b>"));
+        // HTML must go out as full CF_HTML — clipboard-rs's multi-content set()
+        // writes the string raw, and Office rejects a headerless payload.
+        assert!(matches!(
+            &rich[1],
+            ClipboardContent::Html(html)
+                if html.starts_with("Version:0.9\r\nStartHTML:")
+                    && html.contains("<b>Hello</b>")
+        ));
         assert!(matches!(&rich[2], ClipboardContent::Rtf(rtf) if rtf.contains("Hello")));
 
         let plain = clipboard_contents_for_restore(&clip, None, &formats, true).unwrap();

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -636,16 +636,17 @@ pub async fn get_clips(
             let folder_id_num = id.parse::<i64>().ok();
             if let Some(numeric_id) = folder_id_num {
                 log::info!("Querying for folder_id: {}", numeric_id);
-                sqlx::query_as(&format!(
+                let sql = format!(
                     "SELECT * FROM clips WHERE is_deleted = 0 AND folder_id = ?{type_clause} \
                      ORDER BY is_pinned DESC, created_at DESC LIMIT ? OFFSET ?"
-                ))
-                .bind(numeric_id)
-                .bind(limit)
-                .bind(offset)
-                .fetch_all(pool)
-                .await
-                .map_err(|e| e.to_string())?
+                );
+                sqlx::query_as(&sql)
+                    .bind(numeric_id)
+                    .bind(limit)
+                    .bind(offset)
+                    .fetch_all(pool)
+                    .await
+                    .map_err(|e| e.to_string())?
             } else {
                 log::info!("Unknown folder_id, returning empty");
                 Vec::new()
@@ -653,15 +654,16 @@ pub async fn get_clips(
         }
         None => {
             log::info!("Querying for items, offset: {}, limit: {}", offset, limit);
-            sqlx::query_as(&format!(
+            let sql = format!(
                 "SELECT * FROM clips WHERE is_deleted = 0{type_clause} \
                  ORDER BY is_pinned DESC, created_at DESC LIMIT ? OFFSET ?"
-            ))
-            .bind(limit)
-            .bind(offset)
-            .fetch_all(pool)
-            .await
-            .map_err(|e| e.to_string())?
+            );
+            sqlx::query_as(&sql)
+                .bind(limit)
+                .bind(offset)
+                .fetch_all(pool)
+                .await
+                .map_err(|e| e.to_string())?
         }
     };
     let sql_ms = sql_started.elapsed().as_millis();
@@ -1179,22 +1181,24 @@ async fn search_clips_in_database(
     let type_clause = content_filter_clause(content_filter.as_deref());
     let sql_started = Instant::now();
     let ordered_ids: Vec<String> = if let Some(folder_id) = folder_id {
-        sqlx::query_scalar(&format!(
+        let sql = format!(
             "SELECT uuid FROM clips WHERE is_deleted = 0 AND folder_id = ?{type_clause} \
              ORDER BY is_pinned DESC, created_at DESC"
-        ))
-        .bind(folder_id)
-        .fetch_all(pool)
-        .await
-        .map_err(|error| error.to_string())?
+        );
+        sqlx::query_scalar(&sql)
+            .bind(folder_id)
+            .fetch_all(pool)
+            .await
+            .map_err(|error| error.to_string())?
     } else {
-        sqlx::query_scalar(&format!(
+        let sql = format!(
             "SELECT uuid FROM clips WHERE is_deleted = 0{type_clause} \
              ORDER BY is_pinned DESC, created_at DESC"
-        ))
-        .fetch_all(pool)
-        .await
-        .map_err(|error| error.to_string())?
+        );
+        sqlx::query_scalar(&sql)
+            .fetch_all(pool)
+            .await
+            .map_err(|error| error.to_string())?
     };
     let selected_ids = ordered_ids
         .into_iter()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ static IS_ANIMATING: AtomicBool = AtomicBool::new(false);
 static LAST_SHOW_TIME: AtomicI64 = AtomicI64::new(0);
 static SHOW_GENERATION: AtomicU64 = AtomicU64::new(0);
 
+mod cf_html;
 mod clipboard;
 mod commands;
 mod constants;
@@ -294,6 +295,12 @@ pub fn run_app() {
 
             let manager = app_handle.state::<Arc<SettingsManager>>();
             let mut shortcut_settings = manager.get();
+            let user_hotkey = shortcut_settings.hotkey.clone();
+            // Startup conflicts recover for this session only and are surfaced
+            // as a toast. The user's configured hotkey is never persisted over:
+            // a transient conflict at boot (another app briefly holding the
+            // key) must not permanently rewrite their choice, and the next
+            // launch retries the original settings.
             let mut shortcuts_ready = match shortcuts::register_shortcuts(
                 &app_handle,
                 &shortcut_settings.hotkey,
@@ -310,9 +317,16 @@ pub fn run_app() {
                         )
                         .is_ok();
 
-                    let recovered = if replacement_disabled {
+                    if replacement_disabled {
                         shortcut_settings.replace_win_v = false;
-                        log::warn!("SHORTCUT: Disabled Win+V replacement after startup conflict");
+                        log::warn!(
+                            "SHORTCUT: Disabled Win+V replacement for this session after startup conflict"
+                        );
+                        shortcuts::record_startup_notice(
+                            "win_v_disabled",
+                            &user_hotkey,
+                            Some(&user_hotkey),
+                        );
                         true
                     } else {
                         let fallback = "Win+Ctrl+Alt+V";
@@ -321,22 +335,18 @@ pub fn run_app() {
                         {
                             shortcut_settings.hotkey = fallback.to_string();
                             shortcut_settings.replace_win_v = false;
-                            log::warn!("SHORTCUT: Fell back to {}", fallback);
+                            log::warn!("SHORTCUT: Fell back to {} for this session", fallback);
+                            shortcuts::record_startup_notice(
+                                "fallback_hotkey",
+                                &user_hotkey,
+                                Some(fallback),
+                            );
                             true
                         } else {
                             shortcut_settings.replace_win_v = false;
-                            log::error!("SHORTCUT: No startup shortcut could be registered");
                             false
                         }
-                    };
-
-                    if let Err(save_error) = manager.save(shortcut_settings.clone()) {
-                        log::error!(
-                            "SHORTCUT: Failed to persist recovered shortcut settings: {}",
-                            save_error
-                        );
                     }
-                    recovered
                 }
             };
 
@@ -357,12 +367,17 @@ pub fn run_app() {
                     false,
                 )
                 .is_ok();
-                if let Err(save_error) = manager.save(shortcut_settings.clone()) {
-                    log::error!("WIN_V: Failed to persist disabled state: {}", save_error);
+                if shortcuts_ready {
+                    shortcuts::record_startup_notice(
+                        "win_v_disabled",
+                        &user_hotkey,
+                        Some(&shortcut_settings.hotkey),
+                    );
                 }
             }
             if !shortcuts_ready {
                 log::error!("SHORTCUT: Cubby started without a working global shortcut");
+                shortcuts::record_startup_notice("failed", &user_hotkey, None);
             }
             let handle_for_clip = app_handle.clone();
             let db_for_clip = db_for_clipboard.clone();
@@ -446,7 +461,8 @@ pub fn run_app() {
             ocr_queue::get_ocr_queue_status,
             ocr_queue::set_ocr_queue_paused,
             ocr_queue::retry_failed_ocr,
-            clipboard::get_clipboard_capture_status
+            clipboard::get_clipboard_capture_status,
+            shortcuts::get_hotkey_startup_notice
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/paste_engine.rs
+++ b/src-tauri/src/paste_engine.rs
@@ -242,25 +242,90 @@ pub fn restore_previous_foreground_window() -> bool {
     restored
 }
 
+/// Modifiers the user may still be holding from the launch hotkey (e.g.
+/// Win+Alt+V plus a quick Enter) or from Shift+Enter. Left down, they would
+/// combine with the synthesized Ctrl+V into Ctrl+Alt+V / Ctrl+Shift+V and
+/// trigger the wrong command in the target app (Paste Special in Word).
+#[cfg(target_os = "windows")]
+fn physically_held_modifiers() -> Vec<windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY> {
+    use windows::Win32::UI::Input::KeyboardAndMouse::{
+        GetAsyncKeyState, VK_LMENU, VK_LSHIFT, VK_LWIN, VK_RMENU, VK_RSHIFT, VK_RWIN,
+    };
+
+    [VK_LWIN, VK_RWIN, VK_LMENU, VK_RMENU, VK_LSHIFT, VK_RSHIFT]
+        .into_iter()
+        .filter(|key| unsafe { GetAsyncKeyState(key.0 as i32) } as u16 & 0x8000 != 0)
+        .collect()
+}
+
+/// The full key sequence for one synthesized paste: release held modifiers,
+/// tap Ctrl+V, restore the modifiers. `true` means key-up.
+///
+/// Restored Win/Alt would read as a lone tap when the user physically releases
+/// them later (Start menu opens / menu bar focuses), so a masking no-op key is
+/// tapped inside the restored hold — the same trick AutoHotkey uses.
+#[cfg(target_os = "windows")]
+fn paste_input_plan(
+    held_modifiers: &[windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY],
+) -> Vec<(
+    windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY,
+    bool,
+)> {
+    use windows::Win32::UI::Input::KeyboardAndMouse::{
+        VK_CONTROL, VK_LMENU, VK_LWIN, VK_NONAME, VK_RMENU, VK_RWIN, VK_V,
+    };
+
+    let mut plan = Vec::new();
+    for key in held_modifiers {
+        plan.push((*key, true));
+    }
+    plan.extend([
+        (VK_CONTROL, false),
+        (VK_V, false),
+        (VK_V, true),
+        (VK_CONTROL, true),
+    ]);
+    for key in held_modifiers {
+        plan.push((*key, false));
+    }
+    if held_modifiers
+        .iter()
+        .any(|key| [VK_LWIN, VK_RWIN, VK_LMENU, VK_RMENU].contains(key))
+    {
+        plan.push((VK_NONAME, false));
+        plan.push((VK_NONAME, true));
+    }
+    plan
+}
+
 #[cfg(target_os = "windows")]
 pub fn send_paste_input(strategy: PasteStrategy) -> u32 {
-    use windows::Win32::UI::Input::KeyboardAndMouse::{
-        SendInput, INPUT, KEYEVENTF_KEYUP, VK_CONTROL, VK_V,
-    };
+    use windows::Win32::UI::Input::KeyboardAndMouse::{SendInput, INPUT, KEYEVENTF_KEYUP};
 
     let label = match strategy {
         PasteStrategy::Standard => "Ctrl+V",
         PasteStrategy::RemoteSession => "Ctrl+V after remote clipboard synchronization",
         PasteStrategy::NinjaRemote => return send_ninja_paste_as_keystrokes(),
     };
-    log::info!("send_paste_input: sending {label}");
+    let held_modifiers = physically_held_modifiers();
+    log::info!(
+        "send_paste_input: sending {label} (releasing {} held modifier(s) around it)",
+        held_modifiers.len()
+    );
+    let inputs: Vec<INPUT> = paste_input_plan(&held_modifiers)
+        .into_iter()
+        .map(|(key, key_up)| {
+            keyboard_input(
+                key,
+                if key_up {
+                    KEYEVENTF_KEYUP
+                } else {
+                    Default::default()
+                },
+            )
+        })
+        .collect();
     unsafe {
-        let inputs = [
-            keyboard_input(VK_CONTROL, Default::default()),
-            keyboard_input(VK_V, Default::default()),
-            keyboard_input(VK_V, KEYEVENTF_KEYUP),
-            keyboard_input(VK_CONTROL, KEYEVENTF_KEYUP),
-        ];
         let result = SendInput(&inputs, std::mem::size_of::<INPUT>() as i32);
         log::info!("send_paste_input: SendInput returned {}", result);
         result
@@ -439,5 +504,44 @@ mod tests {
 
         assert_eq!(context.target_kind, "ninja");
         assert_eq!(context.remote_paste_mode, "copy_then_paste");
+    }
+
+    #[cfg(target_os = "windows")]
+    mod paste_input_plan {
+        use super::super::paste_input_plan;
+        use windows::Win32::UI::Input::KeyboardAndMouse::{
+            VK_CONTROL, VK_LMENU, VK_LSHIFT, VK_LWIN, VK_NONAME, VK_V,
+        };
+
+        #[test]
+        fn plain_paste_is_just_ctrl_v() {
+            assert_eq!(
+                paste_input_plan(&[]),
+                vec![
+                    (VK_CONTROL, false),
+                    (VK_V, false),
+                    (VK_V, true),
+                    (VK_CONTROL, true),
+                ]
+            );
+        }
+
+        #[test]
+        fn held_modifiers_are_released_first_and_restored_after() {
+            let plan = paste_input_plan(&[VK_LWIN, VK_LMENU]);
+            assert_eq!(&plan[..2], &[(VK_LWIN, true), (VK_LMENU, true)]);
+            assert_eq!(plan[2..4], [(VK_CONTROL, false), (VK_V, false)]);
+            assert_eq!(plan[6..8], [(VK_LWIN, false), (VK_LMENU, false)]);
+            // Win/Alt restore needs the Start-menu / menu-bar mask tap.
+            assert_eq!(&plan[8..], &[(VK_NONAME, false), (VK_NONAME, true)]);
+        }
+
+        #[test]
+        fn shift_only_hold_needs_no_mask_tap() {
+            let plan = paste_input_plan(&[VK_LSHIFT]);
+            assert_eq!(plan.first(), Some(&(VK_LSHIFT, true)));
+            assert_eq!(plan.last(), Some(&(VK_LSHIFT, false)));
+            assert!(!plan.iter().any(|(key, _)| *key == VK_NONAME));
+        }
     }
 }

--- a/src-tauri/src/paste_engine.rs
+++ b/src-tauri/src/paste_engine.rs
@@ -249,13 +249,23 @@ pub fn restore_previous_foreground_window() -> bool {
 #[cfg(target_os = "windows")]
 fn physically_held_modifiers() -> Vec<windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY> {
     use windows::Win32::UI::Input::KeyboardAndMouse::{
-        GetAsyncKeyState, VK_LMENU, VK_LSHIFT, VK_LWIN, VK_RMENU, VK_RSHIFT, VK_RWIN,
+        GetAsyncKeyState, VK_LCONTROL, VK_LMENU, VK_LSHIFT, VK_LWIN, VK_RCONTROL, VK_RMENU,
+        VK_RSHIFT, VK_RWIN,
     };
 
-    [VK_LWIN, VK_RWIN, VK_LMENU, VK_RMENU, VK_LSHIFT, VK_RSHIFT]
-        .into_iter()
-        .filter(|key| unsafe { GetAsyncKeyState(key.0 as i32) } as u16 & 0x8000 != 0)
-        .collect()
+    [
+        VK_LWIN,
+        VK_RWIN,
+        VK_LCONTROL,
+        VK_RCONTROL,
+        VK_LMENU,
+        VK_RMENU,
+        VK_LSHIFT,
+        VK_RSHIFT,
+    ]
+    .into_iter()
+    .filter(|key| unsafe { GetAsyncKeyState(key.0 as i32) } as u16 & 0x8000 != 0)
+    .collect()
 }
 
 /// The full key sequence for one synthesized paste: release held modifiers,
@@ -510,7 +520,7 @@ mod tests {
     mod paste_input_plan {
         use super::super::paste_input_plan;
         use windows::Win32::UI::Input::KeyboardAndMouse::{
-            VK_CONTROL, VK_LMENU, VK_LSHIFT, VK_LWIN, VK_NONAME, VK_V,
+            VK_CONTROL, VK_LCONTROL, VK_LMENU, VK_LSHIFT, VK_LWIN, VK_NONAME, VK_V,
         };
 
         #[test]
@@ -542,6 +552,22 @@ mod tests {
             assert_eq!(plan.first(), Some(&(VK_LSHIFT, true)));
             assert_eq!(plan.last(), Some(&(VK_LSHIFT, false)));
             assert!(!plan.iter().any(|(key, _)| *key == VK_NONAME));
+        }
+
+        #[test]
+        fn held_control_is_released_and_restored_around_paste() {
+            let plan = paste_input_plan(&[VK_LCONTROL]);
+            assert_eq!(plan.first(), Some(&(VK_LCONTROL, true)));
+            assert_eq!(
+                plan[1..5],
+                [
+                    (VK_CONTROL, false),
+                    (VK_V, false),
+                    (VK_V, true),
+                    (VK_CONTROL, true)
+                ]
+            );
+            assert_eq!(plan.last(), Some(&(VK_LCONTROL, false)));
         }
     }
 }

--- a/src-tauri/src/shortcuts.rs
+++ b/src-tauri/src/shortcuts.rs
@@ -15,6 +15,35 @@ struct ShortcutConfiguration {
 static CURRENT_CONFIGURATION: Lazy<Mutex<ShortcutConfiguration>> =
     Lazy::new(|| Mutex::new(ShortcutConfiguration::default()));
 
+/// What startup shortcut recovery did, surfaced to the flyout as a toast.
+/// Recovery is session-only — the user's configured hotkey is never persisted
+/// over — so the user must be told which hotkey is actually active.
+#[derive(Clone, serde::Serialize)]
+pub struct HotkeyStartupNotice {
+    /// "fallback_hotkey" | "win_v_disabled" | "failed"
+    pub kind: String,
+    pub requested_hotkey: String,
+    pub active_hotkey: Option<String>,
+}
+
+static STARTUP_NOTICE: Lazy<Mutex<Option<HotkeyStartupNotice>>> = Lazy::new(|| Mutex::new(None));
+
+pub fn record_startup_notice(kind: &str, requested_hotkey: &str, active_hotkey: Option<&str>) {
+    *STARTUP_NOTICE.lock().unwrap() = Some(HotkeyStartupNotice {
+        kind: kind.to_string(),
+        requested_hotkey: requested_hotkey.to_string(),
+        active_hotkey: active_hotkey.map(str::to_string),
+    });
+}
+
+/// One-shot: the flyout fetches this on mount and shows it on first focus.
+/// The setup hook runs before the webview loads, so an emitted event would be
+/// lost — pull is the reliable direction.
+#[tauri::command]
+pub fn get_hotkey_startup_notice() -> Option<HotkeyStartupNotice> {
+    STARTUP_NOTICE.lock().unwrap().take()
+}
+
 fn parser_hotkey(hotkey: &str) -> String {
     hotkey
         .split('+')


### PR DESCRIPTION
Fixes the confirmed defects from the reliability audit (the ones beyond PR #115), ranked by user impact.

## Fixes

1. **Malformed CF_HTML on paste** - restore now wraps stored HTML in a valid CF_HTML header (Version/StartHTML/EndHTML/StartFragment/EndFragment byte offsets) via a new `cf_html` module before writing, since clipboard-rs's multi-content `set()` writes the Html arm raw. The ignore-hash material uses the same normalized document, so re-capturing our own write still matches and self-pastes stay ignored.
2. **Typing "p" pinned the selected clip** - the bare-letter pin shortcut always collided with type-to-search, so typing "password" toggled pin state. Pin is now Ctrl+P (works in the search box too); type-to-search owns bare letters. AGENTS.md table updated.
3. **Enter pasted the wrong clip after arrow navigation** - `scrollIntoView` slid cards under the stationary cursor and their `mouseenter` stole the selection. Hover selection now fires only when the pointer position actually changed.
4. **Content tabs hid items** - Images/Text/Files filtering moved into the `get_clips`/`search_clips` SQL (allowlisted clause), so tabs page correctly instead of client-filtering 20-row pages. The auto-append workaround is gone.
5. **Startup hotkey conflict silently rewrote the user's hotkey** - recovery (disable Win+V replacement, or fall back to Win+Ctrl+Alt+V) is now session-only and never persisted; next launch retries the user's settings. Both fallback and total failure surface a toast the first time the flyout gains focus (pulled via `get_hotkey_startup_notice`, since setup runs before the webview loads).
6. **Contended/restart-window copies were lost** - the listener marks a clipboard sequence handled only after a successful materialize (or a confirmed clear / unsupported-format payload). A contended read defers the sequence so the watchdog restarts and the new session catches up on it; restarts no longer stamp the current sequence unread. First session still skips pre-launch clipboard content.
7. **Held modifiers combined with the synthesized Ctrl+V** - Win+Alt+V plus a quick Enter used to deliver Ctrl+Alt+V (Paste Special in Word). `send_paste_input` now releases physically-down Win/Alt/Shift via SendInput, taps Ctrl+V, restores them, and adds a VK_NONAME mask tap so the eventual physical Win/Alt release doesn't read as a lone tap (Start menu / menu bar).

## Note for PR #115

`relay_remote_capture` on the #115 branch writes captured HTML through the same raw path. After either branch lands, the relay should reuse `cf_html::to_cf_html` / `cf_html::document`; both PRs touch `clipboard.rs`, so expect a small merge conflict there.

## Verification

- `cargo test`: 95 lib tests pass, including new unit tests for CF_HTML offsets and the paste input plan; the rich-format restore test now asserts the CF_HTML header
- `cargo clippy --all-targets`: clean
- `cargo fmt --check`: clean
- `pnpm build` (tsc strict + vite): clean; `pnpm format:check`: clean