### PR TITLE
Bump version to 1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable Cubby Clipboard changes are documented here. PastePaw entries below Cubby's first beta are retained as upstream history and attribution.
 
+## v1.2.6
+
+### Changed
+- Refreshed the interface icon set. The filter, settings, shield, play, pause, file, and flask icons are redrawn with the same meanings and slightly different shapes
+
 ## v1.2.5
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cubby-clipboard",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "A native-feeling clipboard history replacement for Windows 11",
   "license": "GPL-3.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "cubby"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubby"
-version = "1.2.5"
+version = "1.2.6"
 description = "A native-feeling clipboard history replacement for Windows 11"
 authors = ["SouthForge AI", "PastePaw contributors"]
 license = "GPL-3.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "Cubby Clipboard",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "identifier": "ai.southforge.cubbyclipboard",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Bumps to 1.2.6 so a `workflow_dispatch` test build reports a version distinct from the already-released v1.2.5. Without this, a draft built from `main` would install and report "1.2.5" despite being four commits ahead, making it impossible to tell which build is running.

Version touched in all four places `release:check` and the release workflow care about:

- `package.json`
- `src-tauri/tauri.conf.json`
- `src-tauri/Cargo.toml`
- the `cubby` entry in `src-tauri/Cargo.lock`

## Changelog scope

The entry lists only what a user can actually observe:

```
## v1.2.6

### Changed
- Refreshed the interface icon set. The filter, settings, shield, play,
  pause, file, and flask icons are redrawn with the same meanings and
  slightly different shapes
```

Deliberately **not** listed, since none of it changes what a user sees or does:

| Change | Why omitted |
| --- | --- |
| React 19 (#132) | Internal runtime swap |
| TypeScript 6 (#131) | Type-check only, `noEmit`, emits nothing |
| vite 6 + dependency consolidation (#126) | Build tooling |
| aria-labels (#130) | Landed on `ControlBar`, which currently has no consumers and does not render |

That last one is worth being explicit about. The accessibility fix is real, but it is not reachable in the shipped UI today, so claiming it as a user-facing improvement would be inaccurate.

## Verification

- `pnpm run release:check` → `Cubby Clipboard v1.2.6 release metadata is consistent.`
- `pnpm run format:check` clean
- `pnpm run build` clean

## Next

Once this merges, `gh workflow run release.yml --ref main` produces a draft prerelease tagged `draft-<sha>`, named "Cubby Clipboard v1.2.6 test build", Azure-signed, for installing and exercising the icon refresh and React 19 by hand. It stays a draft and does not reach the updater, which only reads `releases/latest`.
