### PR TITLE
Prepare v1.2.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 
 ### Fixed
 - Capture screenshots from tools such as Matteshot that publish image data alongside a saved-file reference, while continuing to ignore ordinary file copies
-- Paste large screenshots from history much faster by restoring their original PNG data with a compatible Windows bitmap, with safer failure handling that prevents duplicate self-captures
+- Paste large screenshots from history much faster by restoring their original PNG data with a compatible Windows bitmap
+- Fail safely on partial native clipboard writes so an incomplete image restore cannot cause duplicate self-captures
 
 ## v1.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable Cubby Clipboard changes are documented here. PastePaw entries below Cubby's first beta are retained as upstream history and attribution.
 
+## v1.2.5
+
+### Fixed
+- Capture screenshots from tools such as Matteshot that publish image data alongside a saved-file reference, while continuing to ignore ordinary file copies
+- Paste large screenshots from history much faster by restoring their original PNG data with a compatible Windows bitmap, with safer failure handling that prevents duplicate self-captures
+
 ## v1.2.4
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cubby-clipboard",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "A native-feeling clipboard history replacement for Windows 11",
   "license": "GPL-3.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "cubby"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubby"
-version = "1.2.4"
+version = "1.2.5"
 description = "A native-feeling clipboard history replacement for Windows 11"
 authors = ["SouthForge AI", "PastePaw contributors"]
 license = "GPL-3.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "Cubby Clipboard",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "identifier": "ai.southforge.cubbyclipboard",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

- bump Cubby Clipboard from v1.2.4 to v1.2.5 across npm, Cargo, Tauri, and the lockfile
- add the complete v1.2.5 changelog based on every commit since the v1.2.4 tag

## Release notes

- capture Matteshot-style screenshots that publish image data alongside a saved-file reference, without re-enabling general file history
- restore large screenshots from history much faster using their original PNG plus a compatible Windows bitmap
- fail safely on partial native clipboard writes and prevent duplicate self-captures

## Validation

- `pnpm run format:check`
- `pnpm run release:check`
- `pnpm run build`
- `pnpm audit --prod`
- `./scripts/audit-rust.ps1`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --all-targets` — 134 passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved screenshot capture for tools that provide image data alongside saved-file references.
  * Accelerated pasting of large screenshots.
  * Improved handling of duplicate self-capture failures.

* **Release**
  * Updated the application version to 1.2.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->