### PR TITLE
Cover the website analytics click classification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - run: pnpm run release:check
       - run: pnpm run build
       - run: node .github/scripts/check-site.mjs
-      - run: node --test product_pages/worker.test.mjs
+      - run: node --test product_pages/worker.test.mjs product_pages/analytics.test.mjs
       - run: pnpm audit --prod
       - run: cargo install cargo-audit --locked
       - shell: pwsh

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -33,4 +33,4 @@ jobs:
         with:
           node-version: 24
       - run: node .github/scripts/check-site.mjs
-      - run: node --test product_pages/worker.test.mjs
+      - run: node --test product_pages/worker.test.mjs product_pages/analytics.test.mjs

--- a/product_pages/404.html
+++ b/product_pages/404.html
@@ -25,6 +25,6 @@
       <div class="cta-row"><a class="button button-primary" href="/">Go to the homepage</a><a class="button button-secondary" href="/support">Get support</a></div>
     </header>
   </main>
-  <script src="/analytics.js" defer></script>
+  <script src="/analytics.js" type="module"></script>
 </body>
 </html>

--- a/product_pages/analytics.js
+++ b/product_pages/analytics.js
@@ -1,18 +1,66 @@
-(() => {
-  const endpoint = "/api/events";
+const ENDPOINT = "/api/events";
+const REPOSITORY_URL = "https://github.com/tsouth89/cubby-clipboard";
 
+/**
+ * True when `href` points at this project's GitHub repository.
+ *
+ * Deliberately not a bare `startsWith(REPOSITORY_URL)`: that also matches
+ * sibling repositories whose names merely begin the same way, so a link to
+ * `.../cubby-clipboard-docs` would be counted as a click on this repo. Require
+ * the repository URL to end there or continue with a path, query, or fragment.
+ */
+export function isRepositoryUrl(href) {
+  if (typeof href !== "string" || !href.startsWith(REPOSITORY_URL)) return false;
+  const rest = href.slice(REPOSITORY_URL.length);
+  return rest === "" || "/?#".includes(rest[0]);
+}
+
+/**
+ * Decide which event a link click represents, or `null` for links we do not
+ * track. Takes plain values rather than an element so it can be tested without
+ * a DOM.
+ *
+ * Installer and release-page markers win over the repository check, because the
+ * download buttons point at GitHub too and are the more specific intent.
+ */
+export function classifyLinkClick({ href, isLatestInstaller, isLatestRelease }) {
+  if (isLatestInstaller) {
+    return { event: "download_clicked", asset: "windows-x64-installer" };
+  }
+  if (isLatestRelease) {
+    return { event: "download_clicked", asset: "release-page" };
+  }
+  if (isRepositoryUrl(href)) {
+    return { event: "github_clicked" };
+  }
+  return null;
+}
+
+/**
+ * Build the request body for one event.
+ *
+ * Takes the location object and reads `pathname` from it explicitly. The site
+ * must never report query strings or fragments: those carry whatever a referrer
+ * or campaign appended to the URL, which is exactly the kind of incidental
+ * personal data the privacy policy promises not to collect.
+ */
+export function buildEventPayload(event, location, referrer, properties = {}) {
+  return {
+    event,
+    pathname: location.pathname,
+    referrer,
+    ...properties,
+  };
+}
+
+// Browser wiring. Guarded so importing this module in Node (the tests) does not
+// try to touch document/location or fire a request.
+if (typeof document !== "undefined") {
   const capture = (event, properties = {}) => {
-    const payload = JSON.stringify({
-      event,
-      pathname: location.pathname,
-      referrer: document.referrer,
-      ...properties,
-    });
-
-    fetch(endpoint, {
+    fetch(ENDPOINT, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: payload,
+      body: JSON.stringify(buildEventPayload(event, location, document.referrer, properties)),
       keepalive: true,
       credentials: "same-origin",
     }).catch(() => {
@@ -27,14 +75,18 @@
     const link = event.target.closest("a[href]");
     if (!link) return;
 
-    const href = link.href;
-    if (link.matches("[data-latest-installer], [data-latest-release]")) {
-      capture("download_clicked", {
-        asset: link.matches("[data-latest-installer]") ? "windows-x64-installer" : "release-page",
-        release: document.querySelector("[data-release-version]")?.textContent || "latest",
-      });
-    } else if (href.startsWith("https://github.com/tsouth89/cubby-clipboard")) {
-      capture("github_clicked");
+    const classified = classifyLinkClick({
+      href: link.href,
+      isLatestInstaller: link.matches("[data-latest-installer]"),
+      isLatestRelease: link.matches("[data-latest-release]"),
+    });
+    if (!classified) return;
+
+    const { event: name, ...properties } = classified;
+    if (name === "download_clicked") {
+      properties.release =
+        document.querySelector("[data-release-version]")?.textContent || "latest";
     }
+    capture(name, properties);
   });
-})();
+}

--- a/product_pages/analytics.test.mjs
+++ b/product_pages/analytics.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildEventPayload, classifyLinkClick, isRepositoryUrl } from "./analytics.js";
+
+test("installer links report the installer asset", () => {
+  assert.deepEqual(
+    classifyLinkClick({
+      href: "https://github.com/tsouth89/cubby-clipboard/releases/download/v1.2.6/setup.exe",
+      isLatestInstaller: true,
+      isLatestRelease: false,
+    }),
+    { event: "download_clicked", asset: "windows-x64-installer" }
+  );
+});
+
+test("release-page links report the release-page asset", () => {
+  assert.deepEqual(
+    classifyLinkClick({
+      href: "https://github.com/tsouth89/cubby-clipboard/releases/latest",
+      isLatestInstaller: false,
+      isLatestRelease: true,
+    }),
+    { event: "download_clicked", asset: "release-page" }
+  );
+});
+
+test("the installer marker wins when a link carries both", () => {
+  // Both markers on one element must not be ambiguous: the download button
+  // points at GitHub too, and the more specific intent is the installer.
+  assert.deepEqual(
+    classifyLinkClick({
+      href: "https://github.com/tsouth89/cubby-clipboard/releases/latest",
+      isLatestInstaller: true,
+      isLatestRelease: true,
+    }),
+    { event: "download_clicked", asset: "windows-x64-installer" }
+  );
+});
+
+test("repository links without a download marker report a github click", () => {
+  for (const href of [
+    "https://github.com/tsouth89/cubby-clipboard",
+    "https://github.com/tsouth89/cubby-clipboard/issues/45",
+    "https://github.com/tsouth89/cubby-clipboard?tab=readme",
+    "https://github.com/tsouth89/cubby-clipboard#install",
+  ]) {
+    assert.deepEqual(
+      classifyLinkClick({ href, isLatestInstaller: false, isLatestRelease: false }),
+      { event: "github_clicked" },
+      href
+    );
+  }
+});
+
+test("unrelated links are not tracked", () => {
+  for (const href of [
+    "https://example.com/",
+    "https://github.com/",
+    "https://github.com/someone-else/other-project",
+    "https://cubbyclipboard.com/privacy",
+    "mailto:hello@example.com",
+  ]) {
+    assert.equal(
+      classifyLinkClick({ href, isLatestInstaller: false, isLatestRelease: false }),
+      null,
+      href
+    );
+  }
+});
+
+test("a repository whose name merely shares our prefix is not our repository", () => {
+  // A bare startsWith would count these as clicks on this project.
+  assert.equal(isRepositoryUrl("https://github.com/tsouth89/cubby-clipboard-docs"), false);
+  assert.equal(isRepositoryUrl("https://github.com/tsouth89/cubby-clipboardx"), false);
+  assert.equal(isRepositoryUrl("https://github.com/tsouth89/cubby-clipboard"), true);
+  assert.equal(isRepositoryUrl("https://github.com/tsouth89/cubby-clipboard/"), true);
+});
+
+test("isRepositoryUrl tolerates a missing or non-string href", () => {
+  assert.equal(isRepositoryUrl(undefined), false);
+  assert.equal(isRepositoryUrl(null), false);
+  assert.equal(isRepositoryUrl(42), false);
+});
+
+test("the payload reports only the pathname, never the query or fragment", () => {
+  const location = {
+    href: "https://cubbyclipboard.com/start?utm_source=newsletter&email=someone@example.com#top",
+    pathname: "/start",
+    search: "?utm_source=newsletter&email=someone@example.com",
+    hash: "#top",
+  };
+
+  const payload = buildEventPayload("$pageview", location, "https://example.com/ref");
+
+  assert.equal(payload.pathname, "/start");
+  const serialized = JSON.stringify(payload);
+  assert.ok(!serialized.includes("utm_source"), "query parameters must not be reported");
+  assert.ok(!serialized.includes("someone@example.com"), "query values must not be reported");
+  assert.ok(!serialized.includes("#top"), "fragments must not be reported");
+});
+
+test("the payload carries the event, referrer, and any extra properties", () => {
+  const payload = buildEventPayload(
+    "download_clicked",
+    { pathname: "/" },
+    "https://news.example/post",
+    { asset: "windows-x64-installer", release: "v1.2.6" }
+  );
+
+  assert.deepEqual(payload, {
+    event: "download_clicked",
+    pathname: "/",
+    referrer: "https://news.example/post",
+    asset: "windows-x64-installer",
+    release: "v1.2.6",
+  });
+});
+
+test("importing the module in Node fires no request and registers no listener", () => {
+  // The browser wiring is guarded on `document`. If that guard regresses, this
+  // import would have thrown on `document`/`location` before reaching here.
+  assert.equal(typeof classifyLinkClick, "function");
+  assert.equal(typeof globalThis.document, "undefined");
+});

--- a/product_pages/index.html
+++ b/product_pages/index.html
@@ -226,6 +226,6 @@
     <div class="shell footer-bottom"><span>© 2026 SouthForge AI</span><span>Free and open source · GPL-3.0</span></div>
   </footer>
   <script src="/release-links.js" defer></script>
-  <script src="/analytics.js" defer></script>
+  <script src="/analytics.js" type="module"></script>
 </body>
 </html>

--- a/product_pages/privacy.html
+++ b/product_pages/privacy.html
@@ -84,6 +84,6 @@
     </article>
   </main>
   <footer class="site-footer"><div class="shell footer-grid"><div><a class="brand footer-brand" href="/"><img class="brand-mark" src="/brand-mark.svg" alt=""><span>cubby clipboard</span></a><p>A better place for what you copy.</p></div><nav aria-label="Footer navigation"><a href="/privacy">Privacy</a><a href="/terms">Terms</a><a href="/support">Support</a><a href="https://github.com/tsouth89/cubby-clipboard">GitHub</a></nav></div><div class="shell footer-bottom"><span>© 2026 SouthForge AI</span><span>Free and open source · GPL-3.0</span></div></footer>
-  <script src="/analytics.js" defer></script>
+  <script src="/analytics.js" type="module"></script>
 </body>
 </html>

--- a/product_pages/start.html
+++ b/product_pages/start.html
@@ -251,6 +251,6 @@
     <div class="shell footer-bottom"><span>© 2026 SouthForge AI</span><span>Free and open source · GPL-3.0</span></div>
   </footer>
   <script src="/release-links.js" defer></script>
-  <script src="/analytics.js" defer></script>
+  <script src="/analytics.js" type="module"></script>
 </body>
 </html>

--- a/product_pages/support.html
+++ b/product_pages/support.html
@@ -95,6 +95,6 @@
   </main>
   <footer class="site-footer"><div class="shell footer-grid"><div><a class="brand footer-brand" href="/"><img class="brand-mark" src="/brand-mark.svg" alt=""><span>cubby clipboard</span></a><p>A better place for what you copy.</p></div><nav aria-label="Footer navigation"><a href="/privacy">Privacy</a><a href="/terms">Terms</a><a href="/support">Support</a><a href="https://github.com/tsouth89/cubby-clipboard">GitHub</a></nav></div><div class="shell footer-bottom"><span>© 2026 SouthForge AI</span><span>Free and open source · GPL-3.0</span></div></footer>
   <script src="/release-links.js" defer></script>
-  <script src="/analytics.js" defer></script>
+  <script src="/analytics.js" type="module"></script>
 </body>
 </html>

--- a/product_pages/terms.html
+++ b/product_pages/terms.html
@@ -75,6 +75,6 @@
     </article>
   </main>
   <footer class="site-footer"><div class="shell footer-grid"><div><a class="brand footer-brand" href="/"><img class="brand-mark" src="/brand-mark.svg" alt=""><span>cubby clipboard</span></a><p>A better place for what you copy.</p></div><nav aria-label="Footer navigation"><a href="/privacy">Privacy</a><a href="/terms">Terms</a><a href="/support">Support</a><a href="https://github.com/tsouth89/cubby-clipboard">GitHub</a></nav></div><div class="shell footer-bottom"><span>© 2026 SouthForge AI</span><span>Free and open source · GPL-3.0</span></div></footer>
-  <script src="/analytics.js" defer></script>
+  <script src="/analytics.js" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
Closes #43.

## Making it testable

`analytics.js` was one IIFE with nothing importable, so the click classification had no seam. The package is already `"type": "module"` and `_worker.js` already exports for its own tests, so this follows the same pattern: `analytics.js` exports pure helpers and guards the browser wiring behind a `typeof document !== "undefined"` check.

Importing it in Node therefore runs no side effects and fires no request. One test asserts that directly, so if the guard ever regresses the suite fails rather than silently POSTing during CI.

The six `<script>` tags become `type="module"`. That implies defer, so the `defer` attribute is dropped. The site's CSP is `default-src 'self'`, which already permits same-origin module scripts. No bundler, no dependencies — the site stays dependency-free.

## One behaviour change

The GitHub check was:

```js
href.startsWith("https://github.com/tsouth89/cubby-clipboard")
```

which also matches sibling repositories whose names merely begin the same way, so a link to `.../cubby-clipboard-docs` would be recorded as a click on this repository. `isRepositoryUrl` now requires the URL to end there or continue with `/`, `?`, or `#`. That case is one of the tests.

## Coverage

Ten tests: installer links, release-page links, repository links (bare, sub-path, query, fragment), unrelated links (other repos, other hosts, `mailto:`), the both-markers tie-break, and non-string hrefs.

The privacy requirement gets a real test rather than a tautological one. `buildEventPayload` takes the location object and reads `pathname` from it, and the test passes a location carrying `?utm_source=newsletter&email=someone@example.com#top`, then asserts none of that appears anywhere in the serialized body. That catches someone swapping `pathname` for `href`.

## Checks

`node --test product_pages/worker.test.mjs product_pages/analytics.test.mjs` — 18 pass. `node .github/scripts/check-site.mjs` passes. Both the `test` CI job and the website workflow now run the new file, as the issue asks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Analytics**
  * Improved tracking for installer downloads and repository links.
  * Excluded unrelated or invalid links from analytics events.
  * Added release-version details to download events where available.
  * Preserved privacy-safe event payloads.

* **Tests**
  * Expanded analytics coverage for link classification, payloads, validation, and browser-independent behavior.
  * CI and website validation now run both worker and analytics test suites.

* **Technical Improvements**
  * Updated product pages to load analytics consistently as an ES module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->