### PR TITLE
Add accessible names to icon-only ControlBar buttons

### DIFF
--- a/frontend/src/components/ControlBar.tsx
+++ b/frontend/src/components/ControlBar.tsx
@@ -262,6 +262,8 @@ export function ControlBar({
             <button
               data-el="search-close-btn"
               onClick={onSearchClick}
+              title="Close search"
+              aria-label="Close search"
               className="rounded-full p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
             >
               <X size={16} />
@@ -271,6 +273,8 @@ export function ControlBar({
           <button
             data-el="search-btn"
             onClick={onSearchClick}
+            title="Search clipboard history"
+            aria-label="Search clipboard history"
             className="rounded-lg p-2 text-blue-400 transition-colors hover:bg-blue-500/10"
           >
             <Search size={20} />
@@ -359,6 +363,8 @@ export function ControlBar({
         <button
           data-el="add-folder-btn"
           onClick={onAddClick}
+          title="New folder"
+          aria-label="New folder"
           className="rounded-lg p-2 text-emerald-400 transition-colors hover:bg-emerald-500/10"
         >
           <Plus size={20} />
@@ -366,6 +372,8 @@ export function ControlBar({
         <button
           data-el="settings-btn"
           onClick={onMoreClick}
+          title="Settings"
+          aria-label="Settings"
           className="rounded-lg p-2 text-amber-400 transition-colors hover:bg-amber-500/10"
         >
           <MoreHorizontal size={20} />


### PR DESCRIPTION
Four buttons in `ControlBar.tsx` render only a lucide icon with no text, no `aria-label` and no `title`. Screen readers announce them as an unlabeled "button", and there is no mouse tooltip either.

| Button | Icon | Label added |
| --- | --- | --- |
| `search-close-btn` | `X` | Close search |
| `search-btn` | `Search` | Search clipboard history |
| `add-folder-btn` | `Plus` | New folder |
| `settings-btn` | `MoreHorizontal` | Settings |

Wording and the `title` + `aria-label` pairing match what `FlyoutHeader.tsx` and `ClipCard.tsx` already do for the equivalent controls. Plain English string literals, no i18n keys, consistent with the rest of the file.

### Notes

**This is a pre-existing gap, not a regression from #126.** It surfaced while verifying the lucide `0.294.0 -> 0.577.0` upgrade, which adds `aria-hidden="true"` to every icon. That change is a no-op here: 0.294 emitted no `<title>` either, so these buttons never had an accessible name. Kept out of #126 deliberately to leave that PR a pure dependency bump.

**`ControlBar` currently has no consumers.** Nothing in `frontend/src` imports it, so this is a fix to a component that does not render today. Left in place rather than expanded into a dead-code removal, which is a separate call.

### Verification

- `pnpm run format:check` clean
- `pnpm run build` clean on the upgraded toolchain from #126 (vite 6.4.3, lucide 0.577.0, TypeScript 5)
- Re-ran the icon-only button scan: 0 remaining unlabeled buttons in `ControlBar.tsx`
