### PR TITLE
Fix hybrid screenshot capture and speed up image paste

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -562,7 +562,7 @@ function App() {
         await invoke('paste_clip', { id: clipId, plainText });
       } catch (error) {
         console.error('Failed to paste clip:', error);
-        toast.error('Failed to paste clip');
+        toast.error(`Failed to paste clip: ${String(error)}`);
       }
     },
     [clips]

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -1039,14 +1039,19 @@ pub(crate) fn set_clipboard_image_png(png_bytes: &[u8]) -> Result<(), String> {
             .map_err(|e| format!("could not open clipboard: {e}"))?;
         clipboard_win::raw::empty().map_err(|e| format!("could not clear clipboard: {e}"))?;
 
-        // CF_DIB is the compatibility format used by many traditional Windows
-        // paste targets, so it must succeed before this write can be reported
-        // as successful. Writing it first also avoids leaving a PNG-only
-        // clipboard behind when the required format fails.
-        clipboard_win::raw::set_without_clear(CF_DIB_FORMAT, &dib)
-            .map_err(|error| format!("could not set CF_DIB: {error}"))?;
-        if let Err(error) = clipboard_win::raw::set_without_clear(png_format, png_bytes) {
-            log::warn!("CLIPBOARD: CF_DIB set succeeded but PNG failed: {error}");
+        // Both formats are required: PNG preserves byte-stable image identity
+        // for self-write suppression, while CF_DIB supports traditional
+        // Windows paste targets. If the second write fails, clear the partial
+        // clipboard rather than reporting success with an inconsistent payload.
+        clipboard_win::raw::set_without_clear(png_format, png_bytes)
+            .map_err(|error| format!("could not set PNG: {error}"))?;
+        if let Err(dib_error) = clipboard_win::raw::set_without_clear(CF_DIB_FORMAT, &dib) {
+            return match clipboard_win::raw::empty() {
+                Ok(()) => Err(format!("could not set CF_DIB: {dib_error}")),
+                Err(cleanup_error) => Err(format!(
+                    "could not set CF_DIB ({dib_error}) or clear partial PNG ({cleanup_error})"
+                )),
+            };
         }
         Ok(())
     }

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -18,6 +18,8 @@ use std::ffi::OsStr;
 use std::os::windows::ffi::OsStrExt;
 use std::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
+#[cfg(target_os = "windows")]
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 #[cfg(target_os = "windows")]
@@ -69,6 +71,8 @@ pub static CLIPBOARD_SYNC: Lazy<Arc<tokio::sync::Mutex<()>>> =
 /// Password-manager extensions typically clear within tens of seconds. Keep this
 /// short so a deliberate later clear does not erase an intentional keep.
 const CLIPBOARD_CLEAR_FORGET_WINDOW: Duration = Duration::from_secs(90);
+#[cfg(target_os = "windows")]
+const CF_DIB_FORMAT: u32 = 8;
 
 #[derive(Clone, Debug)]
 struct RecentCapture {
@@ -556,25 +560,32 @@ fn clipboard_has_file_payload_format() -> bool {
 }
 
 #[cfg(target_os = "windows")]
-fn clipboard_has_image_format() -> bool {
+fn registered_png_format() -> u32 {
     use windows::core::PCWSTR;
-    use windows::Win32::System::DataExchange::{
-        IsClipboardFormatAvailable, RegisterClipboardFormatW,
-    };
+    use windows::Win32::System::DataExchange::RegisterClipboardFormatW;
+
+    static PNG_FORMAT: OnceLock<u32> = OnceLock::new();
+    *PNG_FORMAT.get_or_init(|| {
+        let name: Vec<u16> = "PNG".encode_utf16().chain(std::iter::once(0)).collect();
+        unsafe { RegisterClipboardFormatW(PCWSTR(name.as_ptr())) }
+    })
+}
+
+#[cfg(target_os = "windows")]
+fn clipboard_has_image_format() -> bool {
+    use windows::Win32::System::DataExchange::IsClipboardFormatAvailable;
 
     const CF_BITMAP: u32 = 2;
-    const CF_DIB: u32 = 8;
     const CF_DIBV5: u32 = 17;
 
-    if [CF_DIBV5, CF_DIB, CF_BITMAP]
+    if [CF_DIBV5, CF_DIB_FORMAT, CF_BITMAP]
         .into_iter()
         .any(|format| unsafe { IsClipboardFormatAvailable(format) }.is_ok())
     {
         return true;
     }
 
-    let name: Vec<u16> = "PNG".encode_utf16().chain(std::iter::once(0)).collect();
-    let png_format = unsafe { RegisterClipboardFormatW(PCWSTR(name.as_ptr())) };
+    let png_format = registered_png_format();
     png_format != 0 && unsafe { IsClipboardFormatAvailable(png_format) }.is_ok()
 }
 
@@ -946,13 +957,9 @@ fn read_registered_png_fast() -> Result<ClipboardImageRead, String> {
 
 #[cfg(target_os = "windows")]
 fn clipboard_has_registered_png() -> bool {
-    use windows::core::PCWSTR;
-    use windows::Win32::System::DataExchange::{
-        IsClipboardFormatAvailable, RegisterClipboardFormatW,
-    };
+    use windows::Win32::System::DataExchange::IsClipboardFormatAvailable;
 
-    let name: Vec<u16> = "PNG".encode_utf16().chain(std::iter::once(0)).collect();
-    let format = unsafe { RegisterClipboardFormatW(PCWSTR(name.as_ptr())) };
+    let format = registered_png_format();
     format != 0 && unsafe { IsClipboardFormatAvailable(format) }.is_ok()
 }
 
@@ -1024,8 +1031,10 @@ pub(crate) fn set_clipboard_image_png(png_bytes: &[u8]) -> Result<(), String> {
             .map_err(|e| e.to_string())?
             .into_rgba8();
         let dib = rgba_to_cf_dib(rgba.width(), rgba.height(), rgba.as_raw())?;
-        let png_format = clipboard_win::register_format("PNG")
-            .ok_or_else(|| "could not register the PNG clipboard format".to_string())?;
+        let png_format = registered_png_format();
+        if png_format == 0 {
+            return Err("could not register the PNG clipboard format".to_string());
+        }
         let _clipboard = clipboard_win::Clipboard::new_attempts(10)
             .map_err(|e| format!("could not open clipboard: {e}"))?;
         clipboard_win::raw::empty().map_err(|e| format!("could not clear clipboard: {e}"))?;
@@ -1034,9 +1043,9 @@ pub(crate) fn set_clipboard_image_png(png_bytes: &[u8]) -> Result<(), String> {
         // paste targets, so it must succeed before this write can be reported
         // as successful. Writing it first also avoids leaving a PNG-only
         // clipboard behind when the required format fails.
-        clipboard_win::raw::set_without_clear(8, &dib)
+        clipboard_win::raw::set_without_clear(CF_DIB_FORMAT, &dib)
             .map_err(|error| format!("could not set CF_DIB: {error}"))?;
-        if let Err(error) = clipboard_win::raw::set_without_clear(png_format.get(), png_bytes) {
+        if let Err(error) = clipboard_win::raw::set_without_clear(png_format, png_bytes) {
             log::warn!("CLIPBOARD: CF_DIB set succeeded but PNG failed: {error}");
         }
         Ok(())

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -3,7 +3,9 @@ use tauri::{AppHandle, Emitter};
 use crate::database::Database;
 #[cfg(target_os = "windows")]
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
-use clipboard_rs::common::{RustImage, RustImageData};
+use clipboard_rs::common::RustImage;
+#[cfg(not(target_os = "windows"))]
+use clipboard_rs::common::RustImageData;
 use clipboard_rs::{Clipboard, ClipboardContent, ClipboardContext};
 #[cfg(target_os = "windows")]
 use clipboard_win::Monitor;
@@ -408,8 +410,12 @@ fn capture_clipboard_update(
     // clipboard content. Recording them as history creates entries that can
     // silently stop working after a move, disconnect, or target-app mismatch.
     // Ignore both physical and virtual file payloads before reading any text
-    // fallback they may advertise.
-    if clipboard_has_file_payload_format() {
+    // fallback they may advertise. Screenshot tools are the exception: they
+    // intentionally add CF_HDROP beside real image data, which Cubby retains
+    // as an image rather than as an unreliable file reference.
+    let has_file_payload = clipboard_has_file_payload_format();
+    let has_image_payload = clipboard_has_image_format();
+    if has_file_payload && !has_image_payload {
         note_clipboard_event(sequence);
         log::debug!(
             "CLIPBOARD: Sequence {} contained a file payload; intentionally ignoring it",
@@ -435,6 +441,18 @@ fn capture_clipboard_update(
             .send(ClipboardListenerEvent::Content(snapshot))
             .map(|_| CaptureAttempt::Handled)
             .map_err(|_| ());
+    }
+
+    if has_file_payload && has_image_payload {
+        // The hybrid image was advertised but remained unreadable after all
+        // bounded attempts. Do not fall through to its path-like text or keep
+        // restarting the listener forever for malformed image data.
+        note_clipboard_event(sequence);
+        log::warn!(
+            "CLIPBOARD: Sequence {} advertised a file-backed image but its image data was unreadable",
+            sequence
+        );
+        return Ok(CaptureAttempt::Handled);
     }
 
     if clipboard_is_cleared() {
@@ -530,6 +548,39 @@ fn clipboard_has_file_payload_format() -> bool {
         .iter()
         .copied()
         .any(|format| format != 0 && unsafe { IsClipboardFormatAvailable(format) }.is_ok())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn clipboard_has_file_payload_format() -> bool {
+    false
+}
+
+#[cfg(target_os = "windows")]
+fn clipboard_has_image_format() -> bool {
+    use windows::core::PCWSTR;
+    use windows::Win32::System::DataExchange::{
+        IsClipboardFormatAvailable, RegisterClipboardFormatW,
+    };
+
+    const CF_BITMAP: u32 = 2;
+    const CF_DIB: u32 = 8;
+    const CF_DIBV5: u32 = 17;
+
+    if [CF_DIBV5, CF_DIB, CF_BITMAP]
+        .into_iter()
+        .any(|format| unsafe { IsClipboardFormatAvailable(format) }.is_ok())
+    {
+        return true;
+    }
+
+    let name: Vec<u16> = "PNG".encode_utf16().chain(std::iter::once(0)).collect();
+    let png_format = unsafe { RegisterClipboardFormatW(PCWSTR(name.as_ptr())) };
+    png_format != 0 && unsafe { IsClipboardFormatAvailable(png_format) }.is_ok()
+}
+
+#[cfg(not(target_os = "windows"))]
+fn clipboard_has_image_format() -> bool {
+    false
 }
 
 #[cfg(target_os = "windows")]
@@ -758,6 +809,24 @@ fn materialize_clipboard_content() -> Option<(CapturedContent, Vec<CapturedForma
     const ATTEMPTS: u32 = 10;
 
     for attempt in 0..ATTEMPTS {
+        // Screenshot tools commonly expose both a bitmap and CF_HDROP for the
+        // saved image. Treat that as an image in Cubby. If the advertised image
+        // is still being rendered, do not let the easier file read mask it
+        // immediately; retry the image for the complete bounded window.
+        if clipboard_has_image_format() && clipboard_has_file_payload_format() {
+            if let Ok(image) = read_clipboard_image_fast(attempt + 1 == ATTEMPTS) {
+                return Some((captured_image(image), Vec::new()));
+            }
+
+            if attempt + 1 < ATTEMPTS {
+                std::thread::sleep(clipboard_retry_delay(attempt));
+                continue;
+            }
+            // The caller records this hybrid update as handled. Do not fall
+            // through to text, where the path could be captured as a text clip.
+            return None;
+        }
+
         if let Ok(ctx) = ClipboardContext::new() {
             if let Ok(text) = ctx.get_text() {
                 if let Some(content) = capture_text(text) {
@@ -783,18 +852,8 @@ fn materialize_clipboard_content() -> Option<(CapturedContent, Vec<CapturedForma
             }
         }
 
-        if let Ok(image) = read_clipboard_image_fast() {
-            return Some((
-                CapturedContent::Image {
-                    png_bytes: image.png_bytes,
-                    width: image.width,
-                    height: image.height,
-                    hash: image.raw_hash,
-                    decode_ms: image.decode_ms,
-                    source_type: image.source_type,
-                },
-                Vec::new(),
-            ));
+        if let Ok(image) = read_clipboard_image_fast(attempt + 1 == ATTEMPTS) {
+            return Some((captured_image(image), Vec::new()));
         }
 
         if attempt + 1 < ATTEMPTS {
@@ -803,6 +862,17 @@ fn materialize_clipboard_content() -> Option<(CapturedContent, Vec<CapturedForma
     }
 
     None
+}
+
+fn captured_image(image: ClipboardImageRead) -> CapturedContent {
+    CapturedContent::Image {
+        png_bytes: image.png_bytes,
+        width: image.width,
+        height: image.height,
+        hash: image.raw_hash,
+        decode_ms: image.decode_ms,
+        source_type: image.source_type,
+    }
 }
 
 fn clipboard_retry_delay(attempt: u32) -> std::time::Duration {
@@ -853,8 +923,135 @@ fn read_clipboard_image_with_clipboard_rs(
     })
 }
 
-fn read_clipboard_image_fast() -> Result<ClipboardImageRead, String> {
+#[cfg(target_os = "windows")]
+fn read_registered_png_fast() -> Result<ClipboardImageRead, String> {
+    use std::io::Cursor;
+
+    let ctx = ClipboardContext::new().map_err(|e| e.to_string())?;
+    let png_bytes = ctx.get_buffer("PNG").map_err(|e| e.to_string())?;
+    let reader = image::io::Reader::new(Cursor::new(&png_bytes))
+        .with_guessed_format()
+        .map_err(|e| e.to_string())?;
+    let (width, height) = reader.into_dimensions().map_err(|e| e.to_string())?;
+
+    Ok(ClipboardImageRead {
+        raw_hash: calculate_hash(&png_bytes),
+        png_bytes,
+        width,
+        height,
+        decode_ms: 0,
+        source_type: "registered-png",
+    })
+}
+
+#[cfg(target_os = "windows")]
+fn clipboard_has_registered_png() -> bool {
+    use windows::core::PCWSTR;
+    use windows::Win32::System::DataExchange::{
+        IsClipboardFormatAvailable, RegisterClipboardFormatW,
+    };
+
+    let name: Vec<u16> = "PNG".encode_utf16().chain(std::iter::once(0)).collect();
+    let format = unsafe { RegisterClipboardFormatW(PCWSTR(name.as_ptr())) };
+    format != 0 && unsafe { IsClipboardFormatAvailable(format) }.is_ok()
+}
+
+fn read_clipboard_image_fast(allow_slow_fallback: bool) -> Result<ClipboardImageRead, String> {
+    #[cfg(target_os = "windows")]
+    if clipboard_has_registered_png() {
+        match read_registered_png_fast() {
+            Ok(image) => return Ok(image),
+            Err(error) if !allow_slow_fallback => return Err(error),
+            Err(_) => {}
+        }
+    }
+
     read_clipboard_image_with_clipboard_rs("clipboard-rs-image")
+}
+
+fn rgba_to_cf_dib(width: u32, height: u32, rgba: &[u8]) -> Result<Vec<u8>, String> {
+    const HEADER_SIZE: usize = 40;
+    let row_bytes = (width as usize)
+        .checked_mul(4)
+        .ok_or_else(|| "clipboard image row is too large".to_string())?;
+    let pixel_bytes = row_bytes
+        .checked_mul(height as usize)
+        .ok_or_else(|| "clipboard image is too large".to_string())?;
+    if rgba.len() != pixel_bytes {
+        return Err("clipboard image pixel buffer has an invalid length".to_string());
+    }
+    let width_i32 = i32::try_from(width).map_err(|_| "clipboard image is too wide".to_string())?;
+    let height_i32 =
+        i32::try_from(height).map_err(|_| "clipboard image is too tall".to_string())?;
+    let image_size =
+        u32::try_from(pixel_bytes).map_err(|_| "clipboard image is too large".to_string())?;
+
+    let mut dib = Vec::with_capacity(HEADER_SIZE + pixel_bytes);
+    dib.extend_from_slice(&(HEADER_SIZE as u32).to_le_bytes());
+    dib.extend_from_slice(&width_i32.to_le_bytes());
+    // Positive DIB heights are bottom-up and have the broadest compatibility
+    // with older Win32 paste targets.
+    dib.extend_from_slice(&height_i32.to_le_bytes());
+    dib.extend_from_slice(&1_u16.to_le_bytes());
+    dib.extend_from_slice(&32_u16.to_le_bytes());
+    dib.extend_from_slice(&0_u32.to_le_bytes()); // BI_RGB
+    dib.extend_from_slice(&image_size.to_le_bytes());
+    dib.extend_from_slice(&0_i32.to_le_bytes());
+    dib.extend_from_slice(&0_i32.to_le_bytes());
+    dib.extend_from_slice(&0_u32.to_le_bytes());
+    dib.extend_from_slice(&0_u32.to_le_bytes());
+
+    for source_row in rgba.chunks_exact(row_bytes).rev() {
+        for pixel in source_row.chunks_exact(4) {
+            dib.extend_from_slice(&[pixel[2], pixel[1], pixel[0], pixel[3]]);
+        }
+    }
+    Ok(dib)
+}
+
+/// Put stored PNG bytes on the clipboard without recompressing them.
+/// `clipboard-rs::set_image` encodes PNG a second time before producing a
+/// bitmap, which costs several seconds for multi-megapixel screenshots in dev
+/// builds. The original PNG remains the lossless representation while CF_DIB
+/// is generated with a linear RGBA-to-BGRA conversion for traditional apps.
+pub(crate) fn set_clipboard_image_png(png_bytes: &[u8]) -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        let rgba = image::load_from_memory(png_bytes)
+            .map_err(|e| e.to_string())?
+            .into_rgba8();
+        let dib = rgba_to_cf_dib(rgba.width(), rgba.height(), rgba.as_raw())?;
+        let png_format = clipboard_win::register_format("PNG")
+            .ok_or_else(|| "could not register the PNG clipboard format".to_string())?;
+        let _clipboard = clipboard_win::Clipboard::new_attempts(10)
+            .map_err(|e| format!("could not open clipboard: {e}"))?;
+        clipboard_win::raw::empty().map_err(|e| format!("could not clear clipboard: {e}"))?;
+
+        let png_result = clipboard_win::raw::set_without_clear(png_format.get(), png_bytes);
+        let dib_result = clipboard_win::raw::set_without_clear(8, &dib); // CF_DIB
+        match (png_result, dib_result) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Ok(()), Err(error)) => {
+                log::warn!("CLIPBOARD: PNG set succeeded but CF_DIB failed: {error}");
+                Ok(())
+            }
+            (Err(error), Ok(())) => {
+                log::warn!("CLIPBOARD: CF_DIB set succeeded but PNG failed: {error}");
+                Ok(())
+            }
+            (Err(png_error), Err(dib_error)) => Err(format!(
+                "could not set PNG ({png_error}) or CF_DIB ({dib_error})"
+            )),
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let image = RustImageData::from_bytes(png_bytes).map_err(|e| e.to_string())?;
+        ClipboardContext::new()
+            .and_then(|context| context.set_image(image))
+            .map_err(|e| e.to_string())
+    }
 }
 
 /// Relay only captures owned by a remote-control viewer, and never
@@ -889,13 +1086,11 @@ fn relay_remote_capture(
         let Some(png_bytes) = full_image_content else {
             return;
         };
-        match RustImageData::from_bytes(png_bytes) {
-            Ok(image) => vec![ClipboardContent::Image(image)],
-            Err(error) => {
-                log::warn!("CLIPBOARD: Relay skipped, image decode failed: {error}");
-                return;
-            }
+        if let Err(error) = image::load_from_memory(png_bytes) {
+            log::warn!("CLIPBOARD: Relay skipped, image decode failed: {error}");
+            return;
         }
+        Vec::new()
     } else {
         vec![ClipboardContent::Text(
             String::from_utf8_lossy(clip_content).to_string(),
@@ -921,7 +1116,14 @@ fn relay_remote_capture(
         *last = Some(clip_hash.to_string());
     }
     set_ignore_hash(clip_hash.to_string());
-    match ClipboardContext::new().and_then(|context| context.set(contents)) {
+    let set_result = if clip_type == "image" {
+        set_clipboard_image_png(full_image_content.unwrap_or_default())
+    } else {
+        ClipboardContext::new()
+            .and_then(|context| context.set(contents))
+            .map_err(|error| error.to_string())
+    };
+    match set_result {
         Ok(()) => log::info!("CLIPBOARD: Relayed remote-session capture under Cubby ownership"),
         Err(error) => {
             clear_ignore_hash_if_matches(clip_hash);
@@ -1004,16 +1206,13 @@ async fn process_clipboard_snapshot(
                 )
             }
         };
-    let mut hash_material = Vec::new();
-    hash_material.extend_from_slice(clip_type.as_bytes());
-    hash_material.push(0);
-    hash_material.extend_from_slice(full_image_content.as_deref().unwrap_or(&clip_content));
-    for format in &captured_formats {
-        hash_material.push(0);
-        hash_material.extend_from_slice(format.name.as_bytes());
-        hash_material.push(0);
-        hash_material.extend_from_slice(&format.content);
-    }
+    let hash_material = build_clip_hash_material(
+        clip_type,
+        full_image_content.as_deref().unwrap_or(&clip_content),
+        captured_formats
+            .iter()
+            .map(|format| (format.name, format.content.as_slice())),
+    );
     let clip_hash = calculate_hash(&hash_material);
 
     // Ignore our own clipboard writes. When a clip is pasted or reused from
@@ -1639,6 +1838,30 @@ pub(crate) fn calculate_hash(content: &[u8]) -> String {
     format!("{:x}", result)
 }
 
+/// Build the stable identity used for capture deduplication and self-write
+/// suppression. Auxiliary representations are part of rich text identity, but
+/// an image is identified by its stored bitmap rather than a screenshot tool's
+/// saved file path.
+pub(crate) fn build_clip_hash_material<'a>(
+    clip_type: &str,
+    primary_content: &[u8],
+    formats: impl IntoIterator<Item = (&'a str, &'a [u8])>,
+) -> Vec<u8> {
+    let mut material = Vec::new();
+    material.extend_from_slice(clip_type.as_bytes());
+    material.push(0);
+    material.extend_from_slice(primary_content);
+    if clip_type != "image" {
+        for (name, content) in formats {
+            material.push(0);
+            material.extend_from_slice(name.as_bytes());
+            material.push(0);
+            material.extend_from_slice(content);
+        }
+    }
+    material
+}
+
 pub(crate) async fn replace_clip_formats(
     pool: &sqlx::SqlitePool,
     crypto: &crate::crypto::CryptoManager,
@@ -2053,10 +2276,10 @@ unsafe fn extract_icon(path: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        calculate_hash, capture_state_name, capture_text, clipboard_retry_delay,
-        next_listener_backoff, should_forget_recent_capture, should_relay_capture, CapturedContent,
-        CAPTURE_STATE_LISTENING, CAPTURE_STATE_RESTARTING, CAPTURE_STATE_STOPPED,
-        CLIPBOARD_CLEAR_FORGET_WINDOW,
+        build_clip_hash_material, calculate_hash, capture_state_name, capture_text,
+        clipboard_retry_delay, next_listener_backoff, rgba_to_cf_dib, should_forget_recent_capture,
+        should_relay_capture, CapturedContent, CAPTURE_STATE_LISTENING, CAPTURE_STATE_RESTARTING,
+        CAPTURE_STATE_STOPPED, CLIPBOARD_CLEAR_FORGET_WINDOW,
     };
     use std::time::{Duration, Instant};
 
@@ -2145,6 +2368,52 @@ mod tests {
 
         assert_eq!(delays, vec![1, 2, 4, 8, 16, 32, 64, 64, 64, 64]);
         assert_eq!(delays.iter().sum::<u128>(), 319);
+        assert_eq!(delays[..9].iter().sum::<u128>(), 255);
+    }
+
+    #[test]
+    fn image_identity_ignores_auxiliary_file_path() {
+        let first = build_clip_hash_material(
+            "image",
+            b"same pixels",
+            [("files", b"[\"C:/shots/first.png\"]".as_slice())],
+        );
+        let second = build_clip_hash_material(
+            "image",
+            b"same pixels",
+            [("files", b"[\"D:/archive/second.png\"]".as_slice())],
+        );
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn non_image_identity_preserves_auxiliary_formats() {
+        let html = build_clip_hash_material(
+            "text",
+            b"same text",
+            [("html", b"<b>same text</b>".as_slice())],
+        );
+        let plain = build_clip_hash_material("text", b"same text", []);
+
+        assert_ne!(html, plain);
+    }
+
+    #[test]
+    fn cf_dib_conversion_writes_bottom_up_bgra_pixels() {
+        let rgba = [
+            1, 2, 3, 4, 5, 6, 7, 8, // top row
+            9, 10, 11, 12, 13, 14, 15, 16, // bottom row
+        ];
+        let dib = rgba_to_cf_dib(2, 2, &rgba).unwrap();
+
+        assert_eq!(&dib[0..4], &40_u32.to_le_bytes());
+        assert_eq!(&dib[4..8], &2_i32.to_le_bytes());
+        assert_eq!(&dib[8..12], &2_i32.to_le_bytes());
+        assert_eq!(
+            &dib[40..],
+            &[11, 10, 9, 12, 15, 14, 13, 16, 3, 2, 1, 4, 7, 6, 5, 8]
+        );
     }
 
     #[test]

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -133,7 +133,7 @@ pub fn set_ignore_hash(hash: String) {
     *lock = Some(hash);
 }
 
-fn clear_ignore_hash_if_matches(hash: &str) {
+pub(crate) fn clear_ignore_hash_if_matches(hash: &str) {
     let mut lock = IGNORE_HASH.lock();
     if lock.as_deref() == Some(hash) {
         lock.take();
@@ -1003,7 +1003,10 @@ fn rgba_to_cf_dib(width: u32, height: u32, rgba: &[u8]) -> Result<Vec<u8>, Strin
 
     for source_row in rgba.chunks_exact(row_bytes).rev() {
         for pixel in source_row.chunks_exact(4) {
-            dib.extend_from_slice(&[pixel[2], pixel[1], pixel[0], pixel[3]]);
+            dib.push(pixel[2]);
+            dib.push(pixel[1]);
+            dib.push(pixel[0]);
+            dib.push(pixel[3]);
         }
     }
     Ok(dib)
@@ -1027,22 +1030,16 @@ pub(crate) fn set_clipboard_image_png(png_bytes: &[u8]) -> Result<(), String> {
             .map_err(|e| format!("could not open clipboard: {e}"))?;
         clipboard_win::raw::empty().map_err(|e| format!("could not clear clipboard: {e}"))?;
 
-        let png_result = clipboard_win::raw::set_without_clear(png_format.get(), png_bytes);
-        let dib_result = clipboard_win::raw::set_without_clear(8, &dib); // CF_DIB
-        match (png_result, dib_result) {
-            (Ok(()), Ok(())) => Ok(()),
-            (Ok(()), Err(error)) => {
-                log::warn!("CLIPBOARD: PNG set succeeded but CF_DIB failed: {error}");
-                Ok(())
-            }
-            (Err(error), Ok(())) => {
-                log::warn!("CLIPBOARD: CF_DIB set succeeded but PNG failed: {error}");
-                Ok(())
-            }
-            (Err(png_error), Err(dib_error)) => Err(format!(
-                "could not set PNG ({png_error}) or CF_DIB ({dib_error})"
-            )),
+        // CF_DIB is the compatibility format used by many traditional Windows
+        // paste targets, so it must succeed before this write can be reported
+        // as successful. Writing it first also avoids leaving a PNG-only
+        // clipboard behind when the required format fails.
+        clipboard_win::raw::set_without_clear(8, &dib)
+            .map_err(|error| format!("could not set CF_DIB: {error}"))?;
+        if let Err(error) = clipboard_win::raw::set_without_clear(png_format.get(), png_bytes) {
+            log::warn!("CLIPBOARD: CF_DIB set succeeded but PNG failed: {error}");
         }
+        Ok(())
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -1082,14 +1079,15 @@ fn relay_remote_capture(
     captured_formats: &[CapturedFormat],
     clip_hash: &str,
 ) {
-    let mut contents = if clip_type == "image" {
+    let image_content = if clip_type == "image" {
         let Some(png_bytes) = full_image_content else {
             return;
         };
-        if let Err(error) = image::load_from_memory(png_bytes) {
-            log::warn!("CLIPBOARD: Relay skipped, image decode failed: {error}");
-            return;
-        }
+        Some(png_bytes)
+    } else {
+        None
+    };
+    let mut contents = if image_content.is_some() {
         Vec::new()
     } else {
         vec![ClipboardContent::Text(
@@ -1116,8 +1114,8 @@ fn relay_remote_capture(
         *last = Some(clip_hash.to_string());
     }
     set_ignore_hash(clip_hash.to_string());
-    let set_result = if clip_type == "image" {
-        set_clipboard_image_png(full_image_content.unwrap_or_default())
+    let set_result = if let Some(png_bytes) = image_content {
+        set_clipboard_image_png(png_bytes)
     } else {
         ClipboardContext::new()
             .and_then(|context| context.set(contents))
@@ -2277,9 +2275,10 @@ unsafe fn extract_icon(path: &str) -> Option<String> {
 mod tests {
     use super::{
         build_clip_hash_material, calculate_hash, capture_state_name, capture_text,
-        clipboard_retry_delay, next_listener_backoff, rgba_to_cf_dib, should_forget_recent_capture,
-        should_relay_capture, CapturedContent, CAPTURE_STATE_LISTENING, CAPTURE_STATE_RESTARTING,
-        CAPTURE_STATE_STOPPED, CLIPBOARD_CLEAR_FORGET_WINDOW,
+        clear_ignore_hash_if_matches, clipboard_retry_delay, next_listener_backoff, rgba_to_cf_dib,
+        set_ignore_hash, should_forget_recent_capture, should_relay_capture, CapturedContent,
+        CAPTURE_STATE_LISTENING, CAPTURE_STATE_RESTARTING, CAPTURE_STATE_STOPPED,
+        CLIPBOARD_CLEAR_FORGET_WINDOW, IGNORE_HASH,
     };
     use std::time::{Duration, Instant};
 
@@ -2414,6 +2413,16 @@ mod tests {
             &dib[40..],
             &[11, 10, 9, 12, 15, 14, 13, 16, 3, 2, 1, 4, 7, 6, 5, 8]
         );
+    }
+
+    #[test]
+    fn failed_write_cleanup_only_clears_its_own_ignore_hash() {
+        set_ignore_hash("expected".to_string());
+        clear_ignore_hash_if_matches("different");
+        assert_eq!(IGNORE_HASH.lock().as_deref(), Some("expected"));
+
+        clear_ignore_hash_if_matches("expected");
+        assert!(IGNORE_HASH.lock().is_none());
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -565,6 +565,7 @@ fn clipboard_contents_for_restore(
     plain_text: bool,
 ) -> Result<Vec<ClipboardContent>, String> {
     let plain_content = String::from_utf8_lossy(&clip.content).to_string();
+    let restoring_image = full_image.is_some();
     let mut contents = if let Some(image) = full_image {
         vec![ClipboardContent::Image(
             RustImageData::from_bytes(image).map_err(|e| e.to_string())?,
@@ -572,7 +573,12 @@ fn clipboard_contents_for_restore(
     } else {
         vec![ClipboardContent::Text(plain_content)]
     };
-    if !plain_text {
+    // Auxiliary CF_HDROP on a captured screenshot describes the producer's
+    // saved file, but replaying it makes some paste targets treat the history
+    // item as a file upload instead of an image. Image clips therefore restore
+    // only their durable bitmap; pure file and rich-text clips keep replaying
+    // their auxiliary formats.
+    if !plain_text && !restoring_image {
         for (format, content) in formats {
             match format.as_str() {
                 // Stored HTML is the header-stripped document (see cf_html.rs);
@@ -717,24 +723,21 @@ fn restore_hash_material(
     formats: &[(String, Vec<u8>)],
     plain_text: bool,
 ) -> Vec<u8> {
-    let mut material = Vec::new();
     if plain_text {
+        let mut material = Vec::new();
         material.extend_from_slice(b"text");
         material.push(0);
         material.extend_from_slice(&clip.content);
         return material;
     }
 
-    material.extend_from_slice(clip.clip_type.as_bytes());
-    material.push(0);
-    material.extend_from_slice(full_image.unwrap_or(&clip.content));
-    for (format, content) in formats {
-        material.push(0);
-        material.extend_from_slice(format.as_bytes());
-        material.push(0);
-        material.extend_from_slice(content);
-    }
-    material
+    crate::clipboard::build_clip_hash_material(
+        &clip.clip_type,
+        full_image.unwrap_or(&clip.content),
+        formats
+            .iter()
+            .map(|(format, content)| (format.as_str(), content.as_slice())),
+    )
 }
 
 async fn restore_clip(
@@ -744,6 +747,7 @@ async fn restore_clip(
     window: &tauri::WebviewWindow,
     db: &Database,
 ) -> Result<(), String> {
+    let restore_started = Instant::now();
     let pool = &db.pool;
 
     let clip: Option<Clip> = sqlx::query_as(r#"SELECT * FROM clips WHERE uuid = ?"#)
@@ -788,13 +792,26 @@ async fn restore_clip(
             let content_hash = crate::clipboard::calculate_hash(&hash_material);
             let uuid = clip.uuid.clone();
 
-            let clipboard_contents =
-                clipboard_contents_for_restore(&clip, full_image.as_deref(), &formats, plain_text)?;
-
             crate::clipboard::set_ignore_hash(content_hash);
-            let final_res = ClipboardContext::new()
-                .and_then(|context| context.set(clipboard_contents))
-                .map_err(|error| format!("Failed to restore clipboard formats: {error}"));
+            let clipboard_write_started = Instant::now();
+            let final_res = if let Some(image) = full_image.as_deref() {
+                crate::clipboard::set_clipboard_image_png(image)
+                    .map_err(|error| format!("Failed to restore clipboard image: {error}"))
+            } else {
+                let clipboard_contents =
+                    clipboard_contents_for_restore(&clip, None, &formats, plain_text)?;
+                ClipboardContext::new()
+                    .and_then(|context| context.set(clipboard_contents))
+                    .map_err(|error| format!("Failed to restore clipboard formats: {error}"))
+            };
+            log::info!(
+                "[perf][restore_clip] type={} image_bytes={} clipboard_write_ms={} total_ms={} success={}",
+                clip.clip_type,
+                full_image.as_ref().map_or(0, Vec::len),
+                clipboard_write_started.elapsed().as_millis(),
+                restore_started.elapsed().as_millis(),
+                final_res.is_ok(),
+            );
 
             // Manually perform the LRU bump (update created_at)
             let _ =
@@ -2328,6 +2345,26 @@ mod tests {
             restore_hash_material(&clip, None, &formats, false),
             restore_hash_material(&clip, None, &formats, true)
         );
+        let mut image_clip = clip.clone();
+        image_clip.clip_type = "image".to_string();
+        let files = vec![("files".to_string(), br#"["C:\\one.png"]"#.to_vec())];
+        let other_files = vec![("files".to_string(), br#"["D:\\other-shot.png"]"#.to_vec())];
+        assert_eq!(
+            restore_hash_material(&image_clip, Some(b"full image"), &files, false),
+            restore_hash_material(&image_clip, Some(b"full image"), &other_files, false),
+        );
+
+        let mut png = Vec::new();
+        image::DynamicImage::new_rgba8(1, 1)
+            .write_to(
+                &mut std::io::Cursor::new(&mut png),
+                image::ImageOutputFormat::Png,
+            )
+            .unwrap();
+        let image_contents =
+            clipboard_contents_for_restore(&image_clip, Some(&png), &files, false).unwrap();
+        assert_eq!(image_contents.len(), 1);
+        assert!(matches!(&image_contents[0], ClipboardContent::Image(_)));
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -447,7 +447,11 @@ pub async fn migrate_clip_format_model(db: &Database) -> Result<u64, String> {
         .map_err(|e| e.to_string())?;
     for clip in &mut clips {
         decrypt_clip_fields(db, clip)?;
-        let formats = load_clip_formats(db, &clip.uuid).await?;
+        let formats = if clip.clip_type == "image" {
+            Vec::new()
+        } else {
+            load_clip_formats(db, &clip.uuid).await?
+        };
         let full_image = if clip.clip_type == "image" {
             Some(load_full_image_content(db, clip).await?)
         } else {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -792,7 +792,7 @@ async fn restore_clip(
             let content_hash = crate::clipboard::calculate_hash(&hash_material);
             let uuid = clip.uuid.clone();
 
-            crate::clipboard::set_ignore_hash(content_hash);
+            crate::clipboard::set_ignore_hash(content_hash.clone());
             let clipboard_write_started = Instant::now();
             let final_res = if let Some(image) = full_image.as_deref() {
                 crate::clipboard::set_clipboard_image_png(image)
@@ -812,6 +812,9 @@ async fn restore_clip(
                 restore_started.elapsed().as_millis(),
                 final_res.is_ok(),
             );
+            if final_res.is_err() {
+                crate::clipboard::clear_ignore_hash_if_matches(&content_hash);
+            }
 
             // Manually perform the LRU bump (update created_at)
             let _ =
@@ -891,10 +894,14 @@ async fn restore_recognized_text(
     let _guard = crate::clipboard::CLIPBOARD_SYNC.lock().await;
     let mut hash_material = b"text\0".to_vec();
     hash_material.extend_from_slice(text.as_bytes());
-    crate::clipboard::set_ignore_hash(crate::clipboard::calculate_hash(&hash_material));
-    ClipboardContext::new()
+    let content_hash = crate::clipboard::calculate_hash(&hash_material);
+    crate::clipboard::set_ignore_hash(content_hash.clone());
+    if let Err(error) = ClipboardContext::new()
         .and_then(|context| context.set(vec![ClipboardContent::Text(text.clone())]))
-        .map_err(|error| format!("Failed to copy recognized text: {error}"))?;
+    {
+        crate::clipboard::clear_ignore_hash_if_matches(&content_hash);
+        return Err(format!("Failed to copy recognized text: {error}"));
+    }
 
     let _ = sqlx::query("UPDATE clips SET created_at = CURRENT_TIMESTAMP WHERE uuid = ?")
         .bind(id)

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -765,7 +765,7 @@ async fn restore_clip(
             // Synchronize clipboard access across the app
             let _guard = crate::clipboard::CLIPBOARD_SYNC.lock().await;
 
-            let formats = if clip.clip_type == "image" {
+            let formats = if clip.clip_type == "image" || plain_text {
                 Vec::new()
             } else {
                 // Normalize HTML to the document form a re-capture of our own

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -453,16 +453,13 @@ pub async fn migrate_clip_format_model(db: &Database) -> Result<u64, String> {
         } else {
             None
         };
-        let mut hash_material = Vec::new();
-        hash_material.extend_from_slice(clip.clip_type.as_bytes());
-        hash_material.push(0);
-        hash_material.extend_from_slice(full_image.as_deref().unwrap_or(&clip.content));
-        for (format, content) in formats {
-            hash_material.push(0);
-            hash_material.extend_from_slice(format.as_bytes());
-            hash_material.push(0);
-            hash_material.extend_from_slice(&content);
-        }
+        let hash_material = crate::clipboard::build_clip_hash_material(
+            &clip.clip_type,
+            full_image.as_deref().unwrap_or(&clip.content),
+            formats
+                .iter()
+                .map(|(format, content)| (format.as_str(), content.as_slice())),
+        );
         sqlx::query("UPDATE clips SET content_hash = ? WHERE uuid = ?")
             .bind(db.crypto.keyed_hash(&hash_material))
             .bind(&clip.uuid)
@@ -573,11 +570,9 @@ fn clipboard_contents_for_restore(
     } else {
         vec![ClipboardContent::Text(plain_content)]
     };
-    // Auxiliary CF_HDROP on a captured screenshot describes the producer's
-    // saved file, but replaying it makes some paste targets treat the history
-    // item as a file upload instead of an image. Image clips therefore restore
-    // only their durable bitmap; pure file and rich-text clips keep replaying
-    // their auxiliary formats.
+    // Image clips restore only their durable bitmap. Adding auxiliary rich
+    // formats can change how a paste target classifies the restored payload;
+    // HTML and RTF are therefore replayed only for text clips.
     if !plain_text && !restoring_image {
         for (format, content) in formats {
             match format.as_str() {
@@ -766,22 +761,26 @@ async fn restore_clip(
             // Synchronize clipboard access across the app
             let _guard = crate::clipboard::CLIPBOARD_SYNC.lock().await;
 
-            // Normalize HTML to the document form a re-capture of our own
-            // clipboard write reads back (bare legacy fragments gain the
-            // standard container), so the ignore hash below matches it.
-            let formats = load_clip_formats(db, &clip.uuid)
-                .await?
-                .into_iter()
-                .map(|(format, content)| {
-                    if format == "html" {
-                        if let Ok(html) = std::str::from_utf8(&content) {
-                            let document = crate::cf_html::document(html);
-                            return (format, document.into_bytes());
+            let formats = if clip.clip_type == "image" {
+                Vec::new()
+            } else {
+                // Normalize HTML to the document form a re-capture of our own
+                // clipboard write reads back (bare legacy fragments gain the
+                // standard container), so the ignore hash below matches it.
+                load_clip_formats(db, &clip.uuid)
+                    .await?
+                    .into_iter()
+                    .map(|(format, content)| {
+                        if format == "html" {
+                            if let Ok(html) = std::str::from_utf8(&content) {
+                                let document = crate::cf_html::document(html);
+                                return (format, document.into_bytes());
+                            }
                         }
-                    }
-                    (format, content)
-                })
-                .collect::<Vec<_>>();
+                        (format, content)
+                    })
+                    .collect::<Vec<_>>()
+            };
             let full_image = if clip.clip_type == "image" {
                 Some(load_full_image_content(db, &mut clip).await?)
             } else {
@@ -2388,6 +2387,17 @@ mod tests {
         .execute(&database.pool)
         .await
         .unwrap();
+        sqlx::query(
+            r#"
+            INSERT INTO clips (uuid, clip_type, content, text_preview, content_hash)
+            VALUES ('image', 'image', ?, ?, 'old-image-hash')
+            "#,
+        )
+        .bind(database.crypto.encrypt(b"png bytes").unwrap())
+        .bind(database.crypto.encrypt_text("Image").unwrap())
+        .execute(&database.pool)
+        .await
+        .unwrap();
         crate::clipboard::replace_clip_formats(
             &database.pool,
             &database.crypto,
@@ -2399,6 +2409,17 @@ mod tests {
         )
         .await
         .unwrap();
+        crate::clipboard::replace_clip_formats(
+            &database.pool,
+            &database.crypto,
+            "image",
+            &[CapturedFormat {
+                name: "files",
+                content: br#"["C:\\shot.png"]"#.to_vec(),
+            }],
+        )
+        .await
+        .unwrap();
         let encrypted_format: Vec<u8> =
             sqlx::query_scalar("SELECT content FROM clip_formats WHERE clip_uuid = 'rich'")
                 .fetch_one(&database.pool)
@@ -2406,7 +2427,7 @@ mod tests {
                 .unwrap();
         assert!(database.crypto.is_encrypted(&encrypted_format));
 
-        assert_eq!(migrate_clip_format_model(&database).await.unwrap(), 1);
+        assert_eq!(migrate_clip_format_model(&database).await.unwrap(), 2);
         assert_eq!(migrate_clip_format_model(&database).await.unwrap(), 0);
         let hash: String = sqlx::query_scalar("SELECT content_hash FROM clips WHERE uuid = 'rich'")
             .fetch_one(&database.pool)
@@ -2416,6 +2437,12 @@ mod tests {
             .crypto
             .keyed_hash(b"text\0Hello\0html\0<b>Hello</b>");
         assert_eq!(hash, expected);
+        let image_hash: String =
+            sqlx::query_scalar("SELECT content_hash FROM clips WHERE uuid = 'image'")
+                .fetch_one(&database.pool)
+                .await
+                .unwrap();
+        assert_eq!(image_hash, database.crypto.keyed_hash(b"image\0png bytes"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- capture screenshot-tool clipboard payloads that advertise both an image and a file reference as images, while continuing to ignore ordinary and virtual file copies
- read registered PNG data directly and restore the original PNG alongside native CF_DIB data, avoiding an unnecessary decode/re-encode cycle
- keep image history restores image-only so Matteshot's saved-file path is not replayed
- improve paste failure details and add timing diagnostics around image restore

## Why

Matteshot intentionally publishes CF_HDROP together with PNG/bitmap formats. Cubby previously treated that payload as a file (and current `main` ignores file payloads entirely), so the screenshot either appeared incorrectly or was omitted. Once captured, restoring larger screenshots also spent several seconds rebuilding clipboard formats.

This keeps the file-history removal from #118 intact. The exception applies only when an actual image format is advertised alongside the file payload.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 109 passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `pnpm build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `git diff --check`
- manual Matteshot testing: history capture and paste confirmed; roughly 1.2 MB PNG clipboard writes measured at 381–431 ms, with total restore around 552–608 ms instead of 3–5 seconds