### PR TITLE
Speed up Windows CI by caching the pinned cargo-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,11 @@ jobs:
         shell: pwsh
         run: |
           $actual = (cargo audit --version | Out-String).Trim()
-          if ($actual -notmatch [regex]::Escape($env:CARGO_AUDIT_VERSION)) {
+          # Match the version as a whole token, so a pin of 0.22.2 is not
+          # satisfied by 0.22.20. Deliberately not anchored on the tool name:
+          # the binary reports itself as "cargo-audit-audit <version>".
+          $pattern = '(?:^|\s)' + [regex]::Escape($env:CARGO_AUDIT_VERSION) + '(?:\s|$)'
+          if ($actual -notmatch $pattern) {
             throw "Expected cargo-audit $env:CARGO_AUDIT_VERSION on PATH, got: $actual"
           }
           Write-Host "cargo-audit verified: $actual"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Pinned so the audit tool cannot change under us on an unrelated run, and so
+  # the cache key below is tied to an exact version. Bumping this string is what
+  # forces a fresh compile.
+  CARGO_AUDIT_VERSION: 0.22.2
+
 jobs:
   test:
     runs-on: windows-latest
@@ -49,7 +55,32 @@ jobs:
       - run: pnpm run test
       - run: node --test product_pages/worker.test.mjs product_pages/analytics.test.mjs
       - run: pnpm audit --prod
-      - run: cargo install cargo-audit --locked
+      # Compiling cargo-audit from source took 5m55s of a 9m17s job, to then run
+      # for 7 seconds. Cache the built binary instead. The key pins the exact
+      # version, so the only way to get a stale tool is to change the pin, which
+      # misses the cache and rebuilds.
+      - name: Cache cargo-audit
+        id: cargo-audit-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cargo/bin/cargo-audit.exe
+          key: ${{ runner.os }}-cargo-audit-${{ env.CARGO_AUDIT_VERSION }}
+
+      - if: steps.cargo-audit-cache.outputs.cache-hit != 'true'
+        run: cargo install cargo-audit --locked --version ${{ env.CARGO_AUDIT_VERSION }}
+
+      # Cheap insurance that a cache hit actually restored the tool we pinned,
+      # so a bad entry fails here with a clear message rather than somewhere
+      # inside the audit.
+      - name: Verify cargo-audit
+        shell: pwsh
+        run: |
+          $actual = (cargo audit --version | Out-String).Trim()
+          if ($actual -notmatch [regex]::Escape($env:CARGO_AUDIT_VERSION)) {
+            throw "Expected cargo-audit $env:CARGO_AUDIT_VERSION on PATH, got: $actual"
+          }
+          Write-Host "cargo-audit verified: $actual"
+
       - shell: pwsh
         run: ./scripts/audit-rust.ps1
       - run: cargo fmt --manifest-path src-tauri/Cargo.toml --check

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,14 @@ data/
 # Don't know why this file is always created...
 nul
 
+# Local marketing scratch work. Listed file by file on purpose: the rest of
+# docs/assets/store/ is tracked, so a directory-wide rule here would quietly
+# hide real store art later.
+docs/assets/store/cubby-store-box-art-1080.png
+docs/assets/store/cubby-store-poster-1440x2160.png
+docs/assets/store/cubby-store-poster.svg
+docs/cubby_15s_search_demo_v2.mp4
+
 # Tauri updater signing keys — the private key must NEVER be committed.
 # It belongs in a GitHub Actions secret (TAURI_SIGNING_PRIVATE_KEY), not the repo.
 cubby-updater.key


### PR DESCRIPTION
Closes #46.

## Measurement

From run [31003535348](https://github.com/tsouth89/cubby-clipboard/actions/runs/31003535348), the merge of #139:

| Step | Duration |
| --- | --- |
| `cargo install cargo-audit --locked` | **5m 55s** |
| `./scripts/audit-rust.ps1` (the actual audit) | 7s |
| Everything else combined | ~3m 22s |
| **Total `test` job** | **9m 17s** |

64% of every run compiled a tool from source so it could run for seven seconds.

Before/after timings from Actions are in a comment below, since the after number needs a run with a warm cache.

## Change

Pin `CARGO_AUDIT_VERSION` and cache the compiled binary at `~/.cargo/bin/cargo-audit.exe`, keyed on `${{ runner.os }}-cargo-audit-<version>`. A cache hit skips the install; a miss compiles exactly the pinned version with `--locked`.

`scripts/audit-rust.ps1` is untouched, its failure behavior is intact, and audits still run on every pull request.

## Trust tradeoff

The acceptance criteria ask for this explicitly, so being precise about what changed:

**Before:** every run compiled cargo-audit from crates.io sources on the runner.
**After:** runs restore a binary that *this same workflow* compiled from crates.io sources with `--locked` on a GitHub-hosted runner. We are trusting our own earlier CI run, not a third-party binary distributor.

That is deliberately different from `cargo-binstall` or `taiki-e/install-action`, which are faster still but fetch prebuilt binaries from a third party. The issue asked to avoid unpinned third-party actions and download URLs, and this introduces neither — the only actions used are `actions/cache@v6`, already in this workflow.

The residual risk is cache poisoning. GitHub scopes caches per branch: a pull request cannot write to the base branch's cache, and fork PRs cannot write to this repo's cache at all. A malicious branch can only poison a cache its own runs would read. The `Verify cargo-audit` step also asserts the restored binary reports the pinned version, so a wrong or truncated entry fails fast with a clear message rather than surfacing somewhere inside the audit.

## Cache invalidation

The key contains the exact pinned version, so the tool cannot drift silently — bumping `CARGO_AUDIT_VERSION` misses the key and forces a fresh compile. There are deliberately no `restore-keys`: a prefix fallback could restore a *different* version's binary, which is precisely the drift this pin exists to prevent.

Worth knowing about the rollout: caches are branch-scoped, so the first run on this PR is a cold miss, and the first run on `main` after merge will also miss and compile once. Every run after that hits.

## Verification

`./scripts/audit-rust.ps1` run locally against the pinned 0.22.2: exits 0 with the same 18 allowed warnings as before, so the waiver and failure behavior are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability by pinning the cargo-audit version and verifying it before Rust checks run.
  * Added caching for the audit tool to speed up CI runs.
  * Added local marketing scratch assets and demo media to the ignore list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->