### PR TITLE
ci: enable the CodeRev second generator

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -49,4 +49,8 @@ jobs:
         uses: tsouth89/coderev@main
         with:
           api-key: ${{ secrets.REVIEW_API_KEY }}
+          # Dual-generator: second model hunts alongside the first; one panel judges.
+          find2-provider: meta
+          find2-model: muse-spark-1.2-contributor
+          find2-api-key: ${{ secrets.REVIEW_FIND2_API_KEY }}
           conventions: AGENTS.md


### PR DESCRIPTION
Adds Muse Spark 1.2 (contributor) as a second finding generator alongside DeepSeek; one panel judges the union. Secret already set.