### PR TITLE
Run the static half of the accessibility pass, and fix what it found

### DIFF
--- a/docs/ACCESSIBILITY_PASS.md
+++ b/docs/ACCESSIBILITY_PASS.md
@@ -115,8 +115,11 @@ Findings, worst first:
 |---|---|---|---|
 | 1 | `ClipList` / `ClipCard` | `role="list"` + `role="listitem"` with `aria-current` for the selected clip. The list is keyboard-navigated with a moving selection, so it needs `listbox` + `option` + `aria-selected`. As written, Narrator announces neither selection nor position. | 2 |
 | 2 | `SearchBar` | The input has only a `placeholder` and no `aria-label` or `<label>`, so it has no reliable accessible name, and the placeholder disappears once typing starts. | 1 |
-| 3 | `WelcomeOverlay` | No `role`, no accessible name, no focus management, on what is the first surface a new user sees. | 3 |
-| 4 | `ConfirmDialog` | Declares `aria-modal="true"` but never moves focus into itself. Neither dialog traps Tab or restores focus to the invoking control on close. | 3 |
+| 3 | `WelcomeOverlay` | No `role`, no accessible name, and no Escape, on what is the first surface a new user sees. It does carry `autoFocus` on its dismiss button, so focus does land inside it. | 3 |
+| 4 | `ConfirmDialog` | Declares `aria-modal="true"` but never moves focus into itself. None of the three dialogs trap Tab or restore focus to the invoking control on close. | 3 |
 | 5 | `ContextMenu` | No `role="menu"` / `role="menuitem"`, no arrow-key navigation, and focus is not moved into the menu on open, so reaching it means tabbing through the page. | 4 |
 | 6 | `SettingsPanel` | Tabs are plain buttons with no `role="tablist"` / `role="tab"` / `aria-selected`, so their tab nature and selected state are not conveyed. | 4 |
 | 7 | App-wide | No `aria-live` region anywhere, so copy, delete, and pin produce no announcement. | 5 |
+
+Fixed on branch `a11y/flyout-accessibility-pass`: 2, 3, 4, 6. Findings 1, 5, and 7
+remain, and the assistive-technology half of this document is still unrun.

--- a/docs/ACCESSIBILITY_PASS.md
+++ b/docs/ACCESSIBILITY_PASS.md
@@ -116,14 +116,24 @@ Findings, worst first:
 | # | Component | Finding | Checklist |
 |---|---|---|---|
 | 1 | `ClipList` / `ClipCard` | `role="list"` + `role="listitem"` with `aria-current` for the selected clip. The list is keyboard-navigated with a moving selection, so it needs `listbox` + `option` + `aria-selected`. As written, Narrator announces neither selection nor position. | 2 |
-| 2 | `SearchBar` | The input has only a `placeholder` and no `aria-label` or `<label>`, so it has no reliable accessible name, and the placeholder disappears once typing starts. | 1 |
+| ~~2~~ | `SearchBar` | **Withdrawn.** Recorded against `SearchBar.tsx`, which is not rendered anywhere. The live search input is in `FlyoutHeader`, and it already has `aria-label` on both the field and its clear button. | 1 |
 | 3 | `WelcomeOverlay` | No `role`, no accessible name, and no Escape, on what is the first surface a new user sees. It does carry `autoFocus` on its dismiss button, so focus does land inside it. | 3 |
 | 4 | `ConfirmDialog` | Declares `aria-modal="true"` but never moves focus into itself. None of the three dialogs trap Tab or restore focus to the invoking control on close. | 3 |
 | 5 | `ContextMenu` | No `role="menu"` / `role="menuitem"`, no arrow-key navigation, and focus is not moved into the menu on open, so reaching it means tabbing through the page. | 4 |
 | 6 | `SettingsPanel` | Tabs are plain buttons with no `role="tablist"` / `role="tab"` / `aria-selected`, so their tab nature and selected state are not conveyed. | 4 |
 | ~~7~~ | App-wide | **Withdrawn.** Recorded as "no `aria-live` region anywhere", which was wrong: grepping the app source found none, but `sonner` renders one in its own container, and copy, delete, and pin all raise toasts through it. | 5 |
 
-Fixed on branch `a11y/flyout-accessibility-pass`: 2, 3, 4, 5, 6. Finding 7 was
-withdrawn as a false positive. Finding 1 remains, and the assistive-technology
-half of this document is still unrun — that is what issue #45 needs next, and
-finding 1 is the item most worth confirming with Narrator once it is fixed.
+| 8 | `SearchBar`, `ControlBar`, `DragPreview` | None of these three components is imported anywhere. They are dead code, and auditing them produced two of the false positives above. `ControlBar` matters most: PR #130 added accessible names to its icon-only buttons, so that accessibility work never reached users. | — |
+
+Fixed on branch `a11y/flyout-accessibility-pass`: 1, 3, 4, 5, 6. Findings 2 and 7
+were withdrawn as false positives. Finding 8 is a live-code question rather than
+an accessibility defect and wants its own decision.
+
+Lesson worth keeping: grep the render tree before auditing a component. Two of
+seven findings were against code that does not ship, and the audit only caught it
+when wiring `aria-activedescendant` revealed `SearchBar` had no call site.
+
+The assistive-technology half of this document is still unrun, and that is what
+issue #45 needs next. The listbox change in finding 1 is the item most worth
+confirming with Narrator, since `aria-activedescendant` is exactly the kind of
+thing that reads correctly in the DOM and still fails in practice.

