### PR TITLE
Take TypeScript 6 and hold the i18next stack

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,13 +13,25 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    # TypeScript 7 removes tsconfig options Cubby currently uses, and i18next
-    # 25 declares support for TypeScript 5 and 6 only. Keep receiving 5.x/6.x
-    # updates while deferring this major until the frontend stack supports it.
+    # The tsconfig half of this deferral is now resolved: `baseUrl` is gone and
+    # tsc 7.0.2 type-checks the project clean. What still blocks the major is
+    # i18next 25.x declaring `typescript: ^5 || ^6` as a peer. Lift this once
+    # the i18n stack moves (see below) or is removed.
+    #
+    # Cubby is English-only; the i18next stack is inherited PastePaw legacy and
+    # is a removal candidate, not something to keep current. react-i18next 17
+    # additionally requires i18next >= 26.2.0, so taking it means two majors on
+    # a dependency we intend to delete. Hold both at their current majors.
     ignore:
       - dependency-name: typescript
         versions:
           - ">=7 <8"
+      - dependency-name: react-i18next
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: i18next
+        update-types:
+          - "version-update:semver-major"
     open-pull-requests-limit: 10
 
   - package-ecosystem: cargo

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prettier": "^3.9.6",
     "prettier-plugin-tailwindcss": "^0.8.1",
     "tailwindcss": "^3.3.6",
-    "typescript": "^5.3.3",
+    "typescript": "^6.0.3",
     "vite": "^6.4.3"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 3.6.0
       i18next:
         specifier: ^25.10.10
-        version: 25.10.10(typescript@5.9.3)
+        version: 25.10.10(typescript@6.0.3)
       i18next-browser-languagedetector:
         specifier: ^7.2.0
         version: 7.2.2
@@ -49,7 +49,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       react-i18next:
         specifier: ^14.0.0
-        version: 14.1.3(i18next@25.10.10(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.1.3(i18next@25.10.10(typescript@6.0.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -88,8 +88,8 @@ importers:
         specifier: ^3.3.6
         version: 3.4.19
       typescript:
-        specifier: ^5.3.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^6.4.3
         version: 6.4.3(jiti@1.21.7)
@@ -1123,8 +1123,8 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1778,11 +1778,11 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.6
 
-  i18next@25.10.10(typescript@5.9.3):
+  i18next@25.10.10(typescript@6.0.3):
     dependencies:
       '@babel/runtime': 7.29.7
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   is-binary-path@2.1.0:
     dependencies:
@@ -1912,11 +1912,11 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-i18next@14.1.3(i18next@25.10.10(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-i18next@14.1.3(i18next@25.10.10(typescript@6.0.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.28.6
       html-parse-stringify: 3.0.1
-      i18next: 25.10.10(typescript@5.9.3)
+      i18next: 25.10.10(typescript@6.0.3)
       react: 18.3.1
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
@@ -2052,7 +2052,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.7):
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,9 +19,8 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["frontend/src/*"]
+      "@/*": ["./frontend/src/*"]
     }
   },
   "include": ["frontend/src"],


### PR DESCRIPTION
Handles two of the three open Dependabot PRs. Supersedes #127, declines #128.

## TypeScript 6 (#127)

#127 failed CI on exactly one error:

```
tsconfig.json(22,5): error TS5101: Option 'baseUrl' is deprecated and will
stop functioning in TypeScript 7.0.
```

Fixed by dropping `baseUrl` and making the `paths` entry relative, which is the form TS 6 and 7 both want:

```diff
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["frontend/src/*"]
+      "@/*": ["./frontend/src/*"]
     }
```

The `@/*` alias has **zero call sites** in `frontend/src` today, so this could have been deleted outright. It stays wired because `vite.config.ts` still defines the matching alias, and removing only the tsconfig half would let tsc and the bundler disagree about a path that resolves.

## react-i18next 17 (#128) — declined

#128 looks safe from its diff, but the resolved peer range is the problem. `react-i18next@17.0.11` requires:

```
"i18next": ">= 26.2.0"
```

We are on i18next 25.10.10, so taking #128 means taking i18next 26 as well. That is two majors on a stack that exists only as inherited PastePaw legacy in an English-only app, and which is a removal candidate rather than something to keep current.

The current pair is peer-satisfied and healthy: `react-i18next@14.1.3` wants `i18next >= 23.2.3`, and we are well inside that. Nothing is broken by staying put.

Recorded as a dependabot `ignore` on majors for both `react-i18next` and `i18next` so this does not reopen every week.

## TypeScript 7 note

The ignore comment claimed two blockers. One is now gone: with this tsconfig, `tsc 7.0.2` type-checks the project clean, verified locally. The remaining blocker is real, though. i18next 25.x declares `typescript: ^5 || ^6` as a peer, so the TS 7 ignore stays and the comment is rewritten to name only that. Newer i18next does widen to `^7`, so this lifts on its own whenever the i18n stack moves or gets deleted.

## Verification

- `tsc 6.0.3` clean
- `pnpm run format:check` clean
- `pnpm run release:check` clean
- `pnpm run build` clean, and the emitted bundle hashes are **identical to main** (`index-BHbFjjVa.js`, `index-CiPbinLK.css`). TypeScript is `noEmit` here and vite does the transform, so a compiler bump changes nothing that ships.

## Not included

#129 (React 19) is being evaluated separately. A green `tsc` says nothing about React 19 runtime behavior, so it needs an actual app launch before it goes anywhere near main.
