### PR TITLE
Remove unreliable file-reference history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - Keep Microsoft Store builds under Store-managed startup and update behavior without unsupported in-app controls
 - Update the reachable `event-listener` dependency to the patched release for RUSTSEC-2026-0221
 
+### Changed
+- Stop presenting copied file references as durable clipboard history; file-copy events are now intentionally ignored and legacy file entries are removed
+
 ## v1.2.3
 
 ### Added

--- a/docs/CAPTURE_PROBE_RESULTS.md
+++ b/docs/CAPTURE_PROBE_RESULTS.md
@@ -41,6 +41,9 @@ rich-format matrix. It publishes each payload from a child process, then verifie
 exact Unicode text, raw CF_HTML and RTF bytes, decoded HTML/RTF, ordered
 `CF_HDROP` paths backed by physical files and a folder, their exact on-disk
 bytes and types, and arbitrary binary bytes with embedded NUL/high-byte values.
+The file fixture remains a low-level Windows clipboard diagnostic only; Cubby's
+product capture intentionally ignores file payloads rather than presenting
+external path references as durable history.
 
 ```powershell
 scripts/test-clipboard-formats.ps1
@@ -57,8 +60,7 @@ bounded retry principle
 used by production capture instead of treating the first contended read as data
 loss.
 
-Delayed-rendered virtual files and the real application matrix remain separate
-because these local deterministic payloads cannot establish those claims.
+Delayed-rendered virtual files are outside Cubby's stored-history contract.
 
 ## NinjaOne remote-session validation
 

--- a/docs/CLIPBOARD_RELIABILITY.md
+++ b/docs/CLIPBOARD_RELIABILITY.md
@@ -29,8 +29,11 @@ The first compatibility baseline covers:
 - HTML
 - RTF
 - PNG and Windows bitmap variants
-- File lists and virtual files
 - Multiple simultaneous formats representing the same copied item
+
+File clipboard payloads are intentionally ignored. Windows file copies are
+references to external paths rather than durable clipboard content, so Cubby
+does not present them as stored history.
 
 Application-specific formats should be preserved when practical and must not prevent standard formats from being captured.
 
@@ -47,7 +50,7 @@ For each client, test:
 
 - remote-to-local and local-to-remote copies
 - rapid sequences of distinct copies
-- text, rich text, HTML, images, and files where supported
+- text, rich text, HTML, and images
 - copies immediately before disconnect and immediately after reconnect
 - repeated identical content
 - clipboard redirection being disabled, enabled, or interrupted

--- a/docs/PRODUCTION_CAPTURE_RESULTS.md
+++ b/docs/PRODUCTION_CAPTURE_RESULTS.md
@@ -33,7 +33,7 @@ Test rows were selected by their dedicated `CUBBY-PROBE-` prefix and removed aft
 
 ## Current boundary
 
-The production schema now preserves text, HTML, RTF, images, and physical file
-lists alongside the primary searchable representation. Virtual files and other
-application-specific delayed-rendered formats still require targeted fixtures
-before Cubby can claim lossless support for them.
+The production schema preserves text, HTML, RTF, and images alongside the
+primary searchable representation. File clipboard payloads are intentionally
+ignored because they reference external paths and cannot provide durable,
+trustworthy history after files move, disappear, or become inaccessible.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,7 +38,6 @@ interface HotkeyStartupNotice {
 const matchesContentFilter = (clip: AppClipboardItem, filter: ContentFilter) => {
   if (filter === 'images') return clip.clip_type === 'image';
   if (filter === 'text') return clip.clip_type === 'text';
-  if (filter === 'files') return clip.clip_type === 'file' || clip.clip_type === 'files';
   return true;
 };
 
@@ -663,12 +662,6 @@ function App() {
       return {
         title: t('clipList.noText'),
         description: t('clipList.noTextDesc'),
-      };
-    }
-    if (contentFilter === 'files') {
-      return {
-        title: t('clipList.noFiles'),
-        description: t('clipList.noFilesDesc'),
       };
     }
     return {

--- a/frontend/src/components/ClipCard.tsx
+++ b/frontend/src/components/ClipCard.tsx
@@ -27,8 +27,7 @@ interface ImageMetadata {
 }
 
 function sourceLabel(value: string | null, type: string) {
-  if (!value)
-    return type === 'image' ? 'Image' : type === 'file' || type === 'files' ? 'Files' : 'Clipboard';
+  if (!value) return type === 'image' ? 'Image' : 'Clipboard';
   return value.replace(/\.exe$/i, '');
 }
 
@@ -49,7 +48,6 @@ function formatBytes(bytes?: number) {
 }
 
 function contentKind(content: string, clipType: string) {
-  if (clipType === 'file' || clipType === 'files') return 'Files';
   const trimmed = content.trim();
   if (clipType === 'url' || /^https?:\/\/\S+$/i.test(trimmed)) return 'URL';
   if (/^[A-Za-z]:[\\/]|^\\\\[^\\]+\\/.test(trimmed)) return 'Path';

--- a/frontend/src/components/DragPreview.tsx
+++ b/frontend/src/components/DragPreview.tsx
@@ -1,7 +1,7 @@
 import { ClipboardItem } from '../types';
 import { clsx } from 'clsx';
 import { CLIP_TYPE_ICONS, ClipType } from '../types';
-import { FileText, Image, Code, Type, File, Link } from 'lucide-react';
+import { FileText, Image, Code, Type, Link } from 'lucide-react';
 
 // Map icon string names to Lucide components
 const IconMap: Record<string, any> = {
@@ -9,7 +9,6 @@ const IconMap: Record<string, any> = {
   Image,
   Code,
   Type,
-  File,
   Link,
 };
 

--- a/frontend/src/components/FlyoutHeader.tsx
+++ b/frontend/src/components/FlyoutHeader.tsx
@@ -1,7 +1,7 @@
 import { FolderItem } from '../types';
 import { ChevronDown, Filter, MoreHorizontal, Plus, Search, Settings2, X } from 'lucide-react';
 
-export type ContentFilter = 'all' | 'text' | 'images' | 'files';
+export type ContentFilter = 'all' | 'text' | 'images';
 
 interface FlyoutHeaderProps {
   searchQuery: string;
@@ -58,7 +58,6 @@ export function FlyoutHeader({
             ['all', 'All'],
             ['text', 'Text'],
             ['images', 'Images'],
-            ['files', 'Files'],
           ] as const
         ).map(([id, label]) => (
           <button

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -21,8 +21,6 @@
     "noImagesDesc": "Copy an image or switch back to All.",
     "noText": "No text in this view",
     "noTextDesc": "Copy some text or switch back to All.",
-    "noFiles": "No files in this view",
-    "noFilesDesc": "Copy a file or switch back to All.",
     "loadFailed": "Couldn’t load clipboard history",
     "loadFailedDesc": "Cubby kept your data. Try loading it again.",
     "retry": "Try again"

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -79,15 +79,13 @@ export interface PasteContext {
   remote_paste_mode: 'copy_then_paste' | 'paste_as_keystrokes';
 }
 
-export type ClipType = 'text' | 'image' | 'html' | 'rtf' | 'file' | 'files' | 'url';
+export type ClipType = 'text' | 'image' | 'html' | 'rtf' | 'url';
 
 export const CLIP_TYPE_LABELS: Record<ClipType, string> = {
   text: 'Text',
   image: 'Image',
   html: 'HTML',
   rtf: 'Rich Text',
-  file: 'File',
-  files: 'Files',
   url: 'URL',
 };
 
@@ -96,7 +94,5 @@ export const CLIP_TYPE_ICONS: Record<ClipType, string> = {
   image: 'Image',
   html: 'Code',
   rtf: 'Type',
-  file: 'File',
-  files: 'File',
   url: 'Link',
 };

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -144,15 +144,28 @@ for (const clipboardFormatGate of [
   'clip_formats',
   'get_html()',
   'get_rich_text()',
-  'get_files()',
   'ClipboardContent::Html',
   'ClipboardContent::Rtf',
-  'ClipboardContent::Files',
 ]) {
   const sources = `${databaseSource}\n${commandSource}\n${clipboardSource}`;
   if (!sources.includes(clipboardFormatGate)) {
     throw new Error(`Multi-format clipboard release gate is missing: ${clipboardFormatGate}`);
   }
+}
+
+for (const [source, fileHistoryGate] of [
+  [clipboardSource, 'clipboard_has_file_payload_format()'],
+  [databaseSource, "DELETE FROM clips WHERE clip_type IN ('file', 'files')"],
+]) {
+  if (!source.includes(fileHistoryGate)) {
+    throw new Error(`File-history removal gate is missing: ${fileHistoryGate}`);
+  }
+}
+
+if (`${clipboardSource}\n${commandSource}`.includes('ClipboardContent::Files')) {
+  throw new Error(
+    'Release product code must not restore external file references as durable history'
+  );
 }
 
 for (const sensitiveLogFragment of ['Detected self-paste for hash', 'full_path: {:?}', 'path match): {}']) {

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -403,6 +403,21 @@ fn capture_clipboard_update(
     event_tx: &tokio::sync::mpsc::UnboundedSender<ClipboardListenerEvent>,
 ) -> Result<CaptureAttempt, ()> {
     let started = Instant::now();
+
+    // File clipboard payloads are references to external paths, not durable
+    // clipboard content. Recording them as history creates entries that can
+    // silently stop working after a move, disconnect, or target-app mismatch.
+    // Ignore both physical and virtual file payloads before reading any text
+    // fallback they may advertise.
+    if clipboard_has_file_payload_format() {
+        note_clipboard_event(sequence);
+        log::debug!(
+            "CLIPBOARD: Sequence {} contained a file payload; intentionally ignoring it",
+            sequence
+        );
+        return Ok(CaptureAttempt::Handled);
+    }
+
     let source_app_identity = get_clipboard_owner_identity();
     let sensitive = clipboard_marked_sensitive();
 
@@ -452,7 +467,7 @@ fn capture_clipboard_update(
 }
 
 /// True when the clipboard advertises a format `materialize_clipboard_content`
-/// can read (text, files, or an image). Used to tell "unsupported payload"
+/// can read (text or an image). Used to tell "unsupported payload"
 /// (mark handled) apart from "supported but contended" (defer and retry).
 #[cfg(target_os = "windows")]
 fn clipboard_has_supported_format() -> bool {
@@ -465,19 +480,11 @@ fn clipboard_has_supported_format() -> bool {
     const CF_BITMAP: u32 = 2;
     const CF_DIB: u32 = 8;
     const CF_UNICODETEXT: u32 = 13;
-    const CF_HDROP: u32 = 15;
     const CF_DIBV5: u32 = 17;
 
-    if [
-        CF_UNICODETEXT,
-        CF_TEXT,
-        CF_HDROP,
-        CF_DIB,
-        CF_DIBV5,
-        CF_BITMAP,
-    ]
-    .into_iter()
-    .any(|format| unsafe { IsClipboardFormatAvailable(format) }.is_ok())
+    if [CF_UNICODETEXT, CF_TEXT, CF_DIB, CF_DIBV5, CF_BITMAP]
+        .into_iter()
+        .any(|format| unsafe { IsClipboardFormatAvailable(format) }.is_ok())
     {
         return true;
     }
@@ -486,6 +493,37 @@ fn clipboard_has_supported_format() -> bool {
     let name: Vec<u16> = "PNG".encode_utf16().chain(std::iter::once(0)).collect();
     let png_format = unsafe { RegisterClipboardFormatW(PCWSTR(name.as_ptr())) };
     png_format != 0 && unsafe { IsClipboardFormatAvailable(png_format) }.is_ok()
+}
+
+#[cfg(target_os = "windows")]
+fn clipboard_has_file_payload_format() -> bool {
+    use windows::core::PCWSTR;
+    use windows::Win32::System::DataExchange::{
+        IsClipboardFormatAvailable, RegisterClipboardFormatW,
+    };
+
+    const CF_HDROP: u32 = 15;
+    if unsafe { IsClipboardFormatAvailable(CF_HDROP) }.is_ok() {
+        return true;
+    }
+
+    // OLE virtual files (for example Outlook attachments) do not necessarily
+    // expose CF_HDROP. Their descriptors still identify the update as a file
+    // payload, which Cubby deliberately does not present as durable history.
+    [
+        "FileGroupDescriptor",
+        "FileGroupDescriptorW",
+        "FileContents",
+    ]
+    .into_iter()
+    .any(|format_name| {
+        let name: Vec<u16> = format_name
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect();
+        let format = unsafe { RegisterClipboardFormatW(PCWSTR(name.as_ptr())) };
+        format != 0 && unsafe { IsClipboardFormatAvailable(format) }.is_ok()
+    })
 }
 
 #[cfg(target_os = "windows")]
@@ -715,27 +753,6 @@ fn materialize_clipboard_content() -> Option<(CapturedContent, Vec<CapturedForma
 
     for attempt in 0..ATTEMPTS {
         if let Ok(ctx) = ClipboardContext::new() {
-            if let Ok(files) = ctx.get_files() {
-                if !files.is_empty() {
-                    let serialized = serde_json::to_vec(&files).ok()?;
-                    let preview = files.join("\n").chars().take(200).collect::<String>();
-                    let hash = calculate_hash(&serialized);
-                    return Some((
-                        CapturedContent::Text {
-                            content: files.join("\n").into_bytes(),
-                            preview,
-                            hash,
-                        },
-                        vec![CapturedFormat {
-                            name: "files",
-                            content: serialized,
-                        }],
-                    ));
-                }
-            }
-        }
-
-        if let Ok(ctx) = ClipboardContext::new() {
             if let Ok(text) = ctx.get_text() {
                 if let Some(content) = capture_text(text) {
                     let mut formats = Vec::new();
@@ -886,11 +903,6 @@ fn relay_remote_capture(
             "rtf" => contents.push(ClipboardContent::Rtf(
                 String::from_utf8_lossy(&format.content).to_string(),
             )),
-            "files" => {
-                if let Ok(files) = serde_json::from_slice::<Vec<String>>(&format.content) {
-                    contents.push(ClipboardContent::Files(files));
-                }
-            }
             _ => {}
         }
     }
@@ -930,31 +942,25 @@ async fn process_clipboard_snapshot(
     let sensitive = snapshot.sensitive;
     let source_app_info = resolve_source_app_info(snapshot.source_app_identity);
     let captured_formats = snapshot.formats;
-    let has_files = captured_formats.iter().any(|format| format.name == "files");
     let (clip_type, clip_content, clip_preview, _primary_hash, full_image_content, metadata) =
         match snapshot.content {
             CapturedContent::Text {
                 content,
                 preview,
                 hash,
-            } => (
-                if has_files { "files" } else { "text" },
-                content,
-                preview,
-                hash,
-                None,
-                if has_files {
-                    Some(
-                        serde_json::json!({ "file_count": captured_formats.first().and_then(|format| serde_json::from_slice::<Vec<String>>(&format.content).ok()).map(|files| files.len()).unwrap_or(0) })
-                            .to_string(),
-                    )
-                } else {
-                    let format_names: Vec<&str> =
-                        captured_formats.iter().map(|format| format.name).collect();
+            } => {
+                let format_names: Vec<&str> =
+                    captured_formats.iter().map(|format| format.name).collect();
+                (
+                    "text",
+                    content,
+                    preview,
+                    hash,
+                    None,
                     (!format_names.is_empty())
-                        .then(|| serde_json::json!({ "formats": format_names }).to_string())
-                },
-            ),
+                        .then(|| serde_json::json!({ "formats": format_names }).to_string()),
+                )
+            }
             CapturedContent::Image {
                 png_bytes,
                 width,

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -497,6 +497,7 @@ fn clipboard_has_supported_format() -> bool {
 
 #[cfg(target_os = "windows")]
 fn clipboard_has_file_payload_format() -> bool {
+    use std::sync::OnceLock;
     use windows::core::PCWSTR;
     use windows::Win32::System::DataExchange::{
         IsClipboardFormatAvailable, RegisterClipboardFormatW,
@@ -510,20 +511,25 @@ fn clipboard_has_file_payload_format() -> bool {
     // OLE virtual files (for example Outlook attachments) do not necessarily
     // expose CF_HDROP. Their descriptors still identify the update as a file
     // payload, which Cubby deliberately does not present as durable history.
-    [
-        "FileGroupDescriptor",
-        "FileGroupDescriptorW",
-        "FileContents",
-    ]
-    .into_iter()
-    .any(|format_name| {
-        let name: Vec<u16> = format_name
-            .encode_utf16()
-            .chain(std::iter::once(0))
-            .collect();
-        let format = unsafe { RegisterClipboardFormatW(PCWSTR(name.as_ptr())) };
-        format != 0 && unsafe { IsClipboardFormatAvailable(format) }.is_ok()
-    })
+    static VIRTUAL_FILE_FORMATS: OnceLock<[u32; 3]> = OnceLock::new();
+    VIRTUAL_FILE_FORMATS
+        .get_or_init(|| {
+            [
+                "FileGroupDescriptor",
+                "FileGroupDescriptorW",
+                "FileContents",
+            ]
+            .map(|format_name| {
+                let name: Vec<u16> = format_name
+                    .encode_utf16()
+                    .chain(std::iter::once(0))
+                    .collect();
+                unsafe { RegisterClipboardFormatW(PCWSTR(name.as_ptr())) }
+            })
+        })
+        .iter()
+        .copied()
+        .any(|format| format != 0 && unsafe { IsClipboardFormatAvailable(format) }.is_ok())
 }
 
 #[cfg(target_os = "windows")]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -586,10 +586,6 @@ fn clipboard_contents_for_restore(
                     String::from_utf8(content.clone())
                         .map_err(|_| "stored RTF is not UTF-8".to_string())?,
                 )),
-                "files" => contents.push(ClipboardContent::Files(
-                    serde_json::from_slice(content)
-                        .map_err(|_| "stored file list is invalid".to_string())?,
-                )),
                 _ => {}
             }
         }
@@ -604,7 +600,6 @@ fn content_filter_clause(content_filter: Option<&str>) -> &'static str {
     match content_filter {
         Some("images") => " AND clip_type = 'image'",
         Some("text") => " AND clip_type = 'text'",
-        Some("files") => " AND clip_type IN ('file', 'files')",
         _ => "",
     }
 }
@@ -2333,13 +2328,6 @@ mod tests {
             restore_hash_material(&clip, None, &formats, false),
             restore_hash_material(&clip, None, &formats, true)
         );
-
-        let files = vec![(
-            "files".to_string(),
-            serde_json::to_vec(&vec![r"C:\one.txt", r"C:\two.txt"]).unwrap(),
-        )];
-        let file_contents = clipboard_contents_for_restore(&clip, None, &files, false).unwrap();
-        assert!(matches!(&file_contents[1], ClipboardContent::Files(paths) if paths.len() == 2));
     }
 
     #[tokio::test]

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -268,6 +268,23 @@ impl Database {
         .execute(&self.pool)
         .await?;
 
+        // Older Cubby builds stored file clipboard payloads as external path
+        // references. Those rows are not durable history: they can stop working
+        // after files move, storage disconnects, or a target rejects CF_HDROP.
+        // Remove them before the in-memory search index is built so no stale
+        // file entry remains visible in All, folders, or search.
+        let removed_file_references =
+            sqlx::query("DELETE FROM clips WHERE clip_type IN ('file', 'files')")
+                .execute(&self.pool)
+                .await?
+                .rows_affected();
+        if removed_file_references > 0 {
+            log::info!(
+                "STORAGE: Removed {} legacy file-reference history items",
+                removed_file_references
+            );
+        }
+
         Ok(())
     }
 }
@@ -707,6 +724,76 @@ mod tests {
         .expect("is_pinned column should exist");
 
         assert_eq!(pin_default, 0);
+    }
+
+    #[tokio::test]
+    async fn migration_removes_legacy_file_references_and_their_formats() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory database should open");
+        sqlx::query("PRAGMA foreign_keys = ON")
+            .execute(&pool)
+            .await
+            .expect("foreign keys should enable");
+        let database = Database {
+            pool,
+            crypto: Arc::new(CryptoManager::ephemeral()),
+            image_dir: std::env::temp_dir().join(format!("cubby-test-{}", uuid::Uuid::new_v4())),
+            search_index: Arc::new(crate::search_index::SearchIndex::default()),
+        };
+        database
+            .migrate()
+            .await
+            .expect("initial migration should succeed");
+
+        for (uuid, clip_type) in [
+            ("legacy-file", "file"),
+            ("legacy-files", "files"),
+            ("keep-text", "text"),
+            ("keep-image", "image"),
+        ] {
+            sqlx::query(
+                r#"
+                INSERT INTO clips (uuid, clip_type, content, text_preview, content_hash)
+                VALUES (?, ?, x'00', '', ?)
+                "#,
+            )
+            .bind(uuid)
+            .bind(clip_type)
+            .bind(format!("hash-{uuid}"))
+            .execute(&database.pool)
+            .await
+            .expect("legacy fixture should insert");
+        }
+        for uuid in ["legacy-file", "legacy-files", "keep-text"] {
+            sqlx::query(
+                "INSERT INTO clip_formats (clip_uuid, format, content) VALUES (?, 'fixture', x'00')",
+            )
+            .bind(uuid)
+            .execute(&database.pool)
+            .await
+            .expect("format fixture should insert");
+        }
+
+        database
+            .migrate()
+            .await
+            .expect("upgrade migration should succeed");
+
+        let remaining: Vec<String> = sqlx::query_scalar("SELECT uuid FROM clips ORDER BY uuid")
+            .fetch_all(&database.pool)
+            .await
+            .expect("remaining clips should query");
+        assert_eq!(remaining, vec!["keep-image", "keep-text"]);
+
+        let remaining_formats: Vec<String> =
+            sqlx::query_scalar("SELECT clip_uuid FROM clip_formats ORDER BY clip_uuid")
+                .fetch_all(&database.pool)
+                .await
+                .expect("remaining formats should query");
+        assert_eq!(remaining_formats, vec!["keep-text"]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- stop recording physical and virtual file clipboard payloads as durable history
- remove the Files tab and file-specific restore and presentation paths
- delete legacy file-reference rows during startup migration and guard the release contract

## Validation
- cargo test (130 passed)
- cargo clippy --all-targets -- -D warnings
- pnpm build
- pnpm format:check
- pnpm release:check
- git diff --check