### PR TITLE
docs: sync keyboard shortcut tables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,8 @@ pnpm run test
 | `Ctrl+F` | Focus search |
 | `Escape` | Close window / clear search |
 | `Enter` | Paste selected item |
+| `Shift+Enter` | Paste as plain text, or paste recognized text from an image |
+| `Ctrl+Enter` | Copy selected item without pasting |
 | `Delete` | Delete selected item |
 | `Ctrl+P` | Pin/Unpin selected item (bare letters go to type-to-search) |
 | `↑` / `↓` | Navigate items |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ The app checks for signed updates at startup and every 30 minutes while it is ru
 | `Up` / `Down` | Move through clips |
 | `Enter` | Paste the selected clip |
 | `Shift+Enter` | Paste as plain text, or paste recognized text from an image |
-| `P` | Pin or unpin the selected clip |
+| `Ctrl+Enter` | Copy the selected clip without pasting it |
+| `Ctrl+P` | Pin or unpin the selected clip |
 | `Delete` | Delete the selected clip |
 | `Escape` | Clear search or close Cubby |
 


### PR DESCRIPTION
## Summary

Aligns the keyboard shortcut tables in `README.md` and `AGENTS.md` with `frontend/src/hooks/useKeyboard.ts`.

## Changes

- README: changes `P` to `Ctrl+P` and adds `Ctrl+Enter` for copy-without-paste.
- AGENTS: adds `Ctrl+Enter` and `Shift+Enter` rows.

## Verification

- Shortcut table rows were checked row by row against `useKeyboard.ts`.

Closes #143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated keyboard shortcut documentation to include `Shift+Enter` and `Ctrl+Enter`.
  * Changed the pin shortcut from `P` to `Ctrl+P`.
  * Clarified that `Ctrl+Enter` copies the selected clip without pasting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->