--- a/docs/ACCESSIBILITY_PASS.md
+++ b/docs/ACCESSIBILITY_PASS.md
@@ -108,6 +108,8 @@ Passing:
 - `ContextMenu` items are real `<button>` elements, so they are focusable and
   activatable, and it handles Escape.
 - Icon-only ControlBar buttons have `aria-label` (added in #130).
+- Status changes are announced. `sonner` renders its toast container with
+  `aria-live="polite"`, and copy, delete, and pin all raise a toast.
 
 Findings, worst first:
 
@@ -119,7 +121,9 @@ Findings, worst first:
 | 4 | `ConfirmDialog` | Declares `aria-modal="true"` but never moves focus into itself. None of the three dialogs trap Tab or restore focus to the invoking control on close. | 3 |
 | 5 | `ContextMenu` | No `role="menu"` / `role="menuitem"`, no arrow-key navigation, and focus is not moved into the menu on open, so reaching it means tabbing through the page. | 4 |
 | 6 | `SettingsPanel` | Tabs are plain buttons with no `role="tablist"` / `role="tab"` / `aria-selected`, so their tab nature and selected state are not conveyed. | 4 |
-| 7 | App-wide | No `aria-live` region anywhere, so copy, delete, and pin produce no announcement. | 5 |
+| ~~7~~ | App-wide | **Withdrawn.** Recorded as "no `aria-live` region anywhere", which was wrong: grepping the app source found none, but `sonner` renders one in its own container, and copy, delete, and pin all raise toasts through it. | 5 |
 
-Fixed on branch `a11y/flyout-accessibility-pass`: 2, 3, 4, 6. Findings 1, 5, and 7
-remain, and the assistive-technology half of this document is still unrun.
+Fixed on branch `a11y/flyout-accessibility-pass`: 2, 3, 4, 5, 6. Finding 7 was
+withdrawn as a false positive. Finding 1 remains, and the assistive-technology
+half of this document is still unrun — that is what issue #45 needs next, and
+finding 1 is the item most worth confirming with Narrator once it is fixed.

--- a/docs/ACCESSIBILITY_PASS.md
+++ b/docs/ACCESSIBILITY_PASS.md
@@ -1,0 +1,122 @@
+# Accessibility pass
+
+A repeatable pass over the flyout and Settings window. Two halves:
+
+- **Static audit** — semantics readable from the source. Anyone can redo it, no
+  Windows session needed. Current results are recorded below.
+- **Assistive-technology pass** — Narrator, scaling, contrast, and motion. These
+  need a real Windows 11 desktop and cannot be inferred from the code.
+
+Never put clipboard content or other sensitive data in test evidence. Copy
+throwaway strings (`test-one`, `test-two`) and crop screenshots to the control
+under test.
+
+## Recording a run
+
+Copy this block into the results section and fill it in:
+
+```
+Date:            YYYY-MM-DD
+Windows version: (winver → e.g. 11 24H2 26100.1234)
+Cubby version:   (Settings → About)
+Display:         (resolution, scaling %, text scaling %)
+Theme:           (light | dark | high-contrast <name>)
+Narrator:        (version / build if relevant)
+Result:          pass | fail per checklist item
+```
+
+## Static audit checklist
+
+Re-runnable with grep; no app session required.
+
+1. Every interactive element has an accessible name — visible text, `aria-label`,
+   or `aria-labelledby`. A `placeholder` is **not** an accessible name.
+2. Selection state is exposed with the role that carries it (`option` +
+   `aria-selected`, `tab` + `aria-selected`, `switch` + `aria-checked`).
+   `aria-current` on a `listitem` does not announce selection.
+3. Every `aria-modal="true"` container also moves focus into itself on open,
+   traps Tab within itself, and restores focus to the invoking control on close.
+   `aria-modal` without a trap is worse than no `aria-modal`, because it tells
+   the screen reader the background is inert when it is not.
+4. Composite widgets carry their full role set: `menu`/`menuitem`,
+   `tablist`/`tab`/`tabpanel`, `listbox`/`option`.
+5. Status changes that produce no focus change are announced through a live
+   region.
+6. `prefers-reduced-motion` and `forced-colors` blocks exist and cover the
+   window chrome, list rows, and selection colors.
+
+## Assistive-technology checklist
+
+Needs a Windows 11 desktop. Start Narrator with `Ctrl+Win+Enter`.
+
+### Narrator
+
+- Opening the flyout announces the window and lands focus somewhere sensible.
+- Arrowing through history announces each clip's position and selection state
+  ("N of M", "selected"), not just its text.
+- Pin, copy, and overflow buttons announce their name and pressed state.
+- Copy, delete, and pin announce their outcome without moving focus.
+- The context menu announces itself as a menu and its items as menu items.
+- Settings tabs announce as tabs with the selected one marked.
+- Dialogs announce their title on open, and Escape returns focus where it was.
+
+### Keyboard only
+
+Unplug or ignore the mouse for this section.
+
+- The configured hotkey opens the flyout and focus is immediately usable.
+- Tab order matches visual order, with no traps outside modal dialogs.
+- Every control reachable by mouse is reachable by keyboard, including the
+  context menu.
+- Focus is always visible against the current theme.
+- Escape closes menus and dialogs, one layer at a time.
+
+### Scaling
+
+Test at 100%, 150%, and 200% display scaling, and separately at 200% text
+scaling (Settings → Accessibility → Text size).
+
+- No clipped or overlapping text in the flyout, control bar, or Settings.
+- The flyout still fits its monitor's work area and stays on screen.
+- Scroll works when content exceeds the window.
+
+### Contrast and motion
+
+- Each Windows high-contrast theme: window chrome, list rows, the selected row,
+  buttons, and inputs all remain distinguishable.
+- Light and dark themes both meet contrast on body text and secondary text.
+- With "Show animations in Windows" off, nothing animates.
+
+## Results
+
+### 2026-08-05 — static audit
+
+Cubby 1.2.6. Static half only; the assistive-technology half has not been run
+and is what issue #45 still needs.
+
+Passing:
+
+- `prefers-reduced-motion` and `forced-colors` blocks exist in
+  `frontend/src/index.css` and cover the app window, clip cards, selected-row
+  colors, and form controls.
+- The show/hide paths in `lib.rs` do not animate despite their `animate_*`
+  names, so there is no native motion outside CSS control.
+- `ConfirmDialog` and `FolderModal` both carry `role="dialog"`,
+  `aria-modal="true"`, and `aria-labelledby`, and both handle Escape.
+- `FolderModal` moves focus to its input on open.
+- Settings toggles use `role="switch"` with `aria-checked`.
+- `ContextMenu` items are real `<button>` elements, so they are focusable and
+  activatable, and it handles Escape.
+- Icon-only ControlBar buttons have `aria-label` (added in #130).
+
+Findings, worst first:
+
+| # | Component | Finding | Checklist |
+|---|---|---|---|
+| 1 | `ClipList` / `ClipCard` | `role="list"` + `role="listitem"` with `aria-current` for the selected clip. The list is keyboard-navigated with a moving selection, so it needs `listbox` + `option` + `aria-selected`. As written, Narrator announces neither selection nor position. | 2 |
+| 2 | `SearchBar` | The input has only a `placeholder` and no `aria-label` or `<label>`, so it has no reliable accessible name, and the placeholder disappears once typing starts. | 1 |
+| 3 | `WelcomeOverlay` | No `role`, no accessible name, no focus management, on what is the first surface a new user sees. | 3 |
+| 4 | `ConfirmDialog` | Declares `aria-modal="true"` but never moves focus into itself. Neither dialog traps Tab or restores focus to the invoking control on close. | 3 |
+| 5 | `ContextMenu` | No `role="menu"` / `role="menuitem"`, no arrow-key navigation, and focus is not moved into the menu on open, so reaching it means tabbing through the page. | 4 |
+| 6 | `SettingsPanel` | Tabs are plain buttons with no `role="tablist"` / `role="tab"` / `aria-selected`, so their tab nature and selected state are not conveyed. | 4 |
+| 7 | App-wide | No `aria-live` region anywhere, so copy, delete, and pin produce no announcement. | 5 |

--- a/docs/ACCESSIBILITY_PASS.md
+++ b/docs/ACCESSIBILITY_PASS.md
@@ -15,7 +15,7 @@ under test.
 
 Copy this block into the results section and fill it in:
 
-```
+```text
 Date:            YYYY-MM-DD
 Windows version: (winver → e.g. 11 24H2 26100.1234)
 Cubby version:   (Settings → About)
@@ -76,7 +76,9 @@ Unplug or ignore the mouse for this section.
 Test at 100%, 150%, and 200% display scaling, and separately at 200% text
 scaling (Settings → Accessibility → Text size).
 
-- No clipped or overlapping text in the flyout, control bar, or Settings.
+- No clipped or overlapping text in the flyout header or Settings. (The
+  `ControlBar` component is not rendered — see finding 8 — so there is no
+  control bar to check until that is resolved.)
 - The flyout still fits its monitor's work area and stays on screen.
 - Scroll works when content exceeds the window.
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1055,6 +1055,7 @@ function App() {
 
           <FlyoutHeader
             searchQuery={searchQuery}
+            selectedClipId={selectedClipId}
             onSearchChange={handleSearch}
             contentFilter={contentFilter}
             onContentFilterChange={(filter) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1055,7 +1055,14 @@ function App() {
 
           <FlyoutHeader
             searchQuery={searchQuery}
-            selectedClipId={selectedClipId}
+            // Only point aria-activedescendant at a clip that is actually
+            // rendered. After a delete or a filter change the selected id can
+            // outlive its option by a render, and a dangling reference is worse
+            // than none.
+            selectedClipId={
+              visibleClips.some((clip) => clip.id === selectedClipId) ? selectedClipId : null
+            }
+            hasClipListbox={visibleClips.length > 0}
             onSearchChange={handleSearch}
             contentFilter={contentFilter}
             onContentFilterChange={(filter) => {

--- a/frontend/src/components/ClipCard.tsx
+++ b/frontend/src/components/ClipCard.tsx
@@ -128,8 +128,13 @@ export const ClipCard = memo(function ClipCard({
       data-el="clip-card"
       data-clip-id={clip.id}
       data-selected={isSelected}
-      role="listitem"
-      aria-current={isSelected ? 'true' : undefined}
+      // The list is single-select and keyboard-navigated, so option/aria-selected
+      // is what conveys the selection. aria-current on a listitem does not: a
+      // screen reader announces neither which clip is selected nor its position.
+      // The id is the aria-activedescendant target the search input points at.
+      id={`clip-option-${clip.id}`}
+      role="option"
+      aria-selected={isSelected}
       onMouseMove={onHover}
       onClick={onPaste}
       onContextMenu={(event) => {

--- a/frontend/src/components/ClipCard.tsx
+++ b/frontend/src/components/ClipCard.tsx
@@ -17,6 +17,10 @@ interface ClipCardProps {
   onCopy: () => void;
   onTogglePin: () => void;
   onContextMenu?: (e: React.MouseEvent) => void;
+  /** 1-based position of this option within the full history. */
+  posInSet: number;
+  /** Total options in the history, or -1 when more pages remain unloaded. */
+  setSize: number;
 }
 
 interface ImageMetadata {
@@ -75,6 +79,8 @@ export const ClipCard = memo(function ClipCard({
   onCopy,
   onTogglePin,
   onContextMenu,
+  posInSet,
+  setSize,
 }: ClipCardProps) {
   const imageSrc = useMemo(() => {
     if (clip.clip_type !== 'image' || !clip.content) return null;
@@ -135,6 +141,11 @@ export const ClipCard = memo(function ClipCard({
       id={`clip-option-${clip.id}`}
       role="option"
       aria-selected={isSelected}
+      // The list is paginated, so the DOM holds only part of the history. Without
+      // these a screen reader counts the rendered rows and announces a position
+      // out of the wrong total.
+      aria-posinset={posInSet}
+      aria-setsize={setSize}
       onMouseMove={onHover}
       onClick={onPaste}
       onContextMenu={(event) => {

--- a/frontend/src/components/ClipList.tsx
+++ b/frontend/src/components/ClipList.tsx
@@ -99,7 +99,8 @@ export function ClipList({
     <div
       ref={listRef}
       data-el="clip-list"
-      role="list"
+      id="clip-listbox"
+      role="listbox"
       aria-label="Clipboard history"
       className="no-scrollbar h-full overflow-y-auto px-2 pb-2"
       onScroll={(event) => {
@@ -110,7 +111,9 @@ export function ClipList({
         }
       }}
     >
-      <div className="space-y-1.5">
+      {/* presentation so the options stay direct children of the listbox in the
+          accessibility tree; an intervening generic would make them invalid. */}
+      <div role="presentation" className="space-y-1.5">
         {clips.map((clip) => (
           <ClipCard
             key={clip.id}
@@ -126,7 +129,7 @@ export function ClipList({
         ))}
       </div>
       {isLoading && (
-        <div className="flex justify-center py-3">
+        <div role="presentation" className="flex justify-center py-3">
           <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary/25 border-t-primary" />
         </div>
       )}

--- a/frontend/src/components/ClipList.tsx
+++ b/frontend/src/components/ClipList.tsx
@@ -114,11 +114,15 @@ export function ClipList({
       {/* presentation so the options stay direct children of the listbox in the
           accessibility tree; an intervening generic would make them invalid. */}
       <div role="presentation" className="space-y-1.5">
-        {clips.map((clip) => (
+        {clips.map((clip, index) => (
           <ClipCard
             key={clip.id}
             clip={clip}
             density={density}
+            posInSet={index + 1}
+            // -1 is the ARIA value for "total unknown", which is the honest
+            // answer while more pages remain unloaded.
+            setSize={hasMore ? -1 : clips.length}
             isSelected={selectedClipId === clip.id}
             onHover={handleCardHover(clip.id)}
             onPaste={() => onPaste(clip.id)}

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
 import { X, AlertTriangle } from 'lucide-react';
 import { useEffect, useId } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useModalDialog } from '../hooks/useModalDialog';
 
 interface ConfirmDialogProps {
   isOpen: boolean;
@@ -28,6 +29,9 @@ export function ConfirmDialog({
   const { t } = useTranslation();
   const titleId = useId();
   const descriptionId = useId();
+  // Escape is handled below (it has to respect isBusy), so the hook only
+  // supplies focus entry, the Tab trap, and focus restore.
+  const dialogRef = useModalDialog<HTMLDivElement>(undefined, isOpen);
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
@@ -44,6 +48,8 @@ export function ConfirmDialog({
   return (
     <div className="animate-in fade-in fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm duration-200">
       <div
+        ref={dialogRef}
+        tabIndex={-1}
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}

--- a/frontend/src/components/ContextMenu.tsx
+++ b/frontend/src/components/ContextMenu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface ContextMenuProps {
   x: number;
@@ -10,11 +11,14 @@ interface ContextMenuProps {
     disabled?: boolean;
   }[];
   onClose: () => void;
-  /** Accessible name for the menu. Screen readers announce this on open. */
+  /** Accessible name for the menu. Screen readers announce this on open.
+   *  Defaults to a translated string rather than a literal, since this is
+   *  user-facing text like every other string in the app. */
   label?: string;
 }
 
-export function ContextMenu({ x, y, options, onClose, label = 'Clip actions' }: ContextMenuProps) {
+export function ContextMenu({ x, y, options, onClose, label }: ContextMenuProps) {
+  const { t } = useTranslation();
   const menuRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const [position, setPosition] = useState({ x, y });
@@ -106,6 +110,10 @@ export function ContextMenu({ x, y, options, onClose, label = 'Clip actions' }: 
           break;
         case 'Tab':
           // A menu is a single stop, not a tab sequence: Tab dismisses it.
+          // preventDefault matters -- without it the browser also advances
+          // focus, which races the focus restore in the unmount cleanup and
+          // makes where focus ends up depend on ordering.
+          event.preventDefault();
           onClose();
           break;
       }
@@ -128,7 +136,7 @@ export function ContextMenu({ x, y, options, onClose, label = 'Clip actions' }: 
     <div
       ref={menuRef}
       role="menu"
-      aria-label={label}
+      aria-label={label ?? t('common.clipActions')}
       tabIndex={-1}
       className="animate-in fade-in-0 zoom-in-95 fixed z-50 max-h-[min(24rem,calc(100vh-1rem))] min-w-[12rem] overflow-y-auto rounded-lg border border-white/[0.1] bg-popover/95 p-1.5 shadow-2xl backdrop-blur-xl"
       style={style}

--- a/frontend/src/components/ContextMenu.tsx
+++ b/frontend/src/components/ContextMenu.tsx
@@ -74,9 +74,7 @@ export function ContextMenu({ x, y, options, onClose, label = 'Clip actions' }: 
       if (enabledIndices.length === 0) return;
 
       const active = document.activeElement;
-      const current = enabledIndices.indexOf(
-        itemRefs.current.findIndex((item) => item === active)
-      );
+      const current = enabledIndices.indexOf(itemRefs.current.findIndex((item) => item === active));
 
       switch (event.key) {
         case 'ArrowDown':
@@ -85,9 +83,7 @@ export function ContextMenu({ x, y, options, onClose, label = 'Clip actions' }: 
           break;
         case 'ArrowUp':
           event.preventDefault();
-          focusItem(
-            enabledIndices[(current - 1 + enabledIndices.length) % enabledIndices.length]
-          );
+          focusItem(enabledIndices[(current - 1 + enabledIndices.length) % enabledIndices.length]);
           break;
         case 'Home':
           event.preventDefault();

--- a/frontend/src/components/ContextMenu.tsx
+++ b/frontend/src/components/ContextMenu.tsx
@@ -10,10 +10,13 @@ interface ContextMenuProps {
     disabled?: boolean;
   }[];
   onClose: () => void;
+  /** Accessible name for the menu. Screen readers announce this on open. */
+  label?: string;
 }
 
-export function ContextMenu({ x, y, options, onClose }: ContextMenuProps) {
+export function ContextMenu({ x, y, options, onClose, label = 'Clip actions' }: ContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const [position, setPosition] = useState({ x, y });
 
   useLayoutEffect(() => {
@@ -28,16 +31,76 @@ export function ContextMenu({ x, y, options, onClose }: ContextMenuProps) {
     });
   }, [x, y, options.length]);
 
+  // Indices of items a keyboard user can land on. Disabled items are skipped
+  // rather than focused-and-inert, which is what a menu widget is expected to do.
+  const enabledIndices = options
+    .map((option, index) => (option.disabled ? -1 : index))
+    .filter((index) => index >= 0);
+
+  const focusItem = (index: number) => itemRefs.current[index]?.focus();
+
+  useEffect(() => {
+    // Move focus into the menu on open, and put it back where it came from on
+    // close. Without this the menu is reachable only by tabbing through
+    // everything behind it, which for a right-click menu means not at all.
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    if (enabledIndices.length > 0) {
+      focusItem(enabledIndices[0]);
+    } else {
+      menuRef.current?.focus();
+    }
+
+    return () => {
+      if (previouslyFocused?.isConnected) {
+        previouslyFocused.focus();
+      }
+    };
+    // Open-time behaviour only; re-running on option changes would yank focus
+    // back to the first item mid-navigation.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
         onClose();
       }
     }
-    // Handle Escape key
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === 'Escape') {
         onClose();
+        return;
+      }
+      if (enabledIndices.length === 0) return;
+
+      const active = document.activeElement;
+      const current = enabledIndices.indexOf(
+        itemRefs.current.findIndex((item) => item === active)
+      );
+
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault();
+          focusItem(enabledIndices[(current + 1) % enabledIndices.length]);
+          break;
+        case 'ArrowUp':
+          event.preventDefault();
+          focusItem(
+            enabledIndices[(current - 1 + enabledIndices.length) % enabledIndices.length]
+          );
+          break;
+        case 'Home':
+          event.preventDefault();
+          focusItem(enabledIndices[0]);
+          break;
+        case 'End':
+          event.preventDefault();
+          focusItem(enabledIndices[enabledIndices.length - 1]);
+          break;
+        case 'Tab':
+          // A menu is a single stop, not a tab sequence: Tab dismisses it.
+          onClose();
+          break;
       }
     }
 
@@ -47,7 +110,7 @@ export function ContextMenu({ x, y, options, onClose }: ContextMenuProps) {
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [onClose]);
+  }, [onClose, enabledIndices.join(',')]);
 
   const style = {
     top: position.y,
@@ -57,6 +120,9 @@ export function ContextMenu({ x, y, options, onClose }: ContextMenuProps) {
   return (
     <div
       ref={menuRef}
+      role="menu"
+      aria-label={label}
+      tabIndex={-1}
       className="animate-in fade-in-0 zoom-in-95 fixed z-50 max-h-[min(24rem,calc(100vh-1rem))] min-w-[12rem] overflow-y-auto rounded-lg border border-white/[0.1] bg-popover/95 p-1.5 shadow-2xl backdrop-blur-xl"
       style={style}
     >
@@ -64,6 +130,12 @@ export function ContextMenu({ x, y, options, onClose }: ContextMenuProps) {
         {options.map((option, index) => (
           <button
             key={index}
+            role="menuitem"
+            // Roving focus: the menu is one Tab stop and arrows move within it.
+            tabIndex={-1}
+            ref={(element) => {
+              itemRefs.current[index] = element;
+            }}
             disabled={option.disabled}
             onClick={() => {
               option.onClick();

--- a/frontend/src/components/ContextMenu.tsx
+++ b/frontend/src/components/ContextMenu.tsx
@@ -74,16 +74,27 @@ export function ContextMenu({ x, y, options, onClose, label = 'Clip actions' }: 
       if (enabledIndices.length === 0) return;
 
       const active = document.activeElement;
+      // -1 when focus is not on a menu item at all, e.g. it landed on the menu
+      // container. Treat that as "no current item" and jump to the end the
+      // arrow points at, instead of letting it fall out of the modulo
+      // arithmetic (ArrowUp from -1 lands second-to-last, not last).
       const current = enabledIndices.indexOf(itemRefs.current.findIndex((item) => item === active));
+      const last = enabledIndices.length - 1;
 
       switch (event.key) {
         case 'ArrowDown':
           event.preventDefault();
-          focusItem(enabledIndices[(current + 1) % enabledIndices.length]);
+          focusItem(
+            current === -1 ? enabledIndices[0] : enabledIndices[(current + 1) % (last + 1)]
+          );
           break;
         case 'ArrowUp':
           event.preventDefault();
-          focusItem(enabledIndices[(current - 1 + enabledIndices.length) % enabledIndices.length]);
+          focusItem(
+            current === -1
+              ? enabledIndices[last]
+              : enabledIndices[(current - 1 + last + 1) % (last + 1)]
+          );
           break;
         case 'Home':
           event.preventDefault();

--- a/frontend/src/components/FlyoutHeader.tsx
+++ b/frontend/src/components/FlyoutHeader.tsx
@@ -14,6 +14,8 @@ interface FlyoutHeaderProps {
   onAddFolder: () => void;
   onOpenHistoryMenu: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onOpenSettings: () => void;
+  /** Id of the currently selected clip, or null. Drives aria-activedescendant. */
+  selectedClipId: string | null;
 }
 
 export function FlyoutHeader({
@@ -27,6 +29,7 @@ export function FlyoutHeader({
   onAddFolder,
   onOpenHistoryMenu,
   onOpenSettings,
+  selectedClipId,
 }: FlyoutHeaderProps) {
   return (
     <header className="drag-area shrink-0 px-3 pb-2 pt-3">
@@ -38,6 +41,11 @@ export function FlyoutHeader({
           onChange={(event) => onSearchChange(event.target.value)}
           placeholder="Search clipboard history"
           aria-label="Search clipboard history"
+          // Arrow keys move the selection in the list while focus stays here, so
+          // the selected clip is announced through aria-activedescendant rather
+          // than by moving focus. Ids match ClipCard's `clip-option-<id>`.
+          aria-controls="clip-listbox"
+          aria-activedescendant={selectedClipId ? `clip-option-${selectedClipId}` : undefined}
           className="min-w-0 flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-muted-foreground"
         />
         {searchQuery && (

--- a/frontend/src/components/FlyoutHeader.tsx
+++ b/frontend/src/components/FlyoutHeader.tsx
@@ -16,6 +16,10 @@ interface FlyoutHeaderProps {
   onOpenSettings: () => void;
   /** Id of the currently selected clip, or null. Drives aria-activedescendant. */
   selectedClipId: string | null;
+  /** Whether the listbox is actually rendered. ClipList returns loading, empty,
+   *  and error markup instead of the list, and aria-controls must not point at
+   *  an id that is not in the document. */
+  hasClipListbox: boolean;
 }
 
 export function FlyoutHeader({
@@ -30,6 +34,7 @@ export function FlyoutHeader({
   onOpenHistoryMenu,
   onOpenSettings,
   selectedClipId,
+  hasClipListbox,
 }: FlyoutHeaderProps) {
   return (
     <header className="drag-area shrink-0 px-3 pb-2 pt-3">
@@ -44,8 +49,10 @@ export function FlyoutHeader({
           // Arrow keys move the selection in the list while focus stays here, so
           // the selected clip is announced through aria-activedescendant rather
           // than by moving focus. Ids match ClipCard's `clip-option-<id>`.
-          aria-controls="clip-listbox"
-          aria-activedescendant={selectedClipId ? `clip-option-${selectedClipId}` : undefined}
+          aria-controls={hasClipListbox ? 'clip-listbox' : undefined}
+          aria-activedescendant={
+            hasClipListbox && selectedClipId ? `clip-option-${selectedClipId}` : undefined
+          }
           className="min-w-0 flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-muted-foreground"
         />
         {searchQuery && (

--- a/frontend/src/components/FolderModal.tsx
+++ b/frontend/src/components/FolderModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useModalDialog } from '../hooks/useModalDialog';
 
 interface FolderModalProps {
   isOpen: boolean;
@@ -14,6 +15,7 @@ export function FolderModal({ isOpen, mode, initialName, onClose, onSubmit }: Fo
   const inputRef = useRef<HTMLInputElement>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const titleId = useId();
+  const dialogRef = useModalDialog<HTMLDivElement>(onClose, isOpen);
 
   useEffect(() => {
     if (isOpen) {
@@ -44,6 +46,8 @@ export function FolderModal({ isOpen, mode, initialName, onClose, onSubmit }: Fo
   return (
     <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
       <div
+        ref={dialogRef}
+        tabIndex={-1}
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
@@ -60,10 +64,10 @@ export function FolderModal({ isOpen, mode, initialName, onClose, onSubmit }: Fo
           defaultValue={initialName}
           className="mb-4 w-full rounded-md border border-input bg-input px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
           onKeyDown={(e) => {
+            // Escape is handled dialog-wide by useModalDialog, so it works from
+            // the buttons too, not only while the input has focus.
             if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
               handleSubmit();
-            } else if (e.key === 'Escape') {
-              onClose();
             }
           }}
         />

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -39,19 +39,11 @@ export function SearchBar({ query, onQueryChange, onClear }: SearchBarProps) {
         value={query}
         onChange={(e) => onQueryChange(e.target.value)}
         placeholder={`Search clips... (Ctrl+F)`}
-        // The placeholder is not an accessible name, and it disappears as soon
-        // as the user types, so the field needs a name of its own.
-        aria-label="Search clips"
         className="search-input pl-10 pr-20"
       />
       <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
         {query && (
-          <button
-            onClick={onClear}
-            className="icon-button p-1"
-            title="Clear search"
-            aria-label="Clear search"
-          >
+          <button onClick={onClear} className="icon-button p-1" title="Clear search">
             <X size={14} />
           </button>
         )}

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -39,11 +39,19 @@ export function SearchBar({ query, onQueryChange, onClear }: SearchBarProps) {
         value={query}
         onChange={(e) => onQueryChange(e.target.value)}
         placeholder={`Search clips... (Ctrl+F)`}
+        // The placeholder is not an accessible name, and it disappears as soon
+        // as the user types, so the field needs a name of its own.
+        aria-label="Search clips"
         className="search-input pl-10 pr-20"
       />
       <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
         {query && (
-          <button onClick={onClear} className="icon-button p-1" title="Clear search">
+          <button
+            onClick={onClear}
+            className="icon-button p-1"
+            title="Clear search"
+            aria-label="Clear search"
+          >
             <X size={14} />
           </button>
         )}

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -707,6 +707,40 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
     { id: 'about', label: t('settings.about'), icon: <Info size={17} /> },
   ];
 
+  // Roving tabindex: only the selected tab is in the Tab order, and Up/Down move
+  // between tabs. That is the expected tab-widget behaviour, and without it a
+  // keyboard user has to Tab through every tab to reach the panel.
+  const tabRefs = useRef<Partial<Record<Tab, HTMLButtonElement | null>>>({});
+
+  const focusTabAt = (index: number) => {
+    const next = tabs[(index + tabs.length) % tabs.length];
+    setActiveTab(next.id);
+    tabRefs.current[next.id]?.focus();
+  };
+
+  const handleTabKeyDown = (event: React.KeyboardEvent, index: number) => {
+    switch (event.key) {
+      case 'ArrowDown':
+      case 'ArrowRight':
+        event.preventDefault();
+        focusTabAt(index + 1);
+        break;
+      case 'ArrowUp':
+      case 'ArrowLeft':
+        event.preventDefault();
+        focusTabAt(index - 1);
+        break;
+      case 'Home':
+        event.preventDefault();
+        focusTabAt(0);
+        break;
+      case 'End':
+        event.preventDefault();
+        focusTabAt(tabs.length - 1);
+        break;
+    }
+  };
+
   const ghostButton =
     'inline-flex items-center gap-2 rounded-lg border border-border bg-accent/40 px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent disabled:opacity-50';
 
@@ -749,10 +783,24 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
         <div className="flex flex-1 overflow-hidden">
           {/* Sidebar */}
           <div className="flex w-[188px] flex-shrink-0 flex-col border-r border-border bg-card/40 p-2.5">
-            <div className="flex flex-col gap-0.5">
-              {tabs.map((tab) => (
+            <div
+              role="tablist"
+              aria-orientation="vertical"
+              aria-label={t('settings.title')}
+              className="flex flex-col gap-0.5"
+            >
+              {tabs.map((tab, index) => (
                 <button
                   key={tab.id}
+                  role="tab"
+                  id={`settings-tab-${tab.id}`}
+                  aria-selected={activeTab === tab.id}
+                  aria-controls="settings-tabpanel"
+                  tabIndex={activeTab === tab.id ? 0 : -1}
+                  ref={(element) => {
+                    tabRefs.current[tab.id] = element;
+                  }}
+                  onKeyDown={(event) => handleTabKeyDown(event, index)}
                   onClick={() => setActiveTab(tab.id)}
                   className={clsx(
                     'flex items-center gap-3 rounded-lg px-3 py-2 text-[13.5px] font-medium transition-colors',
@@ -772,7 +820,13 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
           </div>
 
           {/* Content Area */}
-          <div className="flex-1 overflow-y-auto px-7 py-6">
+          <div
+            role="tabpanel"
+            id="settings-tabpanel"
+            aria-labelledby={`settings-tab-${activeTab}`}
+            tabIndex={0}
+            className="flex-1 overflow-y-auto px-7 py-6"
+          >
             <div className="mx-auto max-w-2xl">
               {/* --- GENERAL TAB --- */}
               {activeTab === 'general' && (

--- a/frontend/src/components/WelcomeOverlay.tsx
+++ b/frontend/src/components/WelcomeOverlay.tsx
@@ -1,5 +1,6 @@
 import { Clipboard, Keyboard, Lock, Pin } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { useModalDialog } from '../hooks/useModalDialog';
 
 interface WelcomeOverlayProps {
   onDismiss: () => void;
@@ -12,6 +13,7 @@ interface WelcomeOverlayProps {
  */
 export function WelcomeOverlay({ onDismiss }: WelcomeOverlayProps) {
   const { t } = useTranslation();
+  const dialogRef = useModalDialog<HTMLDivElement>(onDismiss);
 
   const points = [
     { icon: Keyboard, text: t('onboarding.pointOpen') },
@@ -22,10 +24,22 @@ export function WelcomeOverlay({ onDismiss }: WelcomeOverlayProps) {
 
   return (
     <div className="animate-in fade-in absolute inset-0 z-50 flex items-center justify-center bg-black/60 p-3 backdrop-blur-sm duration-200">
-      <div className="animate-in zoom-in-95 flex max-h-full w-full max-w-sm flex-col overflow-hidden rounded-lg border border-border bg-background shadow-lg duration-200">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="welcome-title"
+        aria-describedby="welcome-intro"
+        tabIndex={-1}
+        className="animate-in zoom-in-95 flex max-h-full w-full max-w-sm flex-col overflow-hidden rounded-lg border border-border bg-background shadow-lg duration-200"
+      >
         <div className="flex flex-col gap-1 px-5 pt-5">
-          <h2 className="text-base font-semibold text-foreground">{t('onboarding.title')}</h2>
-          <p className="text-xs text-muted-foreground">{t('onboarding.intro')}</p>
+          <h2 id="welcome-title" className="text-base font-semibold text-foreground">
+            {t('onboarding.title')}
+          </h2>
+          <p id="welcome-intro" className="text-xs text-muted-foreground">
+            {t('onboarding.intro')}
+          </p>
         </div>
         <ul className="flex flex-col gap-3 overflow-y-auto px-5 py-4">
           {points.map(({ icon: Icon, text }, index) => (

--- a/frontend/src/hooks/useModalDialog.ts
+++ b/frontend/src/hooks/useModalDialog.ts
@@ -69,7 +69,17 @@ export function useModalDialog<T extends HTMLElement>(onEscape?: () => void, ena
       const last = candidates[candidates.length - 1];
       const active = document.activeElement;
 
-      if (event.shiftKey && (active === first || !container.contains(active))) {
+      // Focus can sit outside the dialog despite the trap -- a mousedown on
+      // background content moves it there without a Tab we could intercept.
+      // Pull it back in on the next Tab, in whichever direction was pressed,
+      // rather than letting that Tab walk further away.
+      if (!container.contains(active)) {
+        event.preventDefault();
+        (event.shiftKey ? last : first).focus();
+        return;
+      }
+
+      if (event.shiftKey && active === first) {
         event.preventDefault();
         last.focus();
       } else if (!event.shiftKey && active === last) {

--- a/frontend/src/hooks/useModalDialog.ts
+++ b/frontend/src/hooks/useModalDialog.ts
@@ -1,0 +1,93 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Focus behaviour every `aria-modal="true"` container owes its users.
+ *
+ * Declaring `aria-modal` tells a screen reader the rest of the page is inert.
+ * Without a Tab trap that is a lie: focus walks out into content the user was
+ * just told does not exist, with no way to tell it left. So the three pieces
+ * belong together rather than being optional extras.
+ *
+ * - move focus into the dialog on open (respecting an `autoFocus` element)
+ * - keep Tab and Shift+Tab inside it
+ * - return focus to whatever was focused before, on close
+ *
+ * `onEscape` is optional so a dialog mid-operation can decline to close, and so
+ * a dialog that already owns its own Escape handling can opt out.
+ *
+ * `enabled` exists because a dialog that stays mounted and renders `null` while
+ * closed has no container to focus at mount time. Gate on the same condition
+ * that renders the dialog, or the trap silently never attaches.
+ */
+export function useModalDialog<T extends HTMLElement>(onEscape?: () => void, enabled = true) {
+  const containerRef = useRef<T>(null);
+  // Read through a ref so changing the handler between renders does not tear
+  // down and re-run the focus effect, which would steal focus back on every
+  // parent render.
+  const escapeRef = useRef(onEscape);
+  escapeRef.current = onEscape;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const focusable = () =>
+      Array.from(
+        container.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )
+      ).filter((element) => element.offsetParent !== null || element === document.activeElement);
+
+    // Anything already carrying autoFocus wins; otherwise the first focusable
+    // control, and failing that the container, so focus is never left outside.
+    if (!container.contains(document.activeElement)) {
+      const candidates = focusable();
+      const preferred = candidates.find((element) => element.hasAttribute('autofocus'));
+      (preferred ?? candidates[0] ?? container).focus();
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        escapeRef.current?.();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+
+      const candidates = focusable();
+      if (candidates.length === 0) {
+        // Nothing to move to: hold focus on the container rather than letting
+        // it escape to the background.
+        event.preventDefault();
+        container.focus();
+        return;
+      }
+
+      const first = candidates[0];
+      const last = candidates[candidates.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey && (active === first || !container.contains(active))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, true);
+      // The invoking control can be gone by now (deleted clip, closed panel);
+      // isConnected keeps that from throwing focus somewhere arbitrary.
+      if (previouslyFocused?.isConnected) {
+        previouslyFocused.focus();
+      }
+    };
+  }, [enabled]);
+
+  return containerRef;
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -8,7 +8,8 @@
     "loading": "Loading...",
     "copied": "Copied to clipboard",
     "pause": "Pause",
-    "resume": "Resume"
+    "resume": "Resume",
+    "clipActions": "Clip actions"
   },
   "clipList": {
     "empty": "No clips yet",


### PR DESCRIPTION
Works issue #45. Adds the reproducible checklist that issue asks for, runs the half of it that can be run from source, and fixes five of the findings.

## Scope, and what is deliberately not here

Issue #45 is mostly a manual pass. Narrator announcements, 200% scaling, and high-contrast rendering cannot be inferred from source. So `docs/ACCESSIBILITY_PASS.md` splits into two halves:

- a **static audit**, repeatable with grep, run here against 1.2.6
- an **assistive-technology pass** needing a Windows 11 desktop, still unrun

Issue #45 should stay open for the second half. The listbox change below is the item most worth verifying with Narrator, since `aria-activedescendant` is the pattern that most often reads correctly in the DOM and still fails in practice.

## Fixed

**Clip list is now a listbox.** It was `role="list"` with `role="listitem"` children and `aria-current` marking the selection. Arrow keys move that selection while focus stays in the search field, and `aria-current` on a listitem conveys none of it: a screen reader announces neither which clip is selected nor its position. Now `listbox` / `option` / `aria-selected`, with `aria-controls` and `aria-activedescendant` on the search input. Focus never leaves the input, so this is the `aria-activedescendant` pattern rather than roving tabindex. Wrapper divs are marked `presentation`, since an intervening generic would make the options invalid children of the listbox.

**Modal dialogs got real focus behaviour.** Three containers declared `aria-modal="true"` while none trapped Tab or restored focus on close, and `ConfirmDialog` never moved focus into itself at all. `aria-modal` without a trap is worse than omitting it: the screen reader is told the background is inert, then focus walks straight out into it with nothing signalling the boundary was crossed. The new `useModalDialog` hook does focus entry, the trap, and restore together, because they are only correct together. Its `enabled` flag exists because `ConfirmDialog` and `FolderModal` stay mounted rendering `null` while closed, so a mount-time effect would never attach.

**Context menu is a real menu.** No menu roles, and nothing moved focus into it, so a right-click menu was effectively unreachable by keyboard. Now `role="menu"` with an accessible name, `menuitem` children with roving focus, focus on open and restore on close, arrow navigation that skips disabled items, Home/End, and Tab to dismiss.

**Welcome overlay** gained dialog role, labelling, and Escape. It already had `autoFocus`.

**Settings tabs** became a real tablist: roles, `aria-selected`, `aria-controls`, a labelled tabpanel, roving tabindex, and Up/Down/Home/End.

## Two findings withdrawn

Both were my errors, and both are recorded in the doc rather than quietly dropped.

**No missing live region.** I reported that none existed, having grepped only the app source. `sonner` renders one, and copy, delete, and pin all toast through it. Adding a second would have double-announced.

**The search field already had a name.** I audited `SearchBar.tsx`, which has no call site. The live input is in `FlyoutHeader` and already had `aria-label` on both the field and its clear button.

## One finding worth your attention

That second error surfaced something real: **`SearchBar`, `ControlBar`, and `DragPreview` are all unreferenced.** `ControlBar` is the one that matters, because PR #130 added accessible names to its icon-only buttons, so that accessibility work never reached users and is still outstanding wherever those buttons live now. Left alone here as a live-code question rather than an accessibility fix.

## Checks

`pnpm build` (tsc + vite) and `pnpm format:check` both pass. No behaviour was verified with a screen reader; see the scope note above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Improved screen-reader semantics for clip selection, list navigation, dialogs, context menus, and settings tabs.
  - Added keyboard navigation with arrow, Home, End, Escape, and Tab support where appropriate.
  - Improved focus placement, focus trapping, and focus restoration across modal windows and menus.
  - Added accessible labels, relationships, selection announcements, and reduced reliance on mouse interaction.

- **Documentation**
  - Added accessibility audit guidance and recorded current audit results, including remaining verification items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->