### PR TITLE
Filter History by source app and date range

### DIFF
--- a/frontend/src/utils/dateRange.test.ts
+++ b/frontend/src/utils/dateRange.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { customRange, presetRange, toUtcStamp, UNBOUNDED } from './dateRange';
+
+/**
+ * Boundaries are the user's local midnight, so the expected UTC stamps depend
+ * on the machine's zone. Deriving them the same way the caller would keeps
+ * these assertions true wherever CI runs, while still pinning the *shape* of
+ * each range (which day boundaries, how many of them, half-open).
+ */
+const localMidnight = (year: number, month: number, day: number) =>
+  toUtcStamp(new Date(year, month - 1, day));
+
+// A Wednesday, mid-afternoon: far enough into the day that a "last 7 days"
+// implemented as "now minus 168 hours" would visibly differ.
+const NOW = new Date(2026, 2, 11, 15, 30, 0);
+
+describe('toUtcStamp', () => {
+  it('emits the fixed-width shape created_at is stored in', () => {
+    expect(toUtcStamp(new Date(Date.UTC(2026, 2, 11, 15, 30, 45)))).toBe('2026-03-11 15:30:45');
+  });
+
+  it('produces stamps that sort chronologically as plain strings', () => {
+    const earlier = toUtcStamp(new Date(Date.UTC(2026, 2, 9, 23, 59, 59)));
+    const later = toUtcStamp(new Date(Date.UTC(2026, 2, 10, 0, 0, 0)));
+    expect(earlier < later).toBe(true);
+  });
+});
+
+describe('presetRange', () => {
+  it('spans today from local midnight to midnight tomorrow', () => {
+    expect(presetRange('today', NOW)).toEqual({
+      from: localMidnight(2026, 3, 11),
+      to: localMidnight(2026, 3, 12),
+    });
+  });
+
+  it('spans yesterday only', () => {
+    expect(presetRange('yesterday', NOW)).toEqual({
+      from: localMidnight(2026, 3, 10),
+      to: localMidnight(2026, 3, 11),
+    });
+  });
+
+  it('counts last 7 days as 7 whole days ending with today', () => {
+    // Not "now minus 168 hours" — that would exclude this morning's clips.
+    expect(presetRange('last7', NOW)).toEqual({
+      from: localMidnight(2026, 3, 5),
+      to: localMidnight(2026, 3, 12),
+    });
+  });
+
+  it('counts last 30 days the same way', () => {
+    expect(presetRange('last30', NOW)).toEqual({
+      from: localMidnight(2026, 2, 10),
+      to: localMidnight(2026, 3, 12),
+    });
+  });
+
+  it('leaves "any time" unbounded', () => {
+    expect(presetRange('all', NOW)).toEqual(UNBOUNDED);
+  });
+
+  it('holds up across a month boundary', () => {
+    const firstOfMonth = new Date(2026, 2, 1, 9, 0, 0);
+    expect(presetRange('yesterday', firstOfMonth)).toEqual({
+      from: localMidnight(2026, 2, 28),
+      to: localMidnight(2026, 3, 1),
+    });
+  });
+});
+
+describe('customRange', () => {
+  it('treats both ends as inclusive days', () => {
+    // Same day for both means that whole day, so the upper bound advances.
+    expect(customRange('2026-03-11', '2026-03-11')).toEqual({
+      from: localMidnight(2026, 3, 11),
+      to: localMidnight(2026, 3, 12),
+    });
+  });
+
+  it('supports an open end on either side', () => {
+    expect(customRange('2026-03-11', '')).toEqual({
+      from: localMidnight(2026, 3, 11),
+      to: null,
+    });
+    expect(customRange('', '2026-03-11')).toEqual({
+      from: null,
+      to: localMidnight(2026, 3, 12),
+    });
+  });
+
+  it('is unbounded when neither end is set', () => {
+    expect(customRange('', '')).toEqual(UNBOUNDED);
+  });
+});

--- a/frontend/src/utils/dateRange.ts
+++ b/frontend/src/utils/dateRange.ts
@@ -1,0 +1,91 @@
+/**
+ * Date-range filtering for the History window (SOU-585).
+ *
+ * The backend compares against `clips.created_at`, which is stored as
+ * `YYYY-MM-DD HH:MM:SS` in **UTC** by every write path (`CURRENT_TIMESTAMP` and
+ * the Ditto importer both use that shape). The format is fixed-width, so a
+ * plain string comparison is chronological and uses `idx_clips_created` — but
+ * only if the bounds we send are in the same shape and the same zone.
+ *
+ * Ranges are half-open, `[from, to)`. "Today" is midnight today up to midnight
+ * tomorrow, so nothing has to reason about the last representable instant of a
+ * day, and a clip copied at 23:59:59.999 still counts as today.
+ *
+ * Boundaries are the user's *local* midnight — someone asking for "yesterday"
+ * means their yesterday — converted to UTC for the comparison.
+ */
+
+export type DatePreset = 'all' | 'today' | 'yesterday' | 'last7' | 'last30' | 'custom';
+
+export interface DateRange {
+  /** Inclusive lower bound, or null for unbounded. */
+  from: string | null;
+  /** Exclusive upper bound, or null for unbounded. */
+  to: string | null;
+}
+
+export const UNBOUNDED: DateRange = { from: null, to: null };
+
+export const DATE_PRESET_LABELS: Record<Exclude<DatePreset, 'custom'>, string> = {
+  all: 'Any time',
+  today: 'Today',
+  yesterday: 'Yesterday',
+  last7: 'Last 7 days',
+  last30: 'Last 30 days',
+};
+
+/** `YYYY-MM-DD HH:MM:SS` in UTC, the shape `created_at` is stored in. */
+export function toUtcStamp(date: Date): string {
+  return date.toISOString().slice(0, 19).replace('T', ' ');
+}
+
+/** Local midnight at the start of the day `date` falls in. */
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function addDays(date: Date, days: number): Date {
+  const shifted = new Date(date);
+  shifted.setDate(shifted.getDate() + days);
+  return shifted;
+}
+
+export function presetRange(preset: Exclude<DatePreset, 'custom'>, now: Date): DateRange {
+  const today = startOfLocalDay(now);
+  const tomorrow = addDays(today, 1);
+
+  switch (preset) {
+    case 'today':
+      return { from: toUtcStamp(today), to: toUtcStamp(tomorrow) };
+    case 'yesterday':
+      return { from: toUtcStamp(addDays(today, -1)), to: toUtcStamp(today) };
+    // "Last 7 days" includes today, so it spans 7 day-boundaries back from
+    // tomorrow — not 7 days back from right now, which would silently drop this
+    // morning's clips out of the window as the day went on.
+    case 'last7':
+      return { from: toUtcStamp(addDays(today, -6)), to: toUtcStamp(tomorrow) };
+    case 'last30':
+      return { from: toUtcStamp(addDays(today, -29)), to: toUtcStamp(tomorrow) };
+    case 'all':
+    default:
+      return UNBOUNDED;
+  }
+}
+
+/**
+ * A custom range from two `YYYY-MM-DD` values as typed into date inputs, which
+ * are local dates. Both ends are inclusive to the user: picking the same day
+ * for both means that whole day.
+ */
+export function customRange(from: string, to: string): DateRange {
+  return {
+    from: from ? toUtcStamp(parseLocalDate(from)) : null,
+    // Exclusive upper bound, so advance past the end of the chosen day.
+    to: to ? toUtcStamp(addDays(parseLocalDate(to), 1)) : null,
+  };
+}
+
+function parseLocalDate(value: string): Date {
+  const [year, month, day] = value.split('-').map(Number);
+  return new Date(year, (month ?? 1) - 1, day ?? 1);
+}

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -11,8 +11,18 @@ import { ContentFilter } from '../components/FlyoutHeader';
 import { useTheme } from '../hooks/useTheme';
 import { useLanguage } from '../hooks/useLanguage';
 import { useSystemAccent } from '../hooks/useSystemAccent';
