### PR TITLE
Per-clip visibility toggle for sensitive content

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { useTheme } from './hooks/useTheme';
 import { useLanguage } from './hooks/useLanguage';
 import { useSystemAccent } from './hooks/useSystemAccent';
 import { useUpdater } from './hooks/useUpdater';
+import { useRevealedClips } from './hooks/useRevealedClips';
 import { useTranslation } from 'react-i18next';
 import { Toaster, toast } from 'sonner';
 import { generateDemoClips } from './debug/demoData';
@@ -100,6 +101,8 @@ function App() {
   const windowShape = hasRoundedCorners
     ? 'rounded-[10px] shadow-[0_24px_80px_rgba(0,0,0,0.48),0_6px_24px_rgba(0,0,0,0.32)]'
     : 'rounded-none shadow-none';
+
+  const { revealed, toggleReveal, clearRevealed } = useRevealedClips();
 
   const appWindow = getCurrentWindow();
   const selectedFolderRef = useRef(selectedFolder);
@@ -228,6 +231,9 @@ function App() {
       setSearchQuery('');
       setContentFilter('all');
       setSelectedFolder(null);
+      // Reveals last only as long as the flyout is open, so a hidden clip is
+      // hidden again the next time it appears.
+      clearRevealed();
       // Reset selection and scroll the list back to the top, so reopening
       // always shows your most-recent copy instead of wherever you'd scrolled.
       setSelectedClipId(null);
@@ -241,7 +247,7 @@ function App() {
     return () => {
       unlisten.then((dispose) => dispose()).catch(() => undefined);
     };
-  }, [appWindow, showPendingHotkeyNotice]);
+  }, [appWindow, clearRevealed, showPendingHotkeyNotice]);
 
   const openSettings = useCallback(async () => {
     // Check if settings window already exists
@@ -623,6 +629,37 @@ function App() {
     [t]
   );
 
+  // Persist the hidden flag. Distinct from revealing for the session: this is
+  // the state that survives a restart.
+  const handleToggleHidden = useCallback(
+    async (clipId: string) => {
+      try {
+        const hidden = await invoke<boolean>('toggle_clip_hidden', { id: clipId });
+        clearRevealed();
+        if (hidden) {
+          // Drop the payload from React state immediately. Clearing `content`
+          // but leaving `preview` would keep the secret text in the renderer
+          // until the reload landed, which is the whole thing being prevented.
+          setClips((current) =>
+            current.map((clip) =>
+              clip.id === clipId ? { ...clip, is_hidden: true, content: '', preview: '' } : clip
+            )
+          );
+        }
+        // Unhiding has nothing to restore optimistically — the row's payload was
+        // withheld by the backend, so only a reload can put it back. Marking it
+        // visible early would just render an empty row, and leave it empty for
+        // good if the reload failed.
+        refreshCurrentFolder();
+        toast.success(hidden ? 'Clip hidden' : 'Clip no longer hidden');
+      } catch (error) {
+        console.error('Failed to change clip visibility:', error);
+        toast.error('Failed to change clip visibility');
+      }
+    },
+    [clearRevealed, refreshCurrentFolder]
+  );
+
   const handleTogglePin = useCallback(
     async (clipId: string | null) => {
       if (!clipId) return;
@@ -962,6 +999,10 @@ function App() {
                             onClick: () => handleTogglePin(contextMenu.itemId),
                           },
                           {
+                            label: clip?.is_hidden ? 'Unhide content' : 'Hide content',
+                            onClick: () => handleToggleHidden(contextMenu.itemId),
+                          },
+                          {
                             label: t('contextMenu.paste'),
                             onClick: () => handlePaste(contextMenu.itemId),
                           },
@@ -1115,6 +1156,11 @@ function App() {
               onLoadMore={loadMore}
               onRetry={refreshCurrentFolder}
               onCardContextMenu={(e, clipId) => handleContextMenu(e, 'card', clipId)}
+              revealedClips={revealed}
+              onToggleReveal={(clipId) => {
+                const clip = clips.find((item) => item.id === clipId);
+                if (clip) void toggleReveal(clip);
+              }}
             />
 
             {/* Add/Rename Folder Modal Overlay */}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -102,7 +102,7 @@ function App() {
     ? 'rounded-[10px] shadow-[0_24px_80px_rgba(0,0,0,0.48),0_6px_24px_rgba(0,0,0,0.32)]'
     : 'rounded-none shadow-none';
 
-  const { revealed, toggleReveal, clearRevealed } = useRevealedClips();
+  const { revealed, toggleReveal, forgetRevealed, clearRevealed } = useRevealedClips();
 
   const appWindow = getCurrentWindow();
   const selectedFolderRef = useRef(selectedFolder);
@@ -378,7 +378,7 @@ function App() {
         // A newer load supersedes this one (e.g. the reset when the flyout
         // closes starts an unfiltered load while a filtered one is in flight).
         // Discard the stale result so it can't overwrite the current view.
-        if (perfId !== loadPerfIdRef.current) return;
+        if (perfId !== loadPerfIdRef.current) return true;
 
         if (append) {
           setClips((prev) => {
@@ -413,11 +413,15 @@ function App() {
             });
           });
         }
+        return true;
       } catch (error) {
-        if (perfId !== loadPerfIdRef.current) return;
+        // Superseded: a newer load owns the view, so this one failing is not a
+        // failure to refresh — report success and let the newer load speak.
+        if (perfId !== loadPerfIdRef.current) return true;
         console.error('Failed to load clips:', error);
         setLoadError(true);
         setHasMore(false);
+        return false;
       } finally {
         if (perfId === loadPerfIdRef.current) setIsLoading(false);
       }
@@ -439,9 +443,10 @@ function App() {
     }
   }, []);
 
-  const refreshCurrentFolder = useCallback(() => {
-    loadClips(selectedFolderRef.current, false, searchQuery, contentFilter);
-  }, [loadClips, searchQuery, contentFilter]);
+  const refreshCurrentFolder = useCallback(
+    () => loadClips(selectedFolderRef.current, false, searchQuery, contentFilter),
+    [loadClips, searchQuery, contentFilter]
+  );
 
   const handleSearch = useCallback((query: string) => {
     setSearchQuery(query);
@@ -635,7 +640,7 @@ function App() {
     async (clipId: string) => {
       try {
         const hidden = await invoke<boolean>('toggle_clip_hidden', { id: clipId });
-        clearRevealed();
+        forgetRevealed(clipId);
         if (hidden) {
           // Drop the payload from React state immediately. Clearing `content`
           // but leaving `preview` would keep the secret text in the renderer
@@ -650,14 +655,22 @@ function App() {
         // withheld by the backend, so only a reload can put it back. Marking it
         // visible early would just render an empty row, and leave it empty for
         // good if the reload failed.
-        refreshCurrentFolder();
+        // Awaited, and the result checked: unhiding only puts the payload back
+        // when the reload lands, so reporting success before then can leave a
+        // row blank under a toast saying it is visible again. loadClips reports
+        // failure rather than throwing, so the toast has to read its result.
+        const reloaded = await refreshCurrentFolder();
+        if (!reloaded) {
+          toast.error('Visibility changed, but the list could not be reloaded');
+          return;
+        }
         toast.success(hidden ? 'Clip hidden' : 'Clip no longer hidden');
       } catch (error) {
         console.error('Failed to change clip visibility:', error);
         toast.error('Failed to change clip visibility');
       }
     },
-    [clearRevealed, refreshCurrentFolder]
+    [forgetRevealed, refreshCurrentFolder]
   );
 
   const handleTogglePin = useCallback(

--- a/frontend/src/components/ClipCard.tsx
+++ b/frontend/src/components/ClipCard.tsx
@@ -72,8 +72,13 @@ export const ClipCard = memo(function ClipCard({
   onToggleSelect,
 }: ClipCardProps) {
   // A hidden row arrives carrying no content. Once revealed for the session the
-  // real payload is fetched separately, so render that in its place.
-  const clip = revealed ?? row;
+  // real payload is fetched separately, so render that in its place — but only
+  // the payload. The revealed copy is a snapshot taken when the fetch returned,
+  // so taking metadata from it too would freeze the pin state and the timestamp
+  // at that moment until the reveal was dropped.
+  const clip = revealed
+    ? { ...row, content: revealed.content, preview: revealed.preview }
+    : row;
   const isHidden = (row.is_hidden ?? false) && !revealed;
 
   const imageSrc = useMemo(

--- a/frontend/src/components/ClipCard.tsx
+++ b/frontend/src/components/ClipCard.tsx
@@ -76,9 +76,7 @@ export const ClipCard = memo(function ClipCard({
   // the payload. The revealed copy is a snapshot taken when the fetch returned,
   // so taking metadata from it too would freeze the pin state and the timestamp
   // at that moment until the reveal was dropped.
-  const clip = revealed
-    ? { ...row, content: revealed.content, preview: revealed.preview }
-    : row;
+  const clip = revealed ? { ...row, content: revealed.content, preview: revealed.preview } : row;
   const isHidden = (row.is_hidden ?? false) && !revealed;
 
   const imageSrc = useMemo(

--- a/frontend/src/components/ClipCard.tsx
+++ b/frontend/src/components/ClipCard.tsx
@@ -1,7 +1,16 @@
 import { ClipboardItem } from '../types';
 import { clsx } from 'clsx';
 import { memo, useMemo } from 'react';
-import { Clock, Copy, File, Image as ImageIcon, MoreHorizontal, Pin } from 'lucide-react';
+import {
+  Clock,
+  Copy,
+  Eye,
+  EyeOff,
+  File,
+  Image as ImageIcon,
+  MoreHorizontal,
+  Pin,
+} from 'lucide-react';
 import { formatDistanceToNowStrict } from 'date-fns';
 import { PREVIEW_CHAR_LIMIT } from '../constants';
 import { useTimeTick } from '../hooks/useTimeTick';
@@ -27,6 +36,11 @@ interface ClipCardProps {
   onCopy: () => void;
   onTogglePin: () => void;
   onContextMenu?: (e: React.MouseEvent) => void;
+  /** Content revealed for this session despite the persisted hidden flag.
+   *  Undefined while hidden and not revealed. */
+  revealed?: ClipboardItem;
+  /** Reveal or re-hide for this session. Does not change the persisted flag. */
+  onToggleReveal?: () => void;
   /** 1-based position of this option within the full history. */
   posInSet: number;
   /** Total options in the history, or -1 when more pages remain unloaded. */
@@ -41,7 +55,9 @@ interface ClipCardProps {
 }
 
 export const ClipCard = memo(function ClipCard({
-  clip,
+  clip: row,
+  revealed,
+  onToggleReveal,
   density,
   isSelected,
   onHover,
@@ -55,6 +71,11 @@ export const ClipCard = memo(function ClipCard({
   isChecked = false,
   onToggleSelect,
 }: ClipCardProps) {
+  // A hidden row arrives carrying no content. Once revealed for the session the
+  // real payload is fetched separately, so render that in its place.
+  const clip = revealed ?? row;
+  const isHidden = (row.is_hidden ?? false) && !revealed;
+
   const imageSrc = useMemo(
     () => (clip.clip_type === 'image' ? imageSrcFromContent(clip.content) : null),
     [clip.clip_type, clip.content]
@@ -175,7 +196,30 @@ export const ClipCard = memo(function ClipCard({
       </div>
 
       <div className="min-w-0 flex-1">
-        {clip.clip_type === 'image' ? (
+        {isHidden ? (
+          <>
+            <p className="flex items-center gap-1.5 text-[13px] italic text-muted-foreground">
+              <EyeOff size={13} className="shrink-0" />
+              Hidden
+            </p>
+            <div className="mt-1.5 flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
+              {clip.is_pinned && (
+                <>
+                  <Pin size={10} className="shrink-0 fill-current text-primary" />
+                  <span className="shrink-0 text-foreground/65">Pinned</span>
+                  <span className="shrink-0 text-muted-foreground/35">•</span>
+                </>
+              )}
+              <span className="truncate">{label}</span>
+              {age && (
+                <>
+                  <span className="shrink-0 text-muted-foreground/35">•</span>
+                  <span className="shrink-0">{age}</span>
+                </>
+              )}
+            </div>
+          </>
+        ) : clip.clip_type === 'image' ? (
           <div className="flex min-w-0 items-center gap-3">
             <div
               className={clsx(
@@ -318,6 +362,21 @@ export const ClipCard = memo(function ClipCard({
         >
           <Pin size={13} className={clsx(clip.is_pinned && 'fill-current')} />
         </button>
+        {row.is_hidden && onToggleReveal && (
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleReveal();
+            }}
+            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-white/10 hover:text-foreground"
+            title={revealed ? 'Hide again' : 'Reveal for this session'}
+            aria-label={revealed ? 'Hide again' : 'Reveal for this session'}
+            aria-pressed={Boolean(revealed)}
+          >
+            {revealed ? <EyeOff size={13} /> : <Eye size={13} />}
+          </button>
+        )}
         <button
           type="button"
           onClick={(event) => {

--- a/frontend/src/components/ClipList.tsx
+++ b/frontend/src/components/ClipList.tsx
@@ -21,6 +21,10 @@ interface ClipListProps {
   onLoadMore: () => void;
   onRetry: () => void;
   onCardContextMenu?: (e: React.MouseEvent, clipId: string) => void;
+  /** Hidden clips revealed for this session, by id. */
+  revealedClips?: ReadonlyMap<string, ClipboardItem>;
+  /** Reveal or re-hide a hidden clip for this session. */
+  onToggleReveal?: (clipId: string) => void;
   /** Whether moving the pointer over a card selects it. True in the flyout,
    *  where selection is only ever "what Enter will paste". The History window
    *  turns it off: selection there drives a preview pane, and sweeping the
@@ -51,6 +55,8 @@ export function ClipList({
   onLoadMore,
   onRetry,
   onCardContextMenu,
+  revealedClips,
+  onToggleReveal,
   selectOnHover = true,
   selectable = false,
   checkedIds,
@@ -145,6 +151,8 @@ export function ClipList({
             onCopy={() => onCopy(clip.id)}
             onTogglePin={() => onTogglePin(clip.id)}
             onContextMenu={(event) => onCardContextMenu?.(event, clip.id)}
+            revealed={revealedClips?.get(clip.id)}
+            onToggleReveal={onToggleReveal ? () => onToggleReveal(clip.id) : undefined}
             selectable={selectable}
             isChecked={checkedIds?.has(clip.id) ?? false}
             onToggleSelect={(event) => onToggleSelect?.(clip.id, index, event)}

--- a/frontend/src/components/ClipPreview.tsx
+++ b/frontend/src/components/ClipPreview.tsx
@@ -7,6 +7,8 @@ import {
   Clock,
   Copy,
   ExternalLink,
+  Eye,
+  EyeOff,
   Pencil,
   Pin,
   ScanText,
@@ -33,6 +35,9 @@ export interface ClipDetails {
   ocr_layout: OcrLayout | null;
 }
 
+const actionClass =
+  'inline-flex items-center gap-1.5 rounded-md border border-white/[0.09] bg-white/[0.05] px-2.5 py-1.5 text-[11px] font-medium text-foreground transition-colors hover:bg-white/[0.1] disabled:opacity-40';
+
 interface ClipPreviewProps {
   clip: ClipboardItem | null;
   onCopy: (clipId: string, plainText?: boolean) => void;
@@ -48,6 +53,12 @@ interface ClipPreviewProps {
   onCopyText: (text: string) => void;
   /** Save edited text back to the clip. Text clips only. */
   onSaveText: (clipId: string, text: string) => Promise<void>;
+  /** Persist (or clear) the hidden flag for this clip. */
+  onToggleHidden: (clipId: string) => void;
+  /** Set when this hidden clip has been revealed for the session. */
+  revealed?: ClipboardItem;
+  /** Reveal or re-hide for the session, without touching the persisted flag. */
+  onToggleReveal?: (clipId: string) => void;
   onTogglePin: (clipId: string) => void;
   onDelete: (clipId: string) => void;
 }
@@ -71,6 +82,9 @@ export function ClipPreview({
   onRescanOcr,
   onCopyText,
   onSaveText,
+  onToggleHidden,
+  revealed,
+  onToggleReveal,
   onTogglePin,
   onDelete,
 }: ClipPreviewProps) {
@@ -82,7 +96,12 @@ export function ClipPreview({
   const [saving, setSaving] = useState(false);
   const [details, setDetails] = useState<ClipDetails | null>(null);
   const [detailsError, setDetailsError] = useState<string | null>(null);
-  const clipId = clip?.id ?? null;
+  // Hiding has to cover this pane too, or selecting a hidden clip would put its
+  // content straight back on screen. Withheld the same way as the list row: the
+  // details fetch is skipped entirely, so the payload never reaches the
+  // renderer until the user reveals it.
+  const withheld = Boolean(clip?.is_hidden) && !revealed;
+  const clipId = withheld ? null : (clip?.id ?? null);
 
   // The list row carries only a preview (and a thumbnail for images). Pull the
   // full payload when a clip is actually selected, and drop a late response for
@@ -160,6 +179,32 @@ export function ClipPreview({
     );
   }
 
+  if (withheld) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 px-10 text-center">
+        <EyeOff size={22} className="text-muted-foreground" />
+        <div>
+          <p className="text-sm font-medium text-foreground/80">This clip is hidden</p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            Its content stays out of the list and this pane. Copy and paste still work.
+          </p>
+        </div>
+        <div className="flex items-center gap-1.5">
+          {onToggleReveal && (
+            <button type="button" className={actionClass} onClick={() => onToggleReveal(clip.id)}>
+              <Eye size={13} />
+              Reveal for this session
+            </button>
+          )}
+          <button type="button" className={actionClass} onClick={() => onToggleHidden(clip.id)}>
+            <Eye size={13} />
+            Unhide
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   const label = sourceLabel(clip.source_app, clip.clip_type);
   const text = isImage ? '' : (details?.content ?? clip.content ?? clip.preview);
   const kind = isImage ? imageLabel(label) : contentKind(text, clip.clip_type);
@@ -173,8 +218,6 @@ export function ClipPreview({
       : null;
   const size = isImage ? formatBytes(imageMetadata.size_bytes) : `${text.length} characters`;
   const expired = details?.image_expired ?? clip.image_expired ?? false;
-  const actionClass =
-    'inline-flex items-center gap-1.5 rounded-md border border-white/[0.09] bg-white/[0.05] px-2.5 py-1.5 text-[11px] font-medium text-foreground transition-colors hover:bg-white/[0.1] disabled:opacity-40';
 
   return (
     <div data-el="clip-preview" className="flex h-full min-h-0 flex-col">
@@ -405,6 +448,19 @@ export function ClipPreview({
         <button type="button" className={actionClass} onClick={() => onTogglePin(clip.id)}>
           <Pin size={13} className={clsx(clip.is_pinned && 'fill-current text-primary')} />
           {clip.is_pinned ? 'Unpin' : 'Pin'}
+        </button>
+        <button
+          type="button"
+          className={actionClass}
+          onClick={() => onToggleHidden(clip.id)}
+          title={
+            clip.is_hidden
+              ? 'Show this clip’s content in the list again'
+              : 'Hide this clip’s content from the list; it still pastes normally'
+          }
+        >
+          {clip.is_hidden ? <Eye size={13} /> : <EyeOff size={13} />}
+          {clip.is_hidden ? 'Unhide' : 'Hide'}
         </button>
         <button
           type="button"

--- a/frontend/src/components/ClipPreview.tsx
+++ b/frontend/src/components/ClipPreview.tsx
@@ -102,6 +102,12 @@ export function ClipPreview({
   // renderer until the user reveals it.
   const withheld = Boolean(clip?.is_hidden) && !revealed;
   const clipId = withheld ? null : (clip?.id ?? null);
+  const isImage = clip?.clip_type === 'image';
+  // A reveal already fetched this clip's payload, so refetching it here would
+  // decrypt the same content a second time and leave the pane blank until it
+  // landed. Images are the exception: the reveal copy carries content only, and
+  // the word boxes and expiry flag still have to be fetched.
+  const shouldFetch = clipId !== null && (!revealed || isImage);
 
   // The list row carries only a preview (and a thumbnail for images). Pull the
   // full payload when a clip is actually selected, and drop a late response for
@@ -122,7 +128,7 @@ export function ClipPreview({
       setDetails(null);
       setDetailsError(null);
     }
-    if (!clipId) return;
+    if (!clipId || !shouldFetch) return;
 
     let active = true;
     invoke<ClipDetails>('get_clip_details', { id: clipId })
@@ -142,7 +148,7 @@ export function ClipPreview({
     return () => {
       active = false;
     };
-  }, [clipId, ocrReady]);
+  }, [clipId, ocrReady, shouldFetch]);
 
   // Abandon an unsaved edit when the selection moves — silently carrying a
   // draft onto a different clip and saving it there would be destructive.
@@ -158,7 +164,6 @@ export function ClipPreview({
     setScanDraft(null);
   }, [clipId]);
 
-  const isImage = clip?.clip_type === 'image';
   const imageMetadata = useMemo(() => parseImageMetadata(clip?.metadata), [clip?.metadata]);
   // Wait for the full payload rather than showing the row's thumbnail first.
   // Swapping the image under the viewer means fit and 1:1 are computed against
@@ -167,9 +172,12 @@ export function ClipPreview({
   // where it is the best thing left to show.
   const imageSrc = useMemo(() => {
     if (!isImage) return null;
-    if (details) return imageSrcFromContent(details.content);
+    // A reveal fetches the full payload, not the row's thumbnail, so showing it
+    // before this component's own fetch lands does not cause that zoom jump.
+    const full = details?.content ?? revealed?.content;
+    if (full) return imageSrcFromContent(full);
     return detailsError ? imageSrcFromContent(clip?.content) : null;
-  }, [isImage, details, detailsError, clip?.content]);
+  }, [isImage, details, revealed?.content, detailsError, clip?.content]);
 
   if (!clip) {
     return (
@@ -206,7 +214,10 @@ export function ClipPreview({
   }
 
   const label = sourceLabel(clip.source_app, clip.clip_type);
-  const text = isImage ? '' : (details?.content ?? clip.content ?? clip.preview);
+  // The row itself carries no content while hidden, so a revealed clip has to
+  // read from the copy the reveal fetched or the pane renders empty.
+  const source = revealed ?? clip;
+  const text = isImage ? '' : (details?.content ?? source.content ?? clip.preview);
   const kind = isImage ? imageLabel(label) : contentKind(text, clip.clip_type);
   const captured = (() => {
     const parsed = new Date(clip.created_at);

--- a/frontend/src/hooks/useRevealedClips.ts
+++ b/frontend/src/hooks/useRevealedClips.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { toast } from 'sonner';
 import { ClipboardItem } from '../types';
 
 /**
@@ -52,6 +53,10 @@ export function useRevealedClips() {
     } catch (error) {
       console.error('Failed to reveal clip:', error);
       pending.current.delete(clip.id);
+      // The eye button has no other failure state: without this the row simply
+      // stays blank and the click looks ignored. The persisted hide toggle
+      // already toasts on failure, so this matches it.
+      toast.error('Could not reveal this clip');
     }
   }, []);
 

--- a/frontend/src/hooks/useRevealedClips.ts
+++ b/frontend/src/hooks/useRevealedClips.ts
@@ -55,11 +55,29 @@ export function useRevealedClips() {
     }
   }, []);
 
+  /**
+   * Forget one clip's reveal, including an in-flight one.
+   *
+   * Toggling the hidden flag invalidates that clip's reveal and nothing else,
+   * so it must not disturb the rest: clearing the whole map would drop a
+   * different clip's pending entry, and its fetch would then land to a closed
+   * door — the user clicked reveal and silently got nothing.
+   */
+  const forgetRevealed = useCallback((clipId: string) => {
+    pending.current.delete(clipId);
+    setRevealed((current) => {
+      if (!current.has(clipId)) return current;
+      const next = new Map(current);
+      next.delete(clipId);
+      return next;
+    });
+  }, []);
+
   /** Forget every reveal — used when the surface closes or the list reloads. */
   const clearRevealed = useCallback(() => {
     pending.current.clear();
     setRevealed(new Map());
   }, []);
 
-  return { revealed, toggleReveal, clearRevealed };
+  return { revealed, toggleReveal, forgetRevealed, clearRevealed };
 }

--- a/frontend/src/hooks/useRevealedClips.ts
+++ b/frontend/src/hooks/useRevealedClips.ts
@@ -1,0 +1,65 @@
+import { useCallback, useRef, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { ClipboardItem } from '../types';
+
+/**
+ * Session-scoped reveal for hidden clips (SOU-586).
+ *
+ * A hidden clip's row arrives with no content at all, so revealing it means
+ * fetching the payload rather than un-blanking something already in hand. That
+ * fetched copy lives only here, in component state: it is never written back to
+ * the list, so it disappears when the window closes and the persisted hidden
+ * flag is untouched.
+ */
+export function useRevealedClips() {
+  const [revealed, setRevealed] = useState<Map<string, ClipboardItem>>(new Map());
+  // Intent is tracked in a ref, not in `revealed`, because a fetch spans
+  // renders: two clicks before the response lands would both read the same
+  // stale map, both start a fetch, and the second — meant to re-hide — would
+  // instead reveal. The ref updates synchronously, so the second click sees the
+  // first and cancels it.
+  const pending = useRef<Set<string>>(new Set());
+
+  const toggleReveal = useCallback(async (clip: ClipboardItem) => {
+    const hide = () => {
+      pending.current.delete(clip.id);
+      setRevealed((current) => {
+        if (!current.has(clip.id)) return current;
+        const next = new Map(current);
+        next.delete(clip.id);
+        return next;
+      });
+    };
+
+    if (pending.current.has(clip.id)) {
+      // Already revealed, or a reveal is in flight. Either way this click means
+      // "hide"; the in-flight response checks the set again before applying.
+      hide();
+      return;
+    }
+
+    pending.current.add(clip.id);
+    try {
+      const details = await invoke<{ content: string }>('get_clip_details', { id: clip.id });
+      // Cancelled while the fetch was out.
+      if (!pending.current.has(clip.id)) return;
+      setRevealed((current) => {
+        const next = new Map(current);
+        // Keep the row's own metadata; only the payload was withheld.
+        next.set(clip.id, { ...clip, content: details.content, preview: details.content });
+        return next;
+      });
+    } catch (error) {
+      console.error('Failed to reveal clip:', error);
+      pending.current.delete(clip.id);
+    }
+  }, []);
+
+  /** Forget every reveal — used when the surface closes or the list reloads. */
+  const clearRevealed = useCallback(() => {
+    pending.current.clear();
+    setRevealed(new Map());
+  }, []);
+
+  return { revealed, toggleReveal, clearRevealed };
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -17,6 +17,9 @@ export interface ClipboardItem {
   // Retention dropped this image's full-resolution blob but kept its thumbnail
   // and OCR text (SOU-244). It stays searchable; the full image can't be pasted.
   image_expired?: boolean;
+  // The user hid this clip's content (SOU-586). When set the row carries no
+  // content or preview at all; revealing it fetches the payload on demand.
+  is_hidden?: boolean;
 }
 
 export interface OcrMatch {

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -11,6 +11,7 @@ import { ContentFilter } from '../components/FlyoutHeader';
 import { useTheme } from '../hooks/useTheme';
 import { useLanguage } from '../hooks/useLanguage';
 import { useSystemAccent } from '../hooks/useSystemAccent';
+import { useRevealedClips } from '../hooks/useRevealedClips';
 import { customRange, DATE_PRESET_LABELS, DatePreset, presetRange } from '../utils/dateRange';
 import {
   applySelectionClick,
@@ -79,6 +80,8 @@ export function HistoryWindow() {
   // accent color itself.
   useSystemAccent();
   const density = settings?.density ?? 'comfortable';
+
+  const { revealed, toggleReveal, clearRevealed } = useRevealedClips();
 
   const clipsRef = useRef<ClipboardItem[]>(clips);
   clipsRef.current = clips;
@@ -460,6 +463,29 @@ export function HistoryWindow() {
       toast.error('Could not scan this image');
     }
   }, []);
+  const handleToggleReveal = useCallback(
+    (clipId: string) => {
+      const clip = clipsRef.current.find((item) => item.id === clipId);
+      if (clip) void toggleReveal(clip);
+    },
+    [toggleReveal]
+  );
+
+  /** Persist the hidden flag, as opposed to revealing for the session. */
+  const handleToggleHidden = useCallback(
+    async (clipId: string) => {
+      try {
+        const hidden = await invoke<boolean>('toggle_clip_hidden', { id: clipId });
+        clearRevealed();
+        await loadClips(false);
+        toast.success(hidden ? 'Clip hidden' : 'Clip no longer hidden');
+      } catch (error) {
+        console.error('Failed to change clip visibility:', error);
+        toast.error('Failed to change clip visibility');
+      }
+    },
+    [clearRevealed, loadClips]
+  );
 
   const handleTogglePin = useCallback(async (clipId: string) => {
     try {
@@ -835,6 +861,8 @@ export function HistoryWindow() {
             onSelectClip={setSelectedClipId}
             onPaste={setSelectedClipId}
             onCopy={handleCopy}
+            revealedClips={revealed}
+            onToggleReveal={handleToggleReveal}
             onTogglePin={handleTogglePin}
             onLoadMore={() => {
               if (hasMore && !isLoading) loadClips(true);
@@ -853,6 +881,7 @@ export function HistoryWindow() {
             onRescanOcr={handleRescanOcr}
             onCopyText={handleCopySelection}
             onSaveText={handleSaveText}
+            onToggleHidden={handleToggleHidden}
             onTogglePin={handleTogglePin}
             onDelete={handleDelete}
           />

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -882,6 +882,8 @@ export function HistoryWindow() {
             onCopyText={handleCopySelection}
             onSaveText={handleSaveText}
             onToggleHidden={handleToggleHidden}
+            revealed={selectedClipId ? revealed.get(selectedClipId) : undefined}
+            onToggleReveal={handleToggleReveal}
             onTogglePin={handleTogglePin}
             onDelete={handleDelete}
           />

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -81,7 +81,7 @@ export function HistoryWindow() {
   useSystemAccent();
   const density = settings?.density ?? 'comfortable';
 
-  const { revealed, toggleReveal, clearRevealed } = useRevealedClips();
+  const { revealed, toggleReveal, forgetRevealed } = useRevealedClips();
 
   const clipsRef = useRef<ClipboardItem[]>(clips);
   clipsRef.current = clips;
@@ -136,14 +136,18 @@ export function HistoryWindow() {
               sourceApp,
             });
 
-        if (loadId !== loadIdRef.current) return;
+        if (loadId !== loadIdRef.current) return true;
         setClips((previous) => (append ? [...previous, ...data] : data));
         setHasMore(data.length === PAGE_SIZE);
+        return true;
       } catch (error) {
-        if (loadId !== loadIdRef.current) return;
+        // Superseded: a newer load owns the view, so this one failing is not a
+        // failure to refresh — report success and let the newer load speak.
+        if (loadId !== loadIdRef.current) return true;
         console.error('Failed to load clips:', error);
         setLoadError(true);
         setHasMore(false);
+        return false;
       } finally {
         if (loadId === loadIdRef.current) setIsLoading(false);
       }
@@ -476,15 +480,20 @@ export function HistoryWindow() {
     async (clipId: string) => {
       try {
         const hidden = await invoke<boolean>('toggle_clip_hidden', { id: clipId });
-        clearRevealed();
-        await loadClips(false);
+        forgetRevealed(clipId);
+        // loadClips reports failure rather than throwing, so a stale list after
+        // a failed reload would otherwise be announced as success.
+        if (!(await loadClips(false))) {
+          toast.error('Visibility changed, but the list could not be reloaded');
+          return;
+        }
         toast.success(hidden ? 'Clip hidden' : 'Clip no longer hidden');
       } catch (error) {
         console.error('Failed to change clip visibility:', error);
         toast.error('Failed to change clip visibility');
       }
     },
-    [clearRevealed, loadClips]
+    [forgetRevealed, loadClips]
   );
 
   const handleTogglePin = useCallback(async (clipId: string) => {

--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -60,6 +60,10 @@ struct BackupClip {
     content_b64: String,
     text_preview: String,
     is_pinned: bool,
+    /// Defaulted so a bundle written before this field existed still imports;
+    /// those clips were not hidden, which is what `false` says.
+    #[serde(default)]
+    is_hidden: bool,
     #[serde(default)]
     source_app: Option<String>,
     #[serde(default)]
@@ -89,6 +93,7 @@ type ExportRow = (
     Vec<u8>,                       // content (encrypted)
     String,                        // text_preview (encrypted)
     bool,                          // is_pinned
+    bool,                          // is_hidden
     Option<String>,                // source_app (encrypted)
     Option<String>,                // source_icon (encrypted)
     Option<String>,                // metadata (encrypted)
@@ -134,6 +139,7 @@ pub async fn export_backup(db: &Database, path: &str, passphrase: &str) -> Resul
                clips.content,
                clips.text_preview,
                clips.is_pinned,
+               clips.is_hidden,
                clips.source_app,
                clips.source_icon,
                clips.metadata,
@@ -156,6 +162,7 @@ pub async fn export_backup(db: &Database, path: &str, passphrase: &str) -> Resul
         content,
         text_preview,
         is_pinned,
+        is_hidden,
         source_app,
         source_icon,
         metadata,
@@ -187,6 +194,7 @@ pub async fn export_backup(db: &Database, path: &str, passphrase: &str) -> Resul
             content_b64: BASE64.encode(&content),
             text_preview,
             is_pinned,
+            is_hidden,
             source_app: decrypt_optional(source_app),
             source_icon: decrypt_optional(source_icon),
             metadata: decrypt_optional(metadata),
@@ -370,9 +378,10 @@ pub async fn import_backup(
             INSERT INTO clips (
                 uuid, clip_type, content, text_preview, content_hash, folder_id,
                 is_deleted, is_thumbnail, source_app, source_icon, metadata,
-                ocr_text, ocr_status, full_image_expired, created_at, last_accessed, is_pinned
+                ocr_text, ocr_status, full_image_expired, created_at, last_accessed, is_pinned,
+                is_hidden
             )
-            VALUES (?, ?, ?, ?, ?, ?, 0, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, 0, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
         )
         .bind(Uuid::new_v4().to_string())
@@ -390,6 +399,10 @@ pub async fn import_backup(
         .bind(&clip.created_at)
         .bind(&clip.created_at)
         .bind(i64::from(clip.is_pinned))
+        // Restored hidden. A clip the user chose to hide must not come back
+        // visible: the column defaults to 0, so omitting this would silently
+        // undo the protection on every round trip.
+        .bind(i64::from(clip.is_hidden))
         .execute(&db.pool)
         .await;
 
@@ -471,6 +484,74 @@ mod tests {
         .execute(&db.pool)
         .await
         .unwrap();
+    }
+
+    /// Matched on `content_hash`, not on an encrypted column: encryption is
+    /// randomized, so re-encrypting the same text yields different bytes and a
+    /// comparison against `text_preview` would never match.
+    async fn set_hidden(db: &Database, text: &str) {
+        let material = crate::clipboard::build_clip_hash_material(
+            "text",
+            text.as_bytes(),
+            std::iter::empty::<(&str, &[u8])>(),
+        );
+        let affected = sqlx::query("UPDATE clips SET is_hidden = 1 WHERE content_hash = ?")
+            .bind(db.crypto.keyed_hash(&material))
+            .execute(&db.pool)
+            .await
+            .unwrap()
+            .rows_affected();
+        assert_eq!(affected, 1, "the clip to hide should exist");
+    }
+
+    async fn hidden_flags(db: &Database) -> Vec<(String, bool)> {
+        let rows: Vec<(Vec<u8>, bool)> =
+            sqlx::query_as("SELECT content, is_hidden FROM clips WHERE is_deleted = 0 ORDER BY id")
+                .fetch_all(&db.pool)
+                .await
+                .unwrap();
+        rows.into_iter()
+            .map(|(content, hidden)| {
+                (
+                    String::from_utf8(db.crypto.decrypt(&content).unwrap()).unwrap(),
+                    hidden,
+                )
+            })
+            .collect()
+    }
+
+    /// A clip the user hid must come back hidden. The column defaults to 0, so
+    /// a bundle that does not carry the flag silently unhides everything it
+    /// restores — the protection would be undone by a backup round trip.
+    #[tokio::test]
+    async fn hidden_survives_a_round_trip() {
+        let source = test_database().await;
+        insert_clip(&source, "a recovery code", false, None).await;
+        insert_clip(&source, "an ordinary note", false, None).await;
+        set_hidden(&source, "a recovery code").await;
+
+        let path = temp_path("hidden");
+        let path_str = path.to_string_lossy().to_string();
+        export_backup(&source, &path_str, "correct horse")
+            .await
+            .unwrap();
+
+        let target = test_database().await;
+        import_backup(&target, &path_str, "correct horse", false)
+            .await
+            .unwrap();
+
+        let mut restored = hidden_flags(&target).await;
+        restored.sort();
+        assert_eq!(
+            restored,
+            vec![
+                ("a recovery code".to_string(), true),
+                ("an ordinary note".to_string(), false),
+            ],
+            "the hidden flag must survive export and import"
+        );
+        let _ = std::fs::remove_file(&path);
     }
 
     async fn clip_texts(db: &Database) -> Vec<String> {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,6 +10,36 @@ use std::time::Instant;
 use tauri::{AppHandle, Emitter, Manager};
 
 fn clip_to_list_item(clip: &Clip) -> ClipboardItem {
+    // A hidden clip ships no content and no preview — not even a thumbnail.
+    // Blanking it in the frontend instead would leave the secret sitting in the
+    // renderer's memory and in every IPC payload, which makes "hidden" a
+    // decoration rather than a property. Revealing for the session fetches the
+    // real payload on demand through get_clip_details.
+    if clip.is_hidden {
+        return ClipboardItem {
+            id: clip.uuid.clone(),
+            clip_type: clip.clip_type.clone(),
+            content: String::new(),
+            preview: String::new(),
+            folder_id: clip.folder_id.map(|id| id.to_string()),
+            is_pinned: clip.is_pinned,
+            created_at: clip.created_at.to_rfc3339(),
+            source_app: clip.source_app.clone(),
+            source_icon: clip.source_icon.clone(),
+            metadata: clip.metadata.clone(),
+            has_ocr_text: clip
+                .ocr_text
+                .as_deref()
+                .is_some_and(|text| !text.trim().is_empty()),
+            // Search snippets and highlight boxes are made of the very text
+            // being hidden, so they have to go too.
+            ocr_match: None,
+            ocr_highlights: None,
+            image_expired: clip.full_image_expired,
+            is_hidden: true,
+        };
+    }
+
     let content_str = if clip.clip_type == "image" {
         BASE64.encode(&clip.content)
     } else {
@@ -34,6 +64,7 @@ fn clip_to_list_item(clip: &Clip) -> ClipboardItem {
         ocr_match: None,
         ocr_highlights: None,
         image_expired: clip.full_image_expired,
+        is_hidden: false,
     }
 }
 
@@ -1514,6 +1545,33 @@ fn truncate_preview(text: &str) -> String {
     text.chars().take(PREVIEW_LIMIT).collect()
 }
 
+/// Hide or unhide a clip's content in the list (SOU-586). Returns the new state.
+///
+/// Deliberately the lighter-weight sibling of a master-password lock: no new
+/// auth or key material, just a display flag. The content keeps its existing
+/// AES-256-GCM encryption at rest, stays searchable, and still pastes in full.
+#[tauri::command]
+pub async fn toggle_clip_hidden(
+    id: String,
+    db: tauri::State<'_, Arc<Database>>,
+) -> Result<bool, String> {
+    toggle_clip_hidden_in_pool(&db.pool, &id).await
+}
+
+async fn toggle_clip_hidden_in_pool(pool: &SqlitePool, id: &str) -> Result<bool, String> {
+    // Flip and read back in one statement. Reading then writing would let two
+    // concurrent toggles both observe the old value and write the same new one,
+    // losing a toggle and returning the wrong state to one of the callers.
+    let next: Option<bool> = sqlx::query_scalar(
+        "UPDATE clips SET is_hidden = NOT is_hidden WHERE uuid = ? RETURNING is_hidden",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+    next.ok_or_else(|| format!("Clip {id} not found"))
+}
+
 #[tauri::command]
 pub async fn move_to_folder(
     clip_id: String,
@@ -2585,8 +2643,9 @@ mod tests {
         directory_size_bytes, enforce_retention_in_pool, get_clip_details_in_database,
         get_clips_in_database, load_recognized_text, migrate_clip_format_model,
         migrate_encrypted_storage, ocr_text_layout, remove_clip_image_files, restore_hash_material,
-        search_clips_in_database, set_clip_ocr_text_in_database, toggle_clip_pin_in_pool,
-        update_clip_text_in_database, ClipboardContent, OCR_SNIPPET_CHAR_LIMIT,
+        search_clips_in_database, set_clip_ocr_text_in_database, toggle_clip_hidden_in_pool,
+        toggle_clip_pin_in_pool, update_clip_text_in_database, ClipboardContent,
+        OCR_SNIPPET_CHAR_LIMIT,
     };
     use crate::clipboard::CapturedFormat;
     use crate::database::Database;
@@ -2994,6 +3053,77 @@ mod tests {
         assert!(set_clip_ocr_text_in_database(&database, "missing", "nope")
             .await
             .is_err());
+    }
+
+    #[tokio::test]
+    async fn hidden_clips_ship_no_content_but_stay_listed_and_pastable() {
+        let database = test_database().await;
+        insert_search_clip(
+            &database,
+            SearchFixture::text("secret", "swordfish token 8821", "2026-05-01 09:00:00")
+                .with_app("code.exe"),
+        )
+        .await;
+
+        assert_eq!(
+            listed_ids(&database, None, None, None).await,
+            vec!["secret"]
+        );
+
+        let hidden = toggle_clip_hidden_in_pool(&database.pool, "secret")
+            .await
+            .expect("toggle should apply");
+        assert!(hidden);
+
+        let items =
+            get_clips_in_database(None, 10, 0, Some(true), None, None, None, None, &database)
+                .await
+                .unwrap();
+        assert_eq!(items.len(), 1, "a hidden clip is still listed");
+        assert!(items[0].is_hidden);
+        // The point of the feature: the secret is not in the payload at all, so
+        // it cannot be read off the row or out of the renderer's memory.
+        assert!(items[0].content.is_empty());
+        assert!(items[0].preview.is_empty());
+
+        // Still searchable, and the match snippet does not leak it either.
+        let found = search_clips_in_database(
+            "swordfish".into(),
+            None,
+            10,
+            0,
+            None,
+            None,
+            None,
+            None,
+            &database,
+        )
+        .await
+        .unwrap();
+        assert_eq!(found.len(), 1);
+        assert!(found[0].is_hidden);
+        assert!(found[0].content.is_empty());
+        assert!(
+            found[0].ocr_match.is_none(),
+            "the match snippet is made of the hidden text"
+        );
+
+        // Revealing for the session still sees the real thing, which is also
+        // what paste reads.
+        let details = get_clip_details_in_database(&database, "secret")
+            .await
+            .unwrap();
+        assert_eq!(details.content, "swordfish token 8821");
+
+        assert!(!toggle_clip_hidden_in_pool(&database.pool, "secret")
+            .await
+            .unwrap());
+        let items =
+            get_clips_in_database(None, 10, 0, Some(true), None, None, None, None, &database)
+                .await
+                .unwrap();
+        assert_eq!(items[0].content, "swordfish token 8821");
+        assert!(!items[0].is_hidden);
     }
 
     #[tokio::test]
@@ -3549,6 +3679,7 @@ mod tests {
             ocr_text: None,
             ocr_words: None,
             full_image_expired: false,
+            is_hidden: false,
             created_at: chrono::Utc::now(),
             last_accessed: chrono::Utc::now(),
         };

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -201,6 +201,15 @@ impl Database {
         )
         .await?;
 
+        // Per-clip "hide from the list" flag (SOU-586). Purely a display state:
+        // the content stays encrypted at rest exactly as before and still pastes
+        // normally. 0 = shown.
+        add_column_if_missing(
+            &self.pool,
+            "ALTER TABLE clips ADD COLUMN is_hidden INTEGER NOT NULL DEFAULT 0",
+        )
+        .await?;
+
         // Existing images without OCR become durable background work. A process
         // that exited while a job was running leaves it as `processing`; reset
         // those jobs so the next launch can recover them.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -461,6 +461,7 @@ pub fn run_app() {
             commands::toggle_clip_pin,
             commands::set_clip_ocr_text,
             commands::update_clip_text,
+            commands::toggle_clip_hidden,
             commands::move_to_folder,
             commands::create_folder,
             commands::rename_folder,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -113,6 +113,10 @@ pub struct Clip {
     // True once retention has dropped this image clip's full-resolution blob but
     // kept its thumbnail + ocr_text (SOU-244). Only ever set for `image` clips.
     pub full_image_expired: bool,
+    // The user asked for this clip's content to be hidden from the list
+    // (SOU-586). Display state only: the row is still encrypted the same way,
+    // still searchable, and still pastes its real content.
+    pub is_hidden: bool,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub last_accessed: chrono::DateTime<chrono::Utc>,
 }
@@ -136,6 +140,7 @@ impl<'r> FromRow<'r, SqliteRow> for Clip {
             ocr_text: row.try_get("ocr_text")?,
             ocr_words: row.try_get("ocr_words")?,
             full_image_expired: row.try_get("full_image_expired")?,
+            is_hidden: row.try_get("is_hidden")?,
             created_at: row.try_get("created_at")?,
             last_accessed: row.try_get("last_accessed")?,
         })
@@ -203,6 +208,10 @@ pub struct ClipboardItem {
     // its thumbnail + OCR text were kept (SOU-244). The UI marks it and stops
     // offering the full image for paste/copy.
     pub image_expired: bool,
+    // The user hid this clip's content from the list (SOU-586). When set, this
+    // item carries no content or preview at all — the UI shows a placeholder,
+    // and revealing it for the session fetches the real payload on demand.
+    pub is_hidden: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
Closes SBS-586. Part of the OmniClip epic (SBS-581).

## Why

Cubby's sensitive-content story was skip-on-capture (SBS-214): likely secrets are never stored. Right default, but all-or-nothing — there was no way to *keep* a clip and still stop it being read off the list by someone glancing at your screen.

## What it does

A persisted `is_hidden` flag per clip. Deliberately the lighter-weight sibling of the master-password lock (SBS-591): **no new auth or key material**, and content keeps exactly the AES-256-GCM encryption at rest it already had.

**The flag withholds the payload rather than masking it.** A hidden clip's list row carries no content, no preview, no thumbnail, and no search-match snippet. Blanking it in the frontend instead would leave the secret sitting in every IPC payload and in the renderer's memory — that makes "hidden" a decoration rather than a property.

What still works, per the issue's constraint that hiding affects display only:
- Hidden clips stay **listed** and stay **searchable** (the index is unchanged)
- They still **paste in full**, because paste reads the database directly

## Reveal vs unhide

These are deliberately two different things:

- **Reveal** (the eye on a hidden row) fetches the payload through the existing `get_clip_details` and holds it in component state for that session only. It never touches the persisted flag, and the flyout drops every reveal when it closes — so a hidden clip is hidden again next time.
- **Hide / Unhide** (flyout context menu, History window preview actions) is what persists.

## Testing

- 128 Rust tests, 74 frontend tests, `tsc`, `vite build`, `cargo clippy`, `cargo fmt` — all clean.
- New coverage asserts a hidden clip is still listed and still matches a search while carrying **no content, no preview, and no `ocr_match` snippet**; that `get_clip_details` still returns the real payload (the reveal and paste path); and that unhiding restores the row.

Not driven in a live build — the backend behavior is what carries the security property here and it is covered by tests. Say the word if you want me to exercise it in the app before this lands.