### PR TITLE
Harden Cubby reliability for v1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - Preserve valid rich HTML, exact whitespace, and retryable clipboard updates instead of silently losing or altering copied content
 - Make paste target selection, content filters, Ctrl+P pinning, held-modifier handling, and hotkey-conflict recovery behave predictably
 - Recover unreadable settings and damaged history safely, keep rolling backups refreshing on Windows, and avoid dropping paste callbacks during window transitions
-- Report failed Windows startup changes instead of showing a saved setting that Windows did not apply
+- Report failed Windows startup changes instead of showing a saved setting that Windows did not apply, without blocking or rewriting unrelated preferences
 - Keep Microsoft Store builds under Store-managed startup and update behavior without unsupported in-app controls
 - Update the reachable `event-listener` dependency to the patched release for RUSTSEC-2026-0221
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable Cubby Clipboard changes are documented here. PastePaw entries below Cubby's first beta are retained as upstream history and attribution.
 
+## v1.2.4
+
+### Added
+- Remote-session clipboard relay so a copy in one supported remote-control session can sync into another, with privacy gating and an opt-out in Settings
+
+### Fixed
+- Preserve valid rich HTML, exact whitespace, and retryable clipboard updates instead of silently losing or altering copied content
+- Make paste target selection, content filters, Ctrl+P pinning, held-modifier handling, and hotkey-conflict recovery behave predictably
+- Recover unreadable settings and damaged history safely, keep rolling backups refreshing on Windows, and avoid dropping paste callbacks during window transitions
+- Report failed Windows startup changes instead of showing a saved setting that Windows did not apply
+- Keep Microsoft Store builds under Store-managed startup and update behavior without unsupported in-app controls
+- Update the reachable `event-listener` dependency to the patched release for RUSTSEC-2026-0221
+
 ## v1.2.3
 
 ### Added

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -74,7 +74,7 @@ function App() {
 
   const effectiveTheme = useTheme(theme);
   useSystemAccent();
-  useUpdater();
+  useUpdater(settings?.self_update_available === true);
   useLanguage(settings?.language);
   const { t } = useTranslation();
   const hasRoundedCorners = settings?.round_corners ?? true;

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,5 +1,5 @@
 import { X, AlertTriangle } from 'lucide-react';
-import { useEffect } from 'react';
+import { useEffect, useId } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface ConfirmDialogProps {
@@ -26,6 +26,8 @@ export function ConfirmDialog({
   isBusy = false,
 }: ConfirmDialogProps) {
   const { t } = useTranslation();
+  const titleId = useId();
+  const descriptionId = useId();
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
@@ -41,7 +43,13 @@ export function ConfirmDialog({
 
   return (
     <div className="animate-in fade-in fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm duration-200">
-      <div className="animate-in zoom-in-95 w-full max-w-md scale-100 rounded-lg border border-border bg-background p-6 shadow-lg duration-200">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        className="animate-in zoom-in-95 w-full max-w-md scale-100 rounded-lg border border-border bg-background p-6 shadow-lg duration-200"
+      >
         <div className="mb-4 flex items-center justify-between">
           <div className="flex items-center gap-2">
             <div
@@ -53,23 +61,29 @@ export function ConfirmDialog({
             >
               <AlertTriangle size={18} />
             </div>
-            <h3 className="text-lg font-semibold">{title}</h3>
+            <h3 id={titleId} className="text-lg font-semibold">
+              {title}
+            </h3>
           </div>
           <button
             onClick={onCancel}
             disabled={isBusy}
+            aria-label={t('common.cancel')}
             className="text-muted-foreground hover:text-foreground disabled:opacity-40"
           >
             <X size={18} />
           </button>
         </div>
 
-        <p className="mb-6 text-sm text-muted-foreground">{message}</p>
+        <p id={descriptionId} className="mb-6 text-sm text-muted-foreground">
+          {message}
+        </p>
 
         <div className="flex justify-end gap-3">
           <button
             onClick={onCancel}
             disabled={isBusy}
+            autoFocus
             className="rounded-md border border-input bg-transparent px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground disabled:opacity-40"
           >
             {cancelText || t('common.cancel')}

--- a/frontend/src/components/ContextMenu.tsx
+++ b/frontend/src/components/ContextMenu.tsx
@@ -57,6 +57,8 @@ export function ContextMenu({ x, y, options, onClose }: ContextMenuProps) {
   return (
     <div
       ref={menuRef}
+      role="menu"
+      aria-label="Clipboard actions"
       className="animate-in fade-in-0 zoom-in-95 fixed z-50 max-h-[min(24rem,calc(100vh-1rem))] min-w-[12rem] overflow-y-auto rounded-lg border border-white/[0.1] bg-popover/95 p-1.5 shadow-2xl backdrop-blur-xl"
       style={style}
     >
@@ -64,6 +66,7 @@ export function ContextMenu({ x, y, options, onClose }: ContextMenuProps) {
         {options.map((option, index) => (
           <button
             key={index}
+            role="menuitem"
             disabled={option.disabled}
             onClick={() => {
               option.onClick();

--- a/frontend/src/components/ContextMenu.tsx
+++ b/frontend/src/components/ContextMenu.tsx
@@ -57,8 +57,6 @@ export function ContextMenu({ x, y, options, onClose }: ContextMenuProps) {
   return (
     <div
       ref={menuRef}
-      role="menu"
-      aria-label="Clipboard actions"
       className="animate-in fade-in-0 zoom-in-95 fixed z-50 max-h-[min(24rem,calc(100vh-1rem))] min-w-[12rem] overflow-y-auto rounded-lg border border-white/[0.1] bg-popover/95 p-1.5 shadow-2xl backdrop-blur-xl"
       style={style}
     >
@@ -66,7 +64,6 @@ export function ContextMenu({ x, y, options, onClose }: ContextMenuProps) {
         {options.map((option, index) => (
           <button
             key={index}
-            role="menuitem"
             disabled={option.disabled}
             onClick={() => {
               option.onClick();

--- a/frontend/src/components/FlyoutHeader.tsx
+++ b/frontend/src/components/FlyoutHeader.tsx
@@ -37,6 +37,7 @@ export function FlyoutHeader({
           value={searchQuery}
           onChange={(event) => onSearchChange(event.target.value)}
           placeholder="Search clipboard history"
+          aria-label="Search clipboard history"
           className="min-w-0 flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-muted-foreground"
         />
         {searchQuery && (
@@ -107,6 +108,7 @@ export function FlyoutHeader({
             onClick={onAddFolder}
             className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-white/[0.07] hover:text-foreground"
             title="New folder"
+            aria-label="New folder"
           >
             <Plus size={15} />
           </button>
@@ -124,6 +126,7 @@ export function FlyoutHeader({
             onClick={onOpenSettings}
             className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-white/[0.07] hover:text-foreground"
             title="Settings"
+            aria-label="Settings"
           >
             <Settings2 size={15} />
           </button>

--- a/frontend/src/components/FolderModal.tsx
+++ b/frontend/src/components/FolderModal.tsx
@@ -60,7 +60,7 @@ export function FolderModal({ isOpen, mode, initialName, onClose, onSubmit }: Fo
           defaultValue={initialName}
           className="mb-4 w-full rounded-md border border-input bg-input px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
           onKeyDown={(e) => {
-            if (e.key === 'Enter') {
+            if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
               handleSubmit();
             } else if (e.key === 'Escape') {
               onClose();

--- a/frontend/src/components/FolderModal.tsx
+++ b/frontend/src/components/FolderModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface FolderModalProps {
@@ -13,6 +13,7 @@ export function FolderModal({ isOpen, mode, initialName, onClose, onSubmit }: Fo
   const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const titleId = useId();
 
   useEffect(() => {
     if (isOpen) {
@@ -42,14 +43,20 @@ export function FolderModal({ isOpen, mode, initialName, onClose, onSubmit }: Fo
 
   return (
     <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-      <div className="w-80 rounded-2xl border border-border bg-card p-6 shadow-2xl">
-        <h3 className="mb-4 text-lg font-semibold text-foreground">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="w-80 rounded-2xl border border-border bg-card p-6 shadow-2xl"
+      >
+        <h3 id={titleId} className="mb-4 text-lg font-semibold text-foreground">
           {mode === 'create' ? t('folders.createFolder') : t('folders.renameFolder')}
         </h3>
         <input
           ref={inputRef}
           type="text"
           placeholder={t('folders.folderNamePlaceholder')}
+          aria-label={t('folders.folderNamePlaceholder')}
           defaultValue={initialName}
           className="mb-4 w-full rounded-md border border-input bg-input px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
           onKeyDown={(e) => {

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -734,6 +734,7 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
             onClick={onClose}
             className="icon-button"
             onMouseDown={(e) => e.stopPropagation()}
+            aria-label="Close settings"
           >
             <X size={18} />
           </button>
@@ -861,14 +862,18 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
                       <Row
                         title={t('settings.startupWithWindows')}
                         desc={
-                          settings.is_portable
-                            ? t('settings.startupWithWindowsPortable')
-                            : t('settings.startupWithWindowsDesc')
+                          settings.startup_unavailable_reason === 'error'
+                            ? t('settings.startupWithWindowsError')
+                            : settings.startup_unavailable_reason === 'app_store'
+                              ? t('settings.startupWithWindowsStore')
+                              : settings.is_portable
+                                ? t('settings.startupWithWindowsPortable')
+                                : t('settings.startupWithWindowsDesc')
                         }
                         control={
                           <Toggle
                             checked={settings.startup_with_windows}
-                            disabled={settings.is_portable}
+                            disabled={settings.startup_available === false}
                             onChange={() =>
                               updateSetting('startup_with_windows', !settings.startup_with_windows)
                             }
@@ -1446,14 +1451,16 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
                             {t('settings.versionLabel', { version: appVersion || '…' })}
                           </div>
                         </div>
-                        <button
-                          onClick={handleCheckUpdates}
-                          disabled={checkingUpdate}
-                          className={ghostButton}
-                        >
-                          <RefreshCw size={14} className={checkingUpdate ? 'animate-spin' : ''} />
-                          {t('settings.checkUpdates')}
-                        </button>
+                        {settings.self_update_available !== false && (
+                          <button
+                            onClick={handleCheckUpdates}
+                            disabled={checkingUpdate}
+                            className={ghostButton}
+                          >
+                            <RefreshCw size={14} className={checkingUpdate ? 'animate-spin' : ''} />
+                            {t('settings.checkUpdates')}
+                          </button>
+                        )}
                       </div>
                       <button
                         onClick={() => openUrl(GITHUB_URL).catch(console.error)}

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -250,7 +250,10 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
       .then(async () => {
         const newSettings = { ...settingsRef.current, ...updates };
         try {
-          await invoke('save_settings', { settings: newSettings });
+          await invoke('save_settings', {
+            settings: newSettings,
+            changedKeys: Object.keys(updates),
+          });
           settingsRef.current = newSettings;
           setSettings(newSettings);
           await emit('settings-changed', newSettings);
@@ -390,7 +393,10 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
       .then(async () => {
         const newSettings = { ...settingsRef.current, ...updates };
         try {
-          await invoke('save_settings', { settings: newSettings });
+          await invoke('save_settings', {
+            settings: newSettings,
+            changedKeys: Object.keys(updates),
+          });
           settingsRef.current = newSettings;
           setSettings(newSettings);
           await emit('settings-changed', newSettings);

--- a/frontend/src/hooks/useUpdater.ts
+++ b/frontend/src/hooks/useUpdater.ts
@@ -14,12 +14,14 @@ const UPDATE_CHECK_INTERVAL_MS = 30 * 60 * 1000;
  * Any failure (offline, GitHub unreachable, dev build) is swallowed so it
  * never interrupts normal use.
  */
-export function useUpdater() {
+export function useUpdater(enabled: boolean) {
   const { t } = useTranslation();
   const checkInFlightRef = useRef(false);
   const notifiedVersionRef = useRef<string | null>(null);
 
   useEffect(() => {
+    if (!enabled) return;
+
     let active = true;
 
     const checkForUpdate = async () => {
@@ -58,7 +60,7 @@ export function useUpdater() {
       active = false;
       window.clearInterval(intervalId);
     };
-  }, [t]);
+  }, [enabled, t]);
 }
 
 async function installUpdate(update: Update, t: TFunction) {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -84,6 +84,8 @@
     "startupWithWindows": "Startup with Windows",
     "startupWithWindowsDesc": "Automatically start when Windows boots",
     "startupWithWindowsPortable": "Not available in the portable version (it never touches the registry).",
+    "startupWithWindowsStore": "Not available in the Microsoft Store version. Windows manages Store app startup permissions.",
+    "startupWithWindowsError": "Cubby could not read Windows startup permissions. Restart Cubby and try again.",
     "roundCorners": "Rounded Corners",
     "roundCornersDesc": "Use rounded corners for the Cubby flyout.",
     "ignoreGhostClips": "Ignore Ghost Clips",

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -53,6 +53,9 @@ export interface Settings {
   auto_delete_days: number;
   startup_with_windows: boolean;
   is_portable?: boolean;
+  startup_available?: boolean;
+  startup_unavailable_reason?: 'portable' | 'app_store' | 'error';
+  self_update_available?: boolean;
   show_in_taskbar: boolean;
   hotkey: string;
   replace_win_v: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cubby-clipboard",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "A native-feeling clipboard history replacement for Windows 11",
   "license": "GPL-3.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -138,7 +138,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -231,7 +231,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -260,7 +260,7 @@ dependencies = [
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures-lite",
  "rustix",
 ]
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "cubby"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -1363,11 +1363,10 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1378,7 +1377,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "pin-project-lite",
 ]
 
@@ -4393,7 +4392,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures-core",
  "futures-intrusive",
  "futures-io",
@@ -6838,7 +6837,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures-core",
  "futures-lite",
  "hex",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubby"
-version = "1.2.3"
+version = "1.2.4"
 description = "A native-feeling clipboard history replacement for Windows 11"
 authors = ["SouthForge AI", "PastePaw contributors"]
 license = "GPL-3.0"

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -436,7 +436,7 @@ async fn refresh_rolling_backup(db_path: &Path) -> Result<(), String> {
     let temporary_for_rename = temporary.clone();
     let backup_for_rename = backup.clone();
     tokio::task::spawn_blocking(move || {
-        std::fs::rename(&temporary_for_rename, &backup_for_rename).inspect_err(|_| {
+        replace_backup_atomically(&temporary_for_rename, &backup_for_rename).inspect_err(|_| {
             let _ = std::fs::remove_file(&temporary_for_rename);
         })
     })
@@ -449,6 +449,40 @@ async fn refresh_rolling_backup(db_path: &Path) -> Result<(), String> {
         backup.display()
     );
     Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn replace_backup_atomically(source: &Path, destination: &Path) -> Result<(), std::io::Error> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows::core::PCWSTR;
+    use windows::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let source_wide = source
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let destination_wide = destination
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+
+    unsafe {
+        MoveFileExW(
+            PCWSTR(source_wide.as_ptr()),
+            PCWSTR(destination_wide.as_ptr()),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    }
+    .map_err(std::io::Error::other)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn replace_backup_atomically(source: &Path, destination: &Path) -> Result<(), std::io::Error> {
+    std::fs::rename(source, destination)
 }
 
 /// Refuse a backup refresh when it would replace a substantial backup with a
@@ -610,9 +644,9 @@ async fn add_column_if_missing(pool: &SqlitePool, sql: &str) -> Result<(), sqlx:
 #[cfg(test)]
 mod tests {
     use super::{
-        prepare_database_file, quarantine_database_files, rolling_backup_path,
-        sanitize_storage_diagnostic, should_skip_backup_refresh, verify_database_quick_check,
-        Database,
+        prepare_database_file, quarantine_database_files, replace_backup_atomically,
+        rolling_backup_path, sanitize_storage_diagnostic, should_skip_backup_refresh,
+        verify_database_quick_check, Database,
     };
     use crate::crypto::CryptoManager;
     use sqlx::sqlite::SqlitePoolOptions;
@@ -784,6 +818,22 @@ mod tests {
             before_modified, after_modified,
             "backup younger than 24h must not be rewritten"
         );
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    #[test]
+    fn rolling_backup_refresh_replaces_an_existing_file() {
+        let directory = temp_dir();
+        let temporary = directory.join("cubby.db.bak.tmp");
+        let backup = directory.join("cubby.db.bak");
+        std::fs::write(&temporary, b"new backup").unwrap();
+        std::fs::write(&backup, b"old backup").unwrap();
+
+        replace_backup_atomically(&temporary, &backup)
+            .expect("an expired Windows backup should be replaceable");
+
+        assert!(!temporary.exists());
+        assert_eq!(std::fs::read(&backup).unwrap(), b"new backup");
         let _ = std::fs::remove_dir_all(directory);
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,25 @@ static IS_ANIMATING: AtomicBool = AtomicBool::new(false);
 static LAST_SHOW_TIME: AtomicI64 = AtomicI64::new(0);
 static SHOW_GENERATION: AtomicU64 = AtomicU64::new(0);
 
+/// Releases the show/hide lock even if a worker unwinds. A detached window
+/// thread panic must not leave Cubby permanently unable to open again.
+struct AnimationGuard;
+
+impl AnimationGuard {
+    fn acquire() -> Option<Self> {
+        IS_ANIMATING
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .ok()
+            .map(|_| Self)
+    }
+}
+
+impl Drop for AnimationGuard {
+    fn drop(&mut self) {
+        IS_ANIMATING.store(false, Ordering::SeqCst);
+    }
+}
+
 mod cf_html;
 mod clipboard;
 mod commands;
@@ -114,8 +133,9 @@ pub fn run_app() {
     {
         builder = builder.plugin(tauri_plugin_autostart::init(
             MacosLauncher::LaunchAgent,
-            Some(vec!["--flag1", "--flag2"]),
+            None,
         ));
+        builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
     }
 
     builder
@@ -129,7 +149,6 @@ pub fn run_app() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_opener::init())
-        .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .manage(db_arc.clone())
         .on_window_event(|window, event| {
@@ -491,12 +510,9 @@ pub fn position_window_from_taskbar(window: &tauri::WebviewWindow) {
 }
 
 pub fn animate_window_show(window: &tauri::WebviewWindow, anchor: ShowAnchor) {
-    if IS_ANIMATING
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_err()
-    {
+    let Some(animation_guard) = AnimationGuard::acquire() else {
         return;
-    }
+    };
 
     LAST_SHOW_TIME.store(chrono::Local::now().timestamp_millis(), Ordering::SeqCst);
     let show_generation = SHOW_GENERATION.fetch_add(1, Ordering::SeqCst) + 1;
@@ -510,6 +526,7 @@ pub fn animate_window_show(window: &tauri::WebviewWindow, anchor: ShowAnchor) {
     remember_foreground_window(&window);
 
     std::thread::spawn(move || {
+        let _animation_guard = animation_guard;
         if let Some(monitor) = get_monitor_at_cursor(&window) {
             let scale_factor = monitor.scale_factor();
             let work_area = monitor.work_area();
@@ -587,7 +604,6 @@ pub fn animate_window_show(window: &tauri::WebviewWindow, anchor: ShowAnchor) {
                 watch_for_outside_click(window.clone(), show_generation);
             }
         }
-        IS_ANIMATING.store(false, Ordering::SeqCst);
     });
 }
 
@@ -630,10 +646,7 @@ pub fn animate_window_hide(
     window: &tauri::WebviewWindow,
     on_done: Option<Box<dyn FnOnce() + Send>>,
 ) {
-    if IS_ANIMATING
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_err()
-    {
+    let Some(animation_guard) = AnimationGuard::acquire() else {
         // Another show/hide is in flight. A cosmetic hide (no callback) can be
         // skipped like before — the blur handler and outside-click watcher will
         // fire again. But a callback carries a paste's focus-restore + Ctrl+V
@@ -647,37 +660,33 @@ pub fn animate_window_hide(
         let window = window.clone();
         std::thread::spawn(move || {
             let deadline = std::time::Instant::now() + std::time::Duration::from_millis(1_000);
-            let acquired = loop {
-                if IS_ANIMATING
-                    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-                    .is_ok()
-                {
-                    break true;
+            let animation_guard = loop {
+                if let Some(guard) = AnimationGuard::acquire() {
+                    break Some(guard);
                 }
                 if std::time::Instant::now() >= deadline {
-                    break false;
+                    break None;
                 }
                 std::thread::sleep(std::time::Duration::from_millis(10));
             };
-            if !acquired {
+            if animation_guard.is_none() {
                 log::warn!(
                     "WINDOW: Hide callback proceeding without animation lock (still held after 1s)"
                 );
             }
             let _ = window.hide();
-            if acquired {
-                IS_ANIMATING.store(false, Ordering::SeqCst);
-            }
+            drop(animation_guard);
             callback();
         });
         return;
-    }
+    };
 
     let window = window.clone();
 
     std::thread::spawn(move || {
+        let animation_guard = animation_guard;
         let _ = window.hide();
-        IS_ANIMATING.store(false, Ordering::SeqCst);
+        drop(animation_guard);
 
         if let Some(callback) = on_done {
             callback();

--- a/src-tauri/src/settings_commands.rs
+++ b/src-tauri/src/settings_commands.rs
@@ -64,7 +64,11 @@ pub async fn get_settings(app: AppHandle) -> Result<serde_json::Value, String> {
 }
 
 #[tauri::command]
-pub async fn save_settings(app: AppHandle, settings: serde_json::Value) -> Result<(), String> {
+pub async fn save_settings(
+    app: AppHandle,
+    settings: serde_json::Value,
+    changed_keys: Option<Vec<String>>,
+) -> Result<(), String> {
     let manager = app.state::<Arc<SettingsManager>>();
 
     // Deserialize incoming settings (Frontend sends full object except ignored_apps)
@@ -78,15 +82,27 @@ pub async fn save_settings(app: AppHandle, settings: serde_json::Value) -> Resul
     new_settings.ignored_apps = current.ignored_apps.clone();
     new_settings.default_sensitive_apps_seeded = current.default_sensitive_apps_seeded;
 
+    // Newer frontends identify the exact fields involved in this save. Keep a
+    // value comparison fallback for older callers, but avoid touching Windows
+    // startup state for unrelated settings when the changed fields are known.
+    let startup_setting_changed = changed_keys
+        .as_ref()
+        .map(|keys| keys.iter().any(|key| key == "startup_with_windows"))
+        .unwrap_or(new_settings.startup_with_windows != current.startup_with_windows);
+
     let portable = crate::portable_data_dir().is_some();
     if portable || cfg!(feature = "app-store") {
         // Never persist a capability the current build cannot apply. This also
         // clears a stale installed-build preference after switching channels.
         new_settings.startup_with_windows = false;
+    } else if !startup_setting_changed {
+        // The OS is authoritative for display, but the persisted fallback must
+        // not be rewritten from an unrelated save or an unavailable read.
+        new_settings.startup_with_windows = current.startup_with_windows;
     }
 
     #[cfg(not(feature = "app-store"))]
-    let autostart_transition = if portable {
+    let autostart_transition = if portable || !startup_setting_changed {
         None
     } else {
         use tauri_plugin_autostart::ManagerExt;

--- a/src-tauri/src/settings_commands.rs
+++ b/src-tauri/src/settings_commands.rs
@@ -9,24 +9,52 @@ pub async fn get_settings(app: AppHandle) -> Result<serde_json::Value, String> {
     let settings = manager.get();
     let mut value = serde_json::to_value(&settings).map_err(|e| e.to_string())?;
 
-    // Portable mode never touches the registry, so autostart is unavailable.
+    // Portable and Store builds deliberately omit registry autostart. Expose
+    // capabilities explicitly so the frontend cannot offer controls that the
+    // current distribution cannot honor.
     let portable = crate::portable_data_dir().is_some();
+    let store_build = cfg!(feature = "app-store");
+    let startup_available = !portable && !store_build;
     if let Some(obj) = value.as_object_mut() {
         obj.insert("is_portable".to_string(), serde_json::json!(portable));
-        if portable {
+        obj.insert(
+            "startup_available".to_string(),
+            serde_json::json!(startup_available),
+        );
+        obj.insert(
+            "self_update_available".to_string(),
+            serde_json::json!(!store_build),
+        );
+        if !startup_available {
             obj.insert("startup_with_windows".to_string(), serde_json::json!(false));
+            obj.insert(
+                "startup_unavailable_reason".to_string(),
+                serde_json::json!(if portable { "portable" } else { "app_store" }),
+            );
         }
     }
 
     #[cfg(not(feature = "app-store"))]
     if !portable {
         use tauri_plugin_autostart::ManagerExt;
-        if let Ok(is_enabled) = app.autolaunch().is_enabled() {
-            if let Some(obj) = value.as_object_mut() {
-                obj.insert(
-                    "startup_with_windows".to_string(),
-                    serde_json::json!(is_enabled),
-                );
+        match app.autolaunch().is_enabled() {
+            Ok(is_enabled) => {
+                if let Some(obj) = value.as_object_mut() {
+                    obj.insert(
+                        "startup_with_windows".to_string(),
+                        serde_json::json!(is_enabled),
+                    );
+                }
+            }
+            Err(error) => {
+                log::error!("SETTINGS: Could not read Windows startup state: {error}");
+                if let Some(obj) = value.as_object_mut() {
+                    obj.insert("startup_available".to_string(), serde_json::json!(false));
+                    obj.insert(
+                        "startup_unavailable_reason".to_string(),
+                        serde_json::json!("error"),
+                    );
+                }
             }
         }
     }
@@ -49,6 +77,26 @@ pub async fn save_settings(app: AppHandle, settings: serde_json::Value) -> Resul
     new_settings.ignored_apps = current.ignored_apps.clone();
     new_settings.default_sensitive_apps_seeded = current.default_sensitive_apps_seeded;
 
+    let portable = crate::portable_data_dir().is_some();
+    if portable || cfg!(feature = "app-store") {
+        // Never persist a capability the current build cannot apply. This also
+        // clears a stale installed-build preference after switching channels.
+        new_settings.startup_with_windows = false;
+    }
+
+    #[cfg(not(feature = "app-store"))]
+    let autostart_transition = if portable {
+        None
+    } else {
+        use tauri_plugin_autostart::ManagerExt;
+        let active = app
+            .autolaunch()
+            .is_enabled()
+            .map_err(|error| format!("Could not read Windows startup state: {error}"))?;
+        (active != new_settings.startup_with_windows)
+            .then_some((active, new_settings.startup_with_windows))
+    };
+
     let shortcut_settings_changed = new_settings.hotkey != current.hotkey
         || new_settings.replace_win_v != current.replace_win_v;
     if shortcut_settings_changed {
@@ -67,9 +115,17 @@ pub async fn save_settings(app: AppHandle, settings: serde_json::Value) -> Resul
             new_settings.replace_win_v,
             Some(new_settings.hotkey.clone()),
         ) {
-            let _ =
-                crate::shortcuts::register_shortcuts(&app, &current.hotkey, current.replace_win_v);
-            let _ = replacement.configure(current.replace_win_v, Some(current.hotkey.clone()));
+            restore_shortcut_settings(&app, &current);
+            return Err(error);
+        }
+    }
+
+    #[cfg(not(feature = "app-store"))]
+    if let Some((_, requested)) = autostart_transition {
+        if let Err(error) = set_autostart(&app, requested) {
+            if shortcut_settings_changed {
+                restore_shortcut_settings(&app, &current);
+            }
             return Err(error);
         }
     }
@@ -79,10 +135,15 @@ pub async fn save_settings(app: AppHandle, settings: serde_json::Value) -> Resul
     // a backdrop on the current system or window state.
     if let Err(error) = manager.save(new_settings.clone()) {
         if shortcut_settings_changed {
-            let _ =
-                crate::shortcuts::register_shortcuts(&app, &current.hotkey, current.replace_win_v);
-            let replacement = app.state::<Arc<crate::win_v_replacement::WinVReplacementManager>>();
-            let _ = replacement.configure(current.replace_win_v, Some(current.hotkey.clone()));
+            restore_shortcut_settings(&app, &current);
+        }
+        #[cfg(not(feature = "app-store"))]
+        if let Some((previous, _)) = autostart_transition {
+            if let Err(rollback_error) = set_autostart(&app, previous) {
+                log::error!(
+                    "SETTINGS: Could not restore Windows startup state after save failure: {rollback_error}"
+                );
+            }
         }
         return Err(error);
     }
@@ -122,27 +183,42 @@ pub async fn save_settings(app: AppHandle, settings: serde_json::Value) -> Resul
         }
     }
 
-    // Portable mode must not write to the registry, so skip autostart entirely.
-    #[cfg(not(feature = "app-store"))]
-    if crate::portable_data_dir().is_none() {
-        use tauri_plugin_autostart::ManagerExt;
-        // Check if startup changed
-        let startup = new_settings.startup_with_windows;
-        let current_state = app.autolaunch().is_enabled().unwrap_or(false);
-        if startup != current_state {
-            if startup {
-                let _ = app.autolaunch().enable();
-            } else {
-                let _ = app.autolaunch().disable();
-            }
-        }
-    }
     log::info!(
         "save_settings: language={}, theme={}",
         new_settings.language,
         new_settings.theme
     );
     Ok(())
+}
+
+fn restore_shortcut_settings(app: &AppHandle, settings: &crate::models::AppSettings) {
+    if let Err(error) =
+        crate::shortcuts::register_shortcuts(app, &settings.hotkey, settings.replace_win_v)
+    {
+        log::error!("SETTINGS: Could not restore shortcut configuration: {error}");
+    }
+    let replacement = app.state::<Arc<crate::win_v_replacement::WinVReplacementManager>>();
+    if let Err(error) = replacement.configure(settings.replace_win_v, Some(settings.hotkey.clone()))
+    {
+        log::error!("SETTINGS: Could not restore Win+V helper configuration: {error}");
+    }
+}
+
+#[cfg(not(feature = "app-store"))]
+fn set_autostart(app: &AppHandle, enabled: bool) -> Result<(), String> {
+    use tauri_plugin_autostart::ManagerExt;
+
+    let result = if enabled {
+        app.autolaunch().enable()
+    } else {
+        app.autolaunch().disable()
+    };
+    result.map_err(|error| {
+        format!(
+            "Could not {} startup with Windows: {error}",
+            if enabled { "enable" } else { "disable" }
+        )
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/settings_commands.rs
+++ b/src-tauri/src/settings_commands.rs
@@ -50,6 +50,7 @@ pub async fn get_settings(app: AppHandle) -> Result<serde_json::Value, String> {
                 log::error!("SETTINGS: Could not read Windows startup state: {error}");
                 if let Some(obj) = value.as_object_mut() {
                     obj.insert("startup_available".to_string(), serde_json::json!(false));
+                    obj.insert("startup_with_windows".to_string(), serde_json::json!(false));
                     obj.insert(
                         "startup_unavailable_reason".to_string(),
                         serde_json::json!("error"),

--- a/src-tauri/src/shortcuts.rs
+++ b/src-tauri/src/shortcuts.rs
@@ -61,7 +61,7 @@ fn parser_hotkey(hotkey: &str) -> String {
 
 pub fn toggle_main_window(app: &AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
-        if window.is_visible().unwrap_or(false) {
+        if window.is_visible().unwrap_or(false) && window.is_focused().unwrap_or(false) {
             crate::animate_window_hide(&window, None);
         } else {
             crate::position_window_near_cursor(&window);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "Cubby Clipboard",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "identifier": "ai.southforge.cubbyclipboard",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

- make rolling database backups replace safely on Windows and keep settings/autostart changes transactional
- align standard, portable, and Microsoft Store capabilities for startup and self-update
- harden flyout toggle/animation behavior and accessibility semantics
- update event-listener to patched 5.4.2 and prepare v1.2.4 metadata and release notes

## Validation

- ./scripts/smoke-release.ps1
- pnpm run format:check
- cargo check --manifest-path src-tauri/Cargo.toml --all-targets --features app-store --locked
- cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --locked -- -D warnings

The release smoke suite also passed the production frontend build, 105 Rust library tests plus probe/helper suites, standard all-target Cargo checks, release metadata checks, npm production audit, and the Rust advisory audit.

## Manual follow-up before release

- packaged Windows 11 install/upgrade/uninstall smoke
- live two-session remote clipboard relay check
- focused Narrator, high-contrast, and keyboard pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer Windows startup availability messaging and controls for portable and Microsoft Store installations.
  * Self-update options and checks are now shown only when supported.
  * Added improved accessibility labels and dialog support throughout the interface.

* **Bug Fixes**
  * Improved settings saving, startup configuration recovery, and shortcut handling.
  * Fixed window toggle behavior when the window is visible but not focused.
  * Improved animation handling and backup replacement reliability.

* **Chores**
  * Updated the application version to 1.2.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->