+import { customRange, DATE_PRESET_LABELS, DatePreset, presetRange } from '../utils/dateRange';
+
+/** One entry in the source-app filter, from `get_source_apps`. */
+interface SourceAppCount {
+  name: string;
+  count: number;
+}
 
 const PAGE_SIZE = 20;
+
+const filterSelectClass =
+  'h-9 max-w-[168px] shrink-0 rounded-md border border-white/[0.08] bg-transparent px-2 text-xs text-muted-foreground outline-none hover:text-foreground';
 
 const CONTENT_FILTERS: ReadonlyArray<readonly [ContentFilter, string]> = [
   ['all', 'All'],
@@ -39,6 +49,18 @@ export function HistoryWindow() {
   const [hasMore, setHasMore] = useState(true);
   const [totalClipCount, setTotalClipCount] = useState(0);
   const [settings, setSettings] = useState<Settings | null>(null);
+  const [sourceApps, setSourceApps] = useState<SourceAppCount[]>([]);
+  const [sourceApp, setSourceApp] = useState<string | null>(null);
+  const [datePreset, setDatePreset] = useState<DatePreset>('all');
+  const [customFrom, setCustomFrom] = useState('');
+  const [customTo, setCustomTo] = useState('');
+
+  // Recomputed per render rather than stored, so a window left open overnight
+  // still means "today" tomorrow instead of pinning yesterday's boundaries.
+  const dateRange =
+    datePreset === 'custom'
+      ? customRange(customFrom, customTo)
+      : presetRange(datePreset, new Date());
 
   const effectiveTheme = useTheme(settings?.theme ?? 'system');
   useLanguage(settings?.language);
@@ -61,6 +83,10 @@ export function HistoryWindow() {
     };
   }, []);
 
+  // Destructured so the load callback depends on the two stamps rather than a
+  // fresh object identity each render, which would reload on every keystroke.
+  const { from: dateFrom, to: dateTo } = dateRange;
+
   const loadClips = useCallback(
     async (append: boolean) => {
       const loadId = ++loadIdRef.current;
@@ -81,6 +107,9 @@ export function HistoryWindow() {
               limit: PAGE_SIZE,
               offset,
               contentFilter,
+              dateFrom,
+              dateTo,
+              sourceApp,
             })
           : await invoke<ClipboardItem[]>('get_clips', {
               filterId: selectedFolder,
@@ -88,6 +117,9 @@ export function HistoryWindow() {
               offset,
               previewOnly: true,
               contentFilter,
+              dateFrom,
+              dateTo,
+              sourceApp,
             });
 
         if (loadId !== loadIdRef.current) return;
@@ -102,7 +134,7 @@ export function HistoryWindow() {
         if (loadId === loadIdRef.current) setIsLoading(false);
       }
     },
-    [contentFilter, searchQuery, selectedFolder]
+    [contentFilter, dateFrom, dateTo, searchQuery, selectedFolder, sourceApp]
   );
 
   const loadFolders = useCallback(async () => {
@@ -110,6 +142,14 @@ export function HistoryWindow() {
       setFolders(await invoke<FolderItem[]>('get_folders'));
     } catch (error) {
       console.error('Failed to load folders:', error);
+    }
+  }, []);
+
+  const loadSourceApps = useCallback(async () => {
+    try {
+      setSourceApps(await invoke<SourceAppCount[]>('get_source_apps'));
+    } catch (error) {
+      console.error('Failed to load source apps:', error);
     }
   }, []);
 
@@ -136,7 +176,8 @@ export function HistoryWindow() {
   useEffect(() => {
     loadFolders();
     refreshTotalCount();
-  }, [loadFolders, refreshTotalCount]);
+    loadSourceApps();
+  }, [loadFolders, refreshTotalCount, loadSourceApps]);
 
   // Keep the window live while it sits open next to the flyout: a copy made
   // anywhere shows up here without a manual refresh.
@@ -145,6 +186,8 @@ export function HistoryWindow() {
       loadClips(false);
       loadFolders();
       refreshTotalCount();
+      // A new clip can introduce an app, or move one up the list.
+      loadSourceApps();
     });
     const unlistenOcr = listen<string>('ocr-completed', (event) => {
       setClips((previous) =>
@@ -159,6 +202,9 @@ export function HistoryWindow() {
       loadClips(false);
       loadFolders();
       refreshTotalCount();
+      // Deleting elsewhere can empty out an app, changing its count or dropping
+      // it from the filter list entirely.
+      loadSourceApps();
     };
     window.addEventListener('focus', refreshOnFocus);
 
@@ -167,7 +213,7 @@ export function HistoryWindow() {
       unlistenClipboard.then((dispose) => dispose()).catch(() => undefined);
       unlistenOcr.then((dispose) => dispose()).catch(() => undefined);
     };
-  }, [loadClips, loadFolders, refreshTotalCount]);
+  }, [loadClips, loadFolders, refreshTotalCount, loadSourceApps]);
 
   const selectedClip = useMemo(
     () => clips.find((clip) => clip.id === selectedClipId) ?? null,
@@ -348,15 +394,39 @@ export function HistoryWindow() {
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [handleClose, handleCopy, handleDelete, searchQuery, selectedClipId]);
 
+  const hasNarrowingFilter =
+    Boolean(sourceApp) || dateFrom !== null || dateTo !== null || contentFilter !== 'all';
+
   const emptyState = searchQuery.trim()
-    ? { title: 'No matches', description: 'Try a different search term.' }
-    : selectedFolder
-      ? { title: 'This folder is empty', description: 'Move clips here to keep them together.' }
-      : contentFilter === 'images'
-        ? { title: 'No images yet', description: 'Copy an image and it will show up here.' }
-        : contentFilter === 'text'
-          ? { title: 'No text clips yet', description: 'Copy some text and it will show up here.' }
-          : { title: 'Nothing here yet', description: 'Anything you copy will appear in Cubby.' };
+    ? {
+        title: 'No matches',
+        description: hasNarrowingFilter
+          ? 'Try a different search term, or widen the filters.'
+          : 'Try a different search term.',
+      }
+    : sourceApp
+      ? {
+          title: `Nothing from ${sourceApp}`,
+          description: 'No clips from this app match the other filters.',
+        }
+      : dateFrom !== null || dateTo !== null
+        ? {
+            title: 'Nothing in this date range',
+            description: 'Try a wider range, or Any time.',
+          }
+        : selectedFolder
+          ? { title: 'This folder is empty', description: 'Move clips here to keep them together.' }
+          : contentFilter === 'images'
+            ? { title: 'No images yet', description: 'Copy an image and it will show up here.' }
+            : contentFilter === 'text'
+              ? {
+                  title: 'No text clips yet',
+                  description: 'Copy some text and it will show up here.',
+                }
+              : {
+                  title: 'Nothing here yet',
+                  description: 'Anything you copy will appear in Cubby.',
+                };
 
   return (
     <div className="flex h-screen select-none flex-col bg-background text-foreground">
@@ -425,7 +495,7 @@ export function HistoryWindow() {
         <select
           value={selectedFolder ?? ''}
           onChange={(event) => setSelectedFolder(event.target.value || null)}
-          className="h-9 max-w-[160px] shrink-0 rounded-md border border-white/[0.08] bg-transparent px-2 text-xs text-muted-foreground outline-none hover:text-foreground"
+          className={filterSelectClass}
           aria-label="Filter by folder"
         >
           <option value="">All folders</option>
@@ -435,7 +505,79 @@ export function HistoryWindow() {
             </option>
           ))}
         </select>
+
+        <select
+          value={sourceApp ?? ''}
+          onChange={(event) => setSourceApp(event.target.value || null)}
+          className={filterSelectClass}
+          aria-label="Filter by source app"
+        >
+          <option value="">All apps</option>
+          {/* A previously chosen app can vanish from the list once its last
+              clip is deleted. Keep it as an option so the control still shows
+              what is actually being filtered on. */}
+          {sourceApp && !sourceApps.some((app) => app.name === sourceApp) && (
+            <option value={sourceApp}>{sourceApp} (0)</option>
+          )}
+          {sourceApps.map((app) => (
+            <option key={app.name} value={app.name}>
+              {app.name} ({app.count})
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={datePreset}
+          onChange={(event) => setDatePreset(event.target.value as DatePreset)}
+          className={filterSelectClass}
+          aria-label="Filter by date"
+        >
+          {(Object.keys(DATE_PRESET_LABELS) as (keyof typeof DATE_PRESET_LABELS)[]).map((key) => (
+            <option key={key} value={key}>
+              {DATE_PRESET_LABELS[key]}
+            </option>
+          ))}
+          <option value="custom">Custom range…</option>
+        </select>
       </div>
+
+      {datePreset === 'custom' && (
+        <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-2 text-xs text-muted-foreground">
+          <label className="flex items-center gap-1.5">
+            From
+            <input
+              type="date"
+              value={customFrom}
+              max={customTo || undefined}
+              onChange={(event) => setCustomFrom(event.target.value)}
+              className="rounded-md border border-white/[0.08] bg-transparent px-2 py-1 text-foreground outline-none"
+            />
+          </label>
+          <label className="flex items-center gap-1.5">
+            To
+            <input
+              type="date"
+              value={customTo}
+              min={customFrom || undefined}
+              onChange={(event) => setCustomTo(event.target.value)}
+              className="rounded-md border border-white/[0.08] bg-transparent px-2 py-1 text-foreground outline-none"
+            />
+          </label>
+          {(customFrom || customTo) && (
+            <button
+              type="button"
+              onClick={() => {
+                setCustomFrom('');
+                setCustomTo('');
+              }}
+              className="rounded p-1 hover:bg-white/10 hover:text-foreground"
+              aria-label="Clear custom range"
+            >
+              <X size={13} />
+            </button>
+          )}
+        </div>
+      )}
 
       <main className="flex min-h-0 flex-1">
         <div className="min-h-0 w-[420px] shrink-0 border-r border-border">

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -1732,8 +1732,14 @@ async fn process_clipboard_snapshot(
     if retention_deleted > 0 {
         db.search_index.invalidate();
     } else {
-        db.search_index
-            .upsert(&emitted_id, clip_type, &clip_content, &clip_preview, None);
+        db.search_index.upsert(
+            &emitted_id,
+            clip_type,
+            &clip_content,
+            &clip_preview,
+            None,
+            source_app.as_deref(),
+        );
     }
 
     // Remember this capture so a short-lived auto-clear can forget it (SOU-316).

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -699,68 +699,197 @@ fn content_filter_clause(content_filter: Option<&str>) -> &'static str {
     }
 }
 
+/// The History window's date-range filter (SOU-585). `created_at` is stored in
+/// the clear, unlike the app name, so SQL can apply this one directly and
+/// paging stays authoritative in the database.
+///
+/// The range is half-open, `[from, to)`. The caller passes the instant after
+/// the last one it wants, so a "Today" preset is `[midnight, tomorrow)` and
+/// nothing has to reason about the last representable moment of a day.
+///
+/// Returns the SQL fragment; bind `from` then `to` (whichever are present)
+/// immediately after the folder id and before limit/offset.
+fn date_range_clause(from: Option<&str>, to: Option<&str>) -> String {
+    let mut clause = String::new();
+    if from.is_some() {
+        clause.push_str(" AND created_at >= ?");
+    }
+    if to.is_some() {
+        clause.push_str(" AND created_at < ?");
+    }
+    clause
+}
+
+/// Load a page of clips by id, still ordered the way the database ordered them.
+/// Used by every path that has to narrow ids outside SQL (search, source app)
+/// before fetching the encrypted payloads for just the rows being shown.
+async fn fetch_clips_by_id(pool: &SqlitePool, ids: &[String]) -> Result<Vec<Clip>, String> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let placeholders = std::iter::repeat_n("?", ids.len())
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = format!(
+        "SELECT * FROM clips WHERE is_deleted = 0 AND uuid IN ({placeholders}) \
+         ORDER BY is_pinned DESC, created_at DESC"
+    );
+    let mut query = sqlx::query_as::<_, Clip>(&sql);
+    for id in ids {
+        query = query.bind(id);
+    }
+    query.fetch_all(pool).await.map_err(|e| e.to_string())
+}
+
+/// Filters that SQL can apply itself, assembled into one WHERE body so every
+/// listing path restricts identically.
+fn clip_where_body(
+    folder_id: Option<i64>,
+    content_filter: Option<&str>,
+    from: Option<&str>,
+    to: Option<&str>,
+) -> String {
+    let mut sql = String::from("is_deleted = 0");
+    if folder_id.is_some() {
+        sql.push_str(" AND folder_id = ?");
+    }
+    sql.push_str(content_filter_clause(content_filter));
+    sql.push_str(&date_range_clause(from, to));
+    sql
+}
+
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn get_clips(
     filter_id: Option<String>,
     limit: i64,
     offset: i64,
     preview_only: Option<bool>,
     content_filter: Option<String>,
+    date_from: Option<String>,
+    date_to: Option<String>,
+    source_app: Option<String>,
     db: tauri::State<'_, Arc<Database>>,
+) -> Result<Vec<ClipboardItem>, String> {
+    get_clips_in_database(
+        filter_id,
+        limit,
+        offset,
+        preview_only,
+        content_filter,
+        date_from,
+        date_to,
+        source_app,
+        db.inner(),
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn get_clips_in_database(
+    filter_id: Option<String>,
+    limit: i64,
+    offset: i64,
+    preview_only: Option<bool>,
+    content_filter: Option<String>,
+    date_from: Option<String>,
+    date_to: Option<String>,
+    source_app: Option<String>,
+    db: &Database,
 ) -> Result<Vec<ClipboardItem>, String> {
     let pool = &db.pool;
     let preview_only = preview_only.unwrap_or(false);
     let started = Instant::now();
 
     log::info!(
-        "get_clips called with filter_id: {:?}, preview_only: {}, content_filter: {:?}",
+        "get_clips called with filter_id: {:?}, preview_only: {}, content_filter: {:?}, date: {:?}..{:?}, source_app: {:?}",
         filter_id,
         preview_only,
-        content_filter
+        content_filter,
+        date_from,
+        date_to,
+        source_app
     );
 
-    let type_clause = content_filter_clause(content_filter.as_deref());
-    let sql_started = Instant::now();
-    let mut clips: Vec<Clip> = match filter_id.as_deref() {
-        Some(id) => {
-            let folder_id_num = id.parse::<i64>().ok();
-            if let Some(numeric_id) = folder_id_num {
-                log::info!("Querying for folder_id: {}", numeric_id);
-                let sql = format!(
-                    "SELECT * FROM clips WHERE is_deleted = 0 AND folder_id = ?{type_clause} \
-                     ORDER BY is_pinned DESC, created_at DESC LIMIT ? OFFSET ?"
-                );
-                sqlx::query_as(&sql)
-                    .bind(numeric_id)
-                    .bind(limit)
-                    .bind(offset)
-                    .fetch_all(pool)
-                    .await
-                    .map_err(|e| e.to_string())?
-            } else {
+    let folder_id = match filter_id.as_deref() {
+        Some(id) => match id.parse::<i64>() {
+            Ok(id) => Some(id),
+            Err(_) => {
                 log::info!("Unknown folder_id, returning empty");
-                Vec::new()
+                return Ok(Vec::new());
             }
-        }
-        None => {
-            log::info!("Querying for items, offset: {}, limit: {}", offset, limit);
+        },
+        None => None,
+    };
+    let source_app = source_app.filter(|app| !app.trim().is_empty());
+    let where_body = clip_where_body(
+        folder_id,
+        content_filter.as_deref(),
+        date_from.as_deref(),
+        date_to.as_deref(),
+    );
+
+    let sql_started = Instant::now();
+    let mut clips: Vec<Clip> = if let Some(app) = source_app.as_deref() {
+        // The app name is encrypted with a random nonce, so SQL can neither
+        // match nor group on it. Take the ordered ids from the database, narrow
+        // them against the in-memory index, and page the result — the same
+        // shape search uses, so ordering and pinning stay authoritative in SQL
+        // and a filtered page can't hide matches on unfetched pages.
+        db.search_index.ensure_ready(pool, &db.crypto).await?;
+        let allowed = db.search_index.ids_for_source_app(app);
+        if allowed.is_empty() {
+            Vec::new()
+        } else {
             let sql = format!(
-                "SELECT * FROM clips WHERE is_deleted = 0{type_clause} \
-                 ORDER BY is_pinned DESC, created_at DESC LIMIT ? OFFSET ?"
+                "SELECT uuid FROM clips WHERE {where_body} ORDER BY is_pinned DESC, created_at DESC"
             );
-            sqlx::query_as(&sql)
-                .bind(limit)
-                .bind(offset)
-                .fetch_all(pool)
-                .await
-                .map_err(|e| e.to_string())?
+            let mut query = sqlx::query_scalar::<_, String>(&sql);
+            if let Some(id) = folder_id {
+                query = query.bind(id);
+            }
+            if let Some(from) = date_from.as_deref() {
+                query = query.bind(from.to_string());
+            }
+            if let Some(to) = date_to.as_deref() {
+                query = query.bind(to.to_string());
+            }
+            let ordered_ids = query.fetch_all(pool).await.map_err(|e| e.to_string())?;
+            let page: Vec<String> = ordered_ids
+                .into_iter()
+                .filter(|id| allowed.contains(id))
+                .skip(offset.max(0) as usize)
+                .take(limit.max(0) as usize)
+                .collect();
+            fetch_clips_by_id(pool, &page).await?
         }
+    } else {
+        let sql = format!(
+            "SELECT * FROM clips WHERE {where_body} \
+             ORDER BY is_pinned DESC, created_at DESC LIMIT ? OFFSET ?"
+        );
+        let mut query = sqlx::query_as::<_, Clip>(&sql);
+        if let Some(id) = folder_id {
+            query = query.bind(id);
+        }
+        if let Some(from) = date_from.as_deref() {
+            query = query.bind(from.to_string());
+        }
+        if let Some(to) = date_to.as_deref() {
+            query = query.bind(to.to_string());
+        }
+        query
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(pool)
+            .await
+            .map_err(|e| e.to_string())?
     };
     let sql_ms = sql_started.elapsed().as_millis();
 
     log::info!("DB: Found {} clips", clips.len());
     for clip in &mut clips {
-        decrypt_clip_fields(&db, clip)?;
+        decrypt_clip_fields(db, clip)?;
     }
 
     let image_rows = clips
@@ -1275,23 +1404,42 @@ pub async fn rename_folder(
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn search_clips(
     query: String,
     filter_id: Option<String>,
     limit: i64,
     offset: i64,
     content_filter: Option<String>,
+    date_from: Option<String>,
+    date_to: Option<String>,
+    source_app: Option<String>,
     db: tauri::State<'_, Arc<Database>>,
 ) -> Result<Vec<ClipboardItem>, String> {
-    search_clips_in_database(query, filter_id, limit, offset, content_filter, db.inner()).await
+    search_clips_in_database(
+        query,
+        filter_id,
+        limit,
+        offset,
+        content_filter,
+        date_from,
+        date_to,
+        source_app,
+        db.inner(),
+    )
+    .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn search_clips_in_database(
     query: String,
     filter_id: Option<String>,
     limit: i64,
     offset: i64,
     content_filter: Option<String>,
+    date_from: Option<String>,
+    date_to: Option<String>,
+    source_app: Option<String>,
     db: &Database,
 ) -> Result<Vec<ClipboardItem>, String> {
     let pool = &db.pool;
@@ -1310,37 +1458,46 @@ async fn search_clips_in_database(
     };
     let index_started = Instant::now();
     db.search_index.ensure_ready(pool, &db.crypto).await?;
-    let candidates = db.search_index.matches(&query);
+    let mut candidates = db.search_index.matches(&query);
+    // The source app is encrypted with a random nonce, so it narrows the
+    // candidate set here alongside the text match rather than in SQL. AND, not
+    // OR: every active filter has to hold.
+    if let Some(app) = source_app.as_deref().filter(|app| !app.trim().is_empty()) {
+        let allowed = db.search_index.ids_for_source_app(app);
+        candidates.retain(|id| allowed.contains(id));
+    }
     let index_ms = index_started.elapsed().as_millis();
     if candidates.is_empty() {
         return Ok(Vec::new());
     }
 
-    // Ordering, pinning, folder filtering, and pagination remain authoritative
-    // in SQLite. Only UUIDs are scanned here; encrypted payloads are fetched and
-    // decrypted for the final result page.
-    let type_clause = content_filter_clause(content_filter.as_deref());
+    // Ordering, pinning, folder filtering, date range, and pagination remain
+    // authoritative in SQLite. Only UUIDs are scanned here; encrypted payloads
+    // are fetched and decrypted for the final result page.
+    let where_body = clip_where_body(
+        folder_id,
+        content_filter.as_deref(),
+        date_from.as_deref(),
+        date_to.as_deref(),
+    );
     let sql_started = Instant::now();
-    let ordered_ids: Vec<String> = if let Some(folder_id) = folder_id {
-        let sql = format!(
-            "SELECT uuid FROM clips WHERE is_deleted = 0 AND folder_id = ?{type_clause} \
-             ORDER BY is_pinned DESC, created_at DESC"
-        );
-        sqlx::query_scalar(&sql)
-            .bind(folder_id)
-            .fetch_all(pool)
-            .await
-            .map_err(|error| error.to_string())?
-    } else {
-        let sql = format!(
-            "SELECT uuid FROM clips WHERE is_deleted = 0{type_clause} \
-             ORDER BY is_pinned DESC, created_at DESC"
-        );
-        sqlx::query_scalar(&sql)
-            .fetch_all(pool)
-            .await
-            .map_err(|error| error.to_string())?
-    };
+    let sql = format!(
+        "SELECT uuid FROM clips WHERE {where_body} ORDER BY is_pinned DESC, created_at DESC"
+    );
+    let mut ordered_query = sqlx::query_scalar::<_, String>(&sql);
+    if let Some(id) = folder_id {
+        ordered_query = ordered_query.bind(id);
+    }
+    if let Some(from) = date_from.as_deref() {
+        ordered_query = ordered_query.bind(from.to_string());
+    }
+    if let Some(to) = date_to.as_deref() {
+        ordered_query = ordered_query.bind(to.to_string());
+    }
+    let ordered_ids: Vec<String> = ordered_query
+        .fetch_all(pool)
+        .await
+        .map_err(|error| error.to_string())?;
     let selected_ids = ordered_ids
         .into_iter()
         .filter(|id| candidates.contains(id))
@@ -1351,21 +1508,7 @@ async fn search_clips_in_database(
         return Ok(Vec::new());
     }
 
-    let placeholders = std::iter::repeat_n("?", selected_ids.len())
-        .collect::<Vec<_>>()
-        .join(",");
-    let selected_sql = format!(
-        "SELECT * FROM clips WHERE is_deleted = 0 AND uuid IN ({placeholders}) \
-         ORDER BY is_pinned DESC, created_at DESC"
-    );
-    let mut selected_query = sqlx::query_as::<_, Clip>(&selected_sql);
-    for id in &selected_ids {
-        selected_query = selected_query.bind(id);
-    }
-    let mut clips = selected_query
-        .fetch_all(pool)
-        .await
-        .map_err(|error| error.to_string())?;
+    let mut clips = fetch_clips_by_id(pool, &selected_ids).await?;
     let sql_ms = sql_started.elapsed().as_millis();
     for clip in &mut clips {
         decrypt_clip_fields(db, clip)?;
@@ -2055,6 +2198,33 @@ async fn get_clip_details_in_database(db: &Database, id: &str) -> Result<ClipDet
     })
 }
 
+/// One entry in the History window's source-app filter.
+#[derive(serde::Serialize)]
+pub struct SourceAppCount {
+    pub name: String,
+    pub count: usize,
+}
+
+/// Every source app present in the history, with a live count, most used first.
+///
+/// Counts come from the in-memory index rather than a `GROUP BY`: `source_app`
+/// is encrypted with a random nonce, so two clips from the same app do not
+/// share a ciphertext and SQL cannot group them. The index already holds the
+/// decrypted view of every clip, so this needs no extra table and no second
+/// copy of the capture path's app-name resolution.
+#[tauri::command]
+pub async fn get_source_apps(
+    db: tauri::State<'_, Arc<Database>>,
+) -> Result<Vec<SourceAppCount>, String> {
+    db.search_index.ensure_ready(&db.pool, &db.crypto).await?;
+    Ok(db
+        .search_index
+        .source_app_counts()
+        .into_iter()
+        .map(|(name, count)| SourceAppCount { name, count })
+        .collect())
+}
+
 /// Put a text selection made on an image preview onto the clipboard. Uses the
 /// same ignore-hash discipline as the other copy paths so Cubby's own capture
 /// loop doesn't treat the write as a fresh copy and duplicate it.
@@ -2183,9 +2353,10 @@ mod tests {
     use super::{
         build_ocr_highlights, build_ocr_match, clear_clips_in_pool, clipboard_contents_for_restore,
         directory_size_bytes, enforce_retention_in_pool, get_clip_details_in_database,
-        load_recognized_text, migrate_clip_format_model, migrate_encrypted_storage,
-        ocr_text_layout, remove_clip_image_files, restore_hash_material, search_clips_in_database,
-        toggle_clip_pin_in_pool, ClipboardContent, OCR_SNIPPET_CHAR_LIMIT,
+        get_clips_in_database, load_recognized_text, migrate_clip_format_model,
+        migrate_encrypted_storage, ocr_text_layout, remove_clip_image_files, restore_hash_material,
+        search_clips_in_database, toggle_clip_pin_in_pool, ClipboardContent,
+        OCR_SNIPPET_CHAR_LIMIT,
     };
     use crate::clipboard::CapturedFormat;
     use crate::database::Database;
@@ -2222,6 +2393,29 @@ mod tests {
         folder_id: Option<i64>,
         pinned: bool,
         created_at: &'a str,
+        source_app: Option<&'a str>,
+    }
+
+    impl<'a> SearchFixture<'a> {
+        /// A plain unpinned text clip; tests override only what they exercise.
+        fn text(id: &'a str, content: &'a str, created_at: &'a str) -> Self {
+            Self {
+                id,
+                clip_type: "text",
+                content,
+                preview: content,
+                ocr: None,
+                folder_id: None,
+                pinned: false,
+                created_at,
+                source_app: None,
+            }
+        }
+
+        fn with_app(mut self, app: &'a str) -> Self {
+            self.source_app = Some(app);
+            self
+        }
     }
 
     async fn insert_search_clip(database: &Database, fixture: SearchFixture<'_>) {
@@ -2230,12 +2424,16 @@ mod tests {
         let encrypted_ocr = fixture
             .ocr
             .map(|text| database.crypto.encrypt_text(text).unwrap());
+        let encrypted_source_app = database
+            .crypto
+            .encrypt_optional_text(fixture.source_app)
+            .unwrap();
         sqlx::query(
             r#"
             INSERT INTO clips (
                 uuid, clip_type, content, text_preview, content_hash,
-                folder_id, is_pinned, created_at, ocr_text
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                folder_id, is_pinned, created_at, ocr_text, source_app
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
         )
         .bind(fixture.id)
@@ -2247,9 +2445,198 @@ mod tests {
         .bind(fixture.pinned)
         .bind(fixture.created_at)
         .bind(encrypted_ocr)
+        .bind(encrypted_source_app)
         .execute(&database.pool)
         .await
         .unwrap();
+    }
+
+    /// Three clips over three days from two apps, newest last.
+    async fn seed_filter_clips(database: &Database) {
+        insert_search_clip(
+            database,
+            SearchFixture::text("day-one", "alpha one", "2026-03-01 12:00:00").with_app("code.exe"),
+        )
+        .await;
+        insert_search_clip(
+            database,
+            SearchFixture::text("day-two", "alpha two", "2026-03-02 12:00:00")
+                .with_app("chrome.exe"),
+        )
+        .await;
+        insert_search_clip(
+            database,
+            SearchFixture::text("day-three", "alpha three", "2026-03-03 12:00:00")
+                .with_app("code.exe"),
+        )
+        .await;
+    }
+
+    async fn listed_ids(
+        database: &Database,
+        date_from: Option<&str>,
+        date_to: Option<&str>,
+        source_app: Option<&str>,
+    ) -> Vec<String> {
+        get_clips_in_database(
+            None,
+            50,
+            0,
+            Some(true),
+            None,
+            date_from.map(str::to_string),
+            date_to.map(str::to_string),
+            source_app.map(str::to_string),
+            database,
+        )
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|clip| clip.id)
+        .collect()
+    }
+
+    #[tokio::test]
+    async fn source_app_counts_group_encrypted_app_names() {
+        let database = test_database().await;
+        seed_filter_clips(&database).await;
+        database
+            .search_index
+            .ensure_ready(&database.pool, &database.crypto)
+            .await
+            .unwrap();
+
+        // Each row's app name is encrypted under a fresh nonce, so identical
+        // apps have different ciphertexts and SQL could not group them. The
+        // counts still have to come out right, most used first.
+        assert_eq!(
+            database.search_index.source_app_counts(),
+            vec![("code.exe".to_string(), 2), ("chrome.exe".to_string(), 1)]
+        );
+    }
+
+    #[tokio::test]
+    async fn source_app_filter_narrows_the_list_and_pages_correctly() {
+        let database = test_database().await;
+        seed_filter_clips(&database).await;
+
+        assert_eq!(
+            listed_ids(&database, None, None, Some("code.exe")).await,
+            vec!["day-three", "day-one"]
+        );
+        // Matching is case-insensitive: the stored name is whatever Windows
+        // reported at capture time.
+        assert_eq!(
+            listed_ids(&database, None, None, Some("CODE.EXE")).await,
+            vec!["day-three", "day-one"]
+        );
+        assert!(listed_ids(&database, None, None, Some("nothing.exe"))
+            .await
+            .is_empty());
+
+        // Paging runs over the filtered set, not the raw table: page two of a
+        // one-per-page code.exe listing is the *second code.exe clip*, not
+        // whatever row happens to sit second overall.
+        let page_two = get_clips_in_database(
+            None,
+            1,
+            1,
+            Some(true),
+            None,
+            None,
+            None,
+            Some("code.exe".into()),
+            &database,
+        )
+        .await
+        .unwrap();
+        assert_eq!(page_two.len(), 1);
+        assert_eq!(page_two[0].id, "day-one");
+    }
+
+    #[tokio::test]
+    async fn date_range_filter_is_half_open_and_combines_with_source_app() {
+        let database = test_database().await;
+        seed_filter_clips(&database).await;
+
+        // [from, to): the second day is included, the third is not.
+        assert_eq!(
+            listed_ids(
+                &database,
+                Some("2026-03-02 00:00:00"),
+                Some("2026-03-03 00:00:00"),
+                None
+            )
+            .await,
+            vec!["day-two"]
+        );
+        assert_eq!(
+            listed_ids(&database, Some("2026-03-02 00:00:00"), None, None).await,
+            vec!["day-three", "day-two"]
+        );
+        assert_eq!(
+            listed_ids(&database, None, Some("2026-03-02 00:00:00"), None).await,
+            vec!["day-one"]
+        );
+
+        // Filters combine with AND: day-two is in range but is not code.exe.
+        assert!(listed_ids(
+            &database,
+            Some("2026-03-02 00:00:00"),
+            Some("2026-03-03 00:00:00"),
+            Some("code.exe")
+        )
+        .await
+        .is_empty());
+        assert_eq!(
+            listed_ids(
+                &database,
+                Some("2026-03-03 00:00:00"),
+                None,
+                Some("code.exe")
+            )
+            .await,
+            vec!["day-three"]
+        );
+    }
+
+    #[tokio::test]
+    async fn search_combines_with_date_and_source_app_filters() {
+        let database = test_database().await;
+        seed_filter_clips(&database).await;
+
+        let all = search_clips_in_database(
+            "alpha".into(),
+            None,
+            50,
+            0,
+            None,
+            None,
+            None,
+            None,
+            &database,
+        )
+        .await
+        .unwrap();
+        assert_eq!(all.len(), 3);
+
+        let narrowed = search_clips_in_database(
+            "alpha".into(),
+            None,
+            50,
+            0,
+            None,
+            Some("2026-03-02 00:00:00".into()),
+            None,
+            Some("code.exe".into()),
+            &database,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            narrowed.into_iter().map(|clip| clip.id).collect::<Vec<_>>(),
+            vec!["day-three"]
+        );
     }
 
     #[tokio::test]
@@ -2271,6 +2658,7 @@ mod tests {
                 folder_id: Some(folder_id),
                 pinned: false,
                 created_at: "2026-01-01 00:00:00",
+                source_app: Some("chrome.exe"),
             },
         )
         .await;
@@ -2285,6 +2673,7 @@ mod tests {
                 folder_id: None,
                 pinned: true,
                 created_at: "2026-01-02 00:00:00",
+                source_app: Some("SnippingTool.exe"),
             },
         )
         .await;
@@ -2299,13 +2688,24 @@ mod tests {
                 folder_id: None,
                 pinned: false,
                 created_at: "2026-01-03 00:00:00",
+                source_app: Some("chrome.exe"),
             },
         )
         .await;
 
-        let first = search_clips_in_database("ALPHA".into(), None, 1, 0, None, &database)
-            .await
-            .unwrap();
+        let first = search_clips_in_database(
+            "ALPHA".into(),
+            None,
+            1,
+            0,
+            None,
+            None,
+            None,
+            None,
+            &database,
+        )
+        .await
+        .unwrap();
         assert_eq!(first[0].id, "ocr-result");
         assert!(first[0].ocr_match.is_some());
         assert!(first[0].has_ocr_text);
@@ -2314,9 +2714,19 @@ mod tests {
             "Alpha receipt 8372"
         );
 
-        let second = search_clips_in_database("alpha".into(), None, 1, 1, None, &database)
-            .await
-            .unwrap();
+        let second = search_clips_in_database(
+            "alpha".into(),
+            None,
+            1,
+            1,
+            None,
+            None,
+            None,
+            None,
+            &database,
+        )
+        .await
+        .unwrap();
         assert_eq!(second[0].id, "text-result");
 
         let folder = search_clips_in_database(
@@ -2324,6 +2734,9 @@ mod tests {
             Some(folder_id.to_string()),
             10,
             0,
+            None,
+            None,
+            None,
             None,
             &database,
         )
@@ -2339,6 +2752,9 @@ mod tests {
             10,
             0,
             Some("images".into()),
+            None,
+            None,
+            None,
             &database,
         )
         .await
@@ -2346,10 +2762,19 @@ mod tests {
         assert_eq!(images_only.len(), 1);
         assert_eq!(images_only[0].id, "ocr-result");
 
-        let text_only =
-            search_clips_in_database("alpha".into(), None, 10, 0, Some("text".into()), &database)
-                .await
-                .unwrap();
+        let text_only = search_clips_in_database(
+            "alpha".into(),
+            None,
+            10,
+            0,
+            Some("text".into()),
+            None,
+            None,
+            None,
+            &database,
+        )
+        .await
+        .unwrap();
         assert_eq!(text_only.len(), 1);
         assert_eq!(text_only[0].id, "text-result");
 
@@ -3080,6 +3505,7 @@ mod tests {
                 content: "the whole body, not the row preview",
                 preview: "the whole body...",
                 ocr: None,
+                source_app: None,
                 folder_id: None,
                 pinned: false,
                 created_at: "2026-03-01 00:00:00",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -490,6 +490,7 @@ pub fn run_app() {
             commands::get_clip_details,
             commands::copy_selected_text,
             commands::open_image_window,
+            commands::get_source_apps,
             ocr_queue::get_ocr_queue_status,
             ocr_queue::set_ocr_queue_paused,
             ocr_queue::retry_failed_ocr,

--- a/src-tauri/src/search_index.rs
+++ b/src-tauri/src/search_index.rs
@@ -6,21 +6,42 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-type IndexedClipRow = (String, String, Vec<u8>, String, Option<String>);
+type IndexedClipRow = (
+    String,
+    String,
+    Vec<u8>,
+    String,
+    Option<String>,
+    Option<String>,
+);
 
 #[derive(Clone, Debug, Default)]
 struct SearchDocument {
     content: String,
     preview: String,
     ocr: String,
+    /// Source app exactly as captured, for the History window's per-app filter
+    /// and counts. `source_app` is encrypted with a random nonce, so SQL can
+    /// neither group nor filter on it; this index already holds the decrypted
+    /// view of every clip, so the answer lives here rather than in a second
+    /// table or a parallel index with its own lifecycle to keep in sync.
+    ///
+    /// Deliberately not part of `contains`/`trigrams`: searching "chrome"
+    /// should find clips whose *text* says chrome, not every clip copied from
+    /// the browser.
+    source_app: Option<String>,
 }
 
 impl SearchDocument {
-    fn new(content: &str, preview: &str, ocr: Option<&str>) -> Self {
+    fn new(content: &str, preview: &str, ocr: Option<&str>, source_app: Option<&str>) -> Self {
         Self {
             content: normalize(content),
             preview: normalize(preview),
             ocr: normalize(ocr.unwrap_or_default()),
+            source_app: source_app
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string),
         }
     }
 
@@ -133,7 +154,8 @@ impl SearchIndex {
                        clip_type,
                        CASE WHEN clip_type = 'image' THEN x'' ELSE content END,
                        text_preview,
-                       ocr_text
+                       ocr_text,
+                       source_app
                 FROM clips
                 WHERE is_deleted = 0
                 "#,
@@ -142,7 +164,15 @@ impl SearchIndex {
             .await
             .map_err(|error| error.to_string())?;
             let mut next = IndexState::default();
-            for (id, clip_type, encrypted_content, encrypted_preview, encrypted_ocr) in clips {
+            for (
+                id,
+                clip_type,
+                encrypted_content,
+                encrypted_preview,
+                encrypted_ocr,
+                encrypted_source_app,
+            ) in clips
+            {
                 let content = if clip_type == "image" {
                     Vec::new()
                 } else {
@@ -157,6 +187,16 @@ impl SearchIndex {
                         })
                         .ok()
                 });
+                // Like OCR text, the source app is auxiliary: an unreadable one
+                // must not stop the clip being indexed and searchable.
+                let source_app = encrypted_source_app.as_deref().and_then(|value| {
+                    crypto
+                        .decrypt_text(value)
+                        .map_err(|error| {
+                            log::warn!("SEARCH: Ignoring unreadable source app: {error}")
+                        })
+                        .ok()
+                });
                 let searchable_content = if clip_type != "image" {
                     String::from_utf8_lossy(&content).into_owned()
                 } else {
@@ -164,7 +204,12 @@ impl SearchIndex {
                 };
                 next.insert(
                     id,
-                    SearchDocument::new(&searchable_content, &preview, ocr.as_deref()),
+                    SearchDocument::new(
+                        &searchable_content,
+                        &preview,
+                        ocr.as_deref(),
+                        source_app.as_deref(),
+                    ),
                 );
             }
 
@@ -187,6 +232,52 @@ impl SearchIndex {
             .map_or_else(HashSet::new, |state| state.matches(query))
     }
 
+    /// Every source app present in the history with its clip count, most used
+    /// first, then alphabetically so the list is stable between refreshes.
+    pub fn source_app_counts(&self) -> Vec<(String, usize)> {
+        let state = self.state.read();
+        let Some(state) = state.as_ref() else {
+            return Vec::new();
+        };
+        let mut counts: HashMap<&str, usize> = HashMap::new();
+        for document in state.documents.values() {
+            if let Some(app) = document.source_app.as_deref() {
+                *counts.entry(app).or_default() += 1;
+            }
+        }
+        let mut counts: Vec<(String, usize)> = counts
+            .into_iter()
+            .map(|(app, count)| (app.to_string(), count))
+            .collect();
+        counts.sort_by(|(left_app, left_count), (right_app, right_count)| {
+            right_count
+                .cmp(left_count)
+                .then_with(|| left_app.to_lowercase().cmp(&right_app.to_lowercase()))
+        });
+        counts
+    }
+
+    /// Ids of every clip captured from `app`, compared case-insensitively so a
+    /// filter picked from the list matches regardless of how Windows reported
+    /// the executable name at capture time.
+    pub fn ids_for_source_app(&self, app: &str) -> HashSet<String> {
+        let wanted = app.trim().to_lowercase();
+        let state = self.state.read();
+        state.as_ref().map_or_else(HashSet::new, |state| {
+            state
+                .documents
+                .iter()
+                .filter(|(_, document)| {
+                    document
+                        .source_app
+                        .as_deref()
+                        .is_some_and(|value| value.to_lowercase() == wanted)
+                })
+                .map(|(id, _)| id.to_string())
+                .collect()
+        })
+    }
+
     pub fn upsert(
         &self,
         id: &str,
@@ -194,22 +285,22 @@ impl SearchIndex {
         content: &[u8],
         preview: &str,
         ocr: Option<&str>,
+        source_app: Option<&str>,
     ) {
         self.generation.fetch_add(1, Ordering::AcqRel);
         if let Some(state) = self.state.write().as_mut() {
-            let preserved_ocr = state
-                .documents
-                .get(id)
-                .map(|document| document.ocr.clone())
-                .unwrap_or_default();
+            let existing = state.documents.get(id).cloned().unwrap_or_default();
             let searchable_content = if clip_type != "image" {
                 String::from_utf8_lossy(content).into_owned()
             } else {
                 String::new()
             };
-            let mut document = SearchDocument::new(&searchable_content, preview, ocr);
+            let mut document = SearchDocument::new(&searchable_content, preview, ocr, source_app);
             if ocr.is_none() {
-                document.ocr = preserved_ocr;
+                document.ocr = existing.ocr;
+            }
+            if source_app.is_none() {
+                document.source_app = existing.source_app;
             }
             state.insert(id.to_string(), document);
         }
@@ -259,11 +350,11 @@ mod tests {
         let mut state = IndexState::default();
         state.insert(
             "one".to_string(),
-            SearchDocument::new("Release confirmation 4J7K", "", None),
+            SearchDocument::new("Release confirmation 4J7K", "", None, None),
         );
         state.insert(
             "two".to_string(),
-            SearchDocument::new("unrelated", "", None),
+            SearchDocument::new("unrelated", "", None, None),
         );
 
         assert_eq!(
@@ -276,12 +367,12 @@ mod tests {
     fn supports_short_queries_and_ocr_updates() {
         let index = SearchIndex::default();
         *index.state.write() = Some(IndexState::default());
-        index.upsert("image", "image", &[], "Screenshot", None);
+        index.upsert("image", "image", &[], "Screenshot", None, None);
         assert!(index.matches("sc").contains("image"));
 
         index.update_ocr("image", "The clipboard service is unavailable");
         assert!(index.matches("service is unavailable").contains("image"));
-        index.upsert("image", "image", &[], "Screenshot", None);
+        index.upsert("image", "image", &[], "Screenshot", None, None);
         assert!(index.matches("service is unavailable").contains("image"));
         index.remove("image");
         assert!(index.matches("service").is_empty());


### PR DESCRIPTION
Closes SBS-584 and SBS-585. Part of the OmniClip epic (SBS-581).

> **Stacked on #154** (SBS-582). Base is that branch, so the diff here is just the filters. Retarget to `main` once #154 merges.

Both filters combine with search, folder, and the content-type tabs using **AND**, and both keep ordering and paging authoritative in SQL.

## Source app (SBS-584)

A dropdown listing every app in the history with a live count — `matteshot (8)`.

**The issue's premise was wrong, and it changed the design.** It said to compute counts "from the existing indexed `source_app` column". That column is encrypted with a random nonce, so two clips from the same app share no ciphertext — SQL can neither `GROUP BY` nor `WHERE` on it — and there is no SQL index on it either. So:

- Counts and matching come from the **in-memory index** that already holds the decrypted view of every clip. This honors the constraint that actually mattered: no new table, no second copy of the capture path's app-name resolution.
- Rather than a parallel index with its own lifecycle to keep in sync, the existing `SearchIndex` now carries `source_app` alongside the text it already holds, so one set of `upsert`/`remove`/`invalidate` hooks stays correct. It is deliberately **excluded from the trigram fields**: searching "chrome" should find clips whose *text* says chrome, not everything copied from the browser.
- With the filter active, listing switches to the same **ordered-ids → narrow → page** shape search already uses, so a filtered page can't hide matches living on unfetched pages.
- Matching is case-insensitive, since the stored name is whatever Windows reported at capture time.

## Date range (SBS-585)

Presets (Today, Yesterday, Last 7 / 30 days) plus a custom from/to range.

- `created_at` **is** stored in the clear, as fixed-width `YYYY-MM-DD HH:MM:SS` UTC by every write path (`CURRENT_TIMESTAMP` and the Ditto importer agree), so this one is a plain SQL comparison that uses `idx_clips_created`.
- Ranges are **half-open, `[from, to)`** — nothing has to reason about the last representable instant of a day, and a clip copied at 23:59:59 still counts as today.
- Boundaries are the user's **local** midnight converted to UTC; someone asking for "yesterday" means their yesterday.
- "Last 7 days" spans 7 whole days ending today, not `now - 168h`, which would quietly drop this morning's clips as the day wore on.

## Refactor

Extracts `get_clips_in_database`, mirroring the existing `search_clips_in_database`, so the listing path is testable without constructing a Tauri `State`.

## Testing

- 125 Rust tests, 56 frontend tests, `tsc`, `vite build`, `cargo clippy` — all clean.
- New coverage: grouping encrypted app names, case-insensitive matching, **paging over the filtered set** (page two of a one-per-page `code.exe` listing is the second `code.exe` clip, not whatever row sits second overall), half-open date bounds, AND-combination, and the preset/custom range maths including month boundaries.
- Driven in a real dev build: picked `matteshot (8)` and watched the list narrow to matteshot clips; added **Today** on top and got the correct empty state (those clips are 6 days old); cleared the app filter and **Today** alone returned exactly the two clips from the last hour.