### PR TITLE
Editable text clips

### DIFF
--- a/frontend/src/components/ClipPreview.tsx
+++ b/frontend/src/components/ClipPreview.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { clsx } from 'clsx';
 import { format } from 'date-fns';
-import { Clock, Copy, ExternalLink, Pin, Trash2, Type } from 'lucide-react';
+import { Check, Clock, Copy, ExternalLink, Pencil, Pin, Trash2, Type } from 'lucide-react';
 import { ClipboardItem } from '../types';
 import { ImageTextViewer } from './ImageTextViewer';
 import { OcrLayout } from '../utils/ocrSelection';
@@ -30,6 +30,8 @@ interface ClipPreviewProps {
   onCopySelection: (text: string) => void;
   /** Pops the image out into its own full-size window. */
   onOpenImage: (clipId: string) => void;
+  /** Save edited text back to the clip. Text clips only. */
+  onSaveText: (clipId: string, text: string) => Promise<void>;
   onTogglePin: (clipId: string) => void;
   onDelete: (clipId: string) => void;
 }
@@ -49,9 +51,13 @@ export function ClipPreview({
   onCopyOcrText,
   onCopySelection,
   onOpenImage,
+  onSaveText,
   onTogglePin,
   onDelete,
 }: ClipPreviewProps) {
+  // Null when not editing; otherwise the working copy of the text.
+  const [draft, setDraft] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
   const [details, setDetails] = useState<ClipDetails | null>(null);
   const [detailsError, setDetailsError] = useState<string | null>(null);
   const clipId = clip?.id ?? null;
@@ -96,6 +102,12 @@ export function ClipPreview({
       active = false;
     };
   }, [clipId, ocrReady]);
+
+  // Abandon an unsaved edit when the selection moves — silently carrying a
+  // draft onto a different clip and saving it there would be destructive.
+  useEffect(() => {
+    setDraft(null);
+  }, [clipId]);
 
   const isImage = clip?.clip_type === 'image';
   const imageMetadata = useMemo(() => parseImageMetadata(clip?.metadata), [clip?.metadata]);
@@ -185,14 +197,32 @@ export function ClipPreview({
         </div>
       ) : (
         <div className="min-h-0 flex-1 overflow-y-auto p-4">
-          <pre
-            className={clsx(
-              'whitespace-pre-wrap break-words text-[12.5px] leading-[19px] text-foreground/95',
-              kind === 'Code' && 'font-mono text-[12px]'
-            )}
-          >
-            {text}
-          </pre>
+          {draft !== null ? (
+            <textarea
+              autoFocus
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') {
+                  event.stopPropagation();
+                  setDraft(null);
+                }
+              }}
+              className={clsx(
+                'h-full min-h-[200px] w-full resize-none rounded-md border border-primary/45 bg-black/20 p-2 text-[12.5px] leading-[19px] text-foreground outline-none',
+                kind === 'Code' && 'font-mono text-[12px]'
+              )}
+            />
+          ) : (
+            <pre
+              className={clsx(
+                'whitespace-pre-wrap break-words text-[12.5px] leading-[19px] text-foreground/95',
+                kind === 'Code' && 'font-mono text-[12px]'
+              )}
+            >
+              {text}
+            </pre>
+          )}
           {detailsError && (
             <p className="mt-3 text-[11px] text-destructive">
               Could not load the full clip. Showing the list preview instead.
@@ -210,6 +240,50 @@ export function ClipPreview({
       </div>
 
       <div className="flex shrink-0 flex-wrap items-center gap-1.5 border-t border-white/[0.07] px-4 py-3">
+        {draft !== null ? (
+          <>
+            <button
+              type="button"
+              className={actionClass}
+              disabled={saving}
+              onClick={async () => {
+                setSaving(true);
+                try {
+                  await onSaveText(clip.id, draft);
+                  setDraft(null);
+                } finally {
+                  setSaving(false);
+                }
+              }}
+            >
+              <Check size={13} />
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+            <button
+              type="button"
+              className={actionClass}
+              disabled={saving}
+              onClick={() => setDraft(null)}
+            >
+              Cancel
+            </button>
+          </>
+        ) : (
+          !isImage && (
+            <button
+              type="button"
+              className={actionClass}
+              // The full text, not the row's truncated preview — editing from a
+              // preview would silently chop the clip on save.
+              onClick={() => setDraft(details?.content ?? clip.content ?? '')}
+              disabled={!details && !detailsError}
+              title={!details && !detailsError ? 'Loading the full text…' : undefined}
+            >
+              <Pencil size={13} />
+              Edit
+            </button>
+          )
+        )}
         <button
           type="button"
           className={actionClass}

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -418,6 +418,22 @@ export function HistoryWindow() {
     }
   }, []);
 
+  const handleSaveText = useCallback(
+    async (clipId: string, text: string) => {
+      try {
+        await invoke('update_clip_text', { id: clipId, text });
+        // The row still holds the pre-edit preview, and the edit may have
+        // changed which clips a filter or search matches.
+        await loadClips(false);
+        toast.success('Clip updated');
+      } catch (error) {
+        console.error('Failed to update the clip:', error);
+        toast.error('Failed to update the clip');
+      }
+    },
+    [loadClips]
+  );
+
   const handleTogglePin = useCallback(async (clipId: string) => {
     try {
       const isPinned = await invoke<boolean>('toggle_clip_pin', { id: clipId });
@@ -806,6 +822,7 @@ export function HistoryWindow() {
             onCopyOcrText={handleCopyOcrText}
             onCopySelection={handleCopySelection}
             onOpenImage={handleOpenImage}
+            onSaveText={handleSaveText}
             onTogglePin={handleTogglePin}
             onDelete={handleDelete}
           />

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1386,6 +1386,82 @@ pub async fn toggle_clip_pin(
     toggle_clip_pin_in_pool(&db.pool, &id).await
 }
 
+/// Replace a text clip's content in place (SOU-587), for the copy-fix-paste
+/// workflow that otherwise means pasting first and editing at the destination.
+#[tauri::command]
+pub async fn update_clip_text(
+    id: String,
+    text: String,
+    db: tauri::State<'_, Arc<Database>>,
+) -> Result<(), String> {
+    update_clip_text_in_database(db.inner(), &id, &text).await
+}
+
+async fn update_clip_text_in_database(db: &Database, id: &str, text: &str) -> Result<(), String> {
+    let clip_type: Option<String> =
+        sqlx::query_scalar("SELECT clip_type FROM clips WHERE uuid = ?")
+            .bind(id)
+            .fetch_optional(&db.pool)
+            .await
+            .map_err(|e| e.to_string())?;
+    let clip_type = clip_type.ok_or_else(|| format!("Clip {id} not found"))?;
+    if clip_type == "image" {
+        return Err("Image clips cannot be edited".to_string());
+    }
+
+    // The edited text is now the whole clip. Any html/rtf captured alongside it
+    // described the *old* text, so keeping them would paste the pre-edit version
+    // into anything that prefers a rich format — the edit would look like it had
+    // silently failed. Dropping them makes the clip plain text, which is what
+    // was actually edited. This is also why the hash is computed over no extra
+    // formats: it has to describe what the clip now is.
+    sqlx::query("DELETE FROM clip_formats WHERE clip_uuid = ?")
+        .bind(id)
+        .execute(&db.pool)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let hash_material = crate::clipboard::build_clip_hash_material(
+        "text",
+        text.as_bytes(),
+        std::iter::empty::<(&str, &[u8])>(),
+    );
+    // Dedup treats an edited clip exactly like any other clip: the hash follows
+    // the content, so re-copying this text later matches this row instead of
+    // adding a third. A collision with an existing clip is allowed rather than
+    // rejected — refusing an edit because some unrelated row happens to hold the
+    // same text would be the more surprising behavior.
+    let content_hash = db.crypto.keyed_hash(&hash_material);
+    let preview = truncate_preview(text);
+
+    sqlx::query(
+        "UPDATE clips SET clip_type = 'text', content = ?, text_preview = ?, content_hash = ? WHERE uuid = ?",
+    )
+    .bind(db.crypto.encrypt(text.as_bytes())?)
+    .bind(db.crypto.encrypt_text(&preview)?)
+    .bind(&content_hash)
+    .bind(id)
+    .execute(&db.pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    // The index holds the pre-edit text until it is told otherwise, so search
+    // would keep matching words the clip no longer contains.
+    db.search_index
+        .upsert(id, "text", text.as_bytes(), &preview, None, None);
+    // A capture of the old text would otherwise be suppressed as a duplicate of
+    // what this row used to hold.
+    crate::clipboard::reset_capture_dedup();
+    Ok(())
+}
+
+/// Preview text stored on the row, bounded so a huge clip does not bloat every
+/// list query. Mirrors the capture path's limit.
+fn truncate_preview(text: &str) -> String {
+    const PREVIEW_LIMIT: usize = 500;
+    text.chars().take(PREVIEW_LIMIT).collect()
+}
+
 #[tauri::command]
 pub async fn move_to_folder(
     clip_id: String,
@@ -2457,8 +2533,8 @@ mod tests {
         directory_size_bytes, enforce_retention_in_pool, get_clip_details_in_database,
         get_clips_in_database, load_recognized_text, migrate_clip_format_model,
         migrate_encrypted_storage, ocr_text_layout, remove_clip_image_files, restore_hash_material,
-        search_clips_in_database, toggle_clip_pin_in_pool, ClipboardContent,
-        OCR_SNIPPET_CHAR_LIMIT,
+        search_clips_in_database, toggle_clip_pin_in_pool, update_clip_text_in_database,
+        ClipboardContent, OCR_SNIPPET_CHAR_LIMIT,
     };
     use crate::clipboard::CapturedFormat;
     use crate::database::Database;
@@ -2702,6 +2778,103 @@ mod tests {
         .into_iter()
         .map(|clip| clip.id)
         .collect()
+    }
+
+    #[tokio::test]
+    async fn editing_a_clip_replaces_its_text_hash_and_stale_rich_formats() {
+        let database = test_database().await;
+        insert_search_clip(
+            &database,
+            SearchFixture::text("editable", "teh quick brown fox", "2026-06-01 09:00:00"),
+        )
+        .await;
+        // A rich capture: the html describes the *old* text.
+        sqlx::query(
+            "INSERT INTO clip_formats (clip_uuid, format, content) VALUES ('editable', 'html', ?)",
+        )
+        .bind(
+            database
+                .crypto
+                .encrypt(b"<b>teh quick brown fox</b>")
+                .unwrap(),
+        )
+        .execute(&database.pool)
+        .await
+        .unwrap();
+
+        let before: String = sqlx::query_scalar("SELECT content_hash FROM clips WHERE uuid = ?")
+            .bind("editable")
+            .fetch_one(&database.pool)
+            .await
+            .unwrap();
+
+        update_clip_text_in_database(&database, "editable", "the quick brown fox")
+            .await
+            .expect("edit should apply");
+
+        let details = get_clip_details_in_database(&database, "editable")
+            .await
+            .unwrap();
+        assert_eq!(details.content, "the quick brown fox");
+
+        // The hash follows the content, so dedup keeps working against what the
+        // clip now holds rather than what it used to.
+        let after: String = sqlx::query_scalar("SELECT content_hash FROM clips WHERE uuid = ?")
+            .bind("editable")
+            .fetch_one(&database.pool)
+            .await
+            .unwrap();
+        assert_ne!(before, after);
+        let expected = database
+            .crypto
+            .keyed_hash(&crate::clipboard::build_clip_hash_material(
+                "text",
+                b"the quick brown fox",
+                std::iter::empty::<(&str, &[u8])>(),
+            ));
+        assert_eq!(after, expected);
+
+        // The stale rich format is gone; keeping it would paste the pre-edit
+        // text into anything that prefers html, making the edit look ignored.
+        let formats: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM clip_formats WHERE clip_uuid = 'editable'")
+                .fetch_one(&database.pool)
+                .await
+                .unwrap();
+        assert_eq!(formats, 0);
+
+        // Search follows the edit rather than the original wording.
+        database
+            .search_index
+            .ensure_ready(&database.pool, &database.crypto)
+            .await
+            .unwrap();
+        update_clip_text_in_database(&database, "editable", "the quick brown fox")
+            .await
+            .unwrap();
+        assert!(database.search_index.matches("quick").contains("editable"));
+        assert!(database.search_index.matches("teh").is_empty());
+    }
+
+    #[tokio::test]
+    async fn editing_refuses_an_image_and_an_unknown_clip() {
+        let database = test_database().await;
+        sqlx::query(
+            "INSERT INTO clips (uuid, clip_type, content, text_preview, content_hash) VALUES ('shot', 'image', ?, ?, 'h')",
+        )
+        .bind(database.crypto.encrypt(&[1, 2, 3]).unwrap())
+        .bind(database.crypto.encrypt_text("Screenshot").unwrap())
+        .execute(&database.pool)
+        .await
+        .unwrap();
+
+        assert!(update_clip_text_in_database(&database, "shot", "nope")
+            .await
+            .unwrap_err()
+            .contains("Image clips cannot be edited"));
+        assert!(update_clip_text_in_database(&database, "missing", "nope")
+            .await
+            .is_err());
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -459,6 +459,7 @@ pub fn run_app() {
             commands::copy_ocr_text,
             commands::delete_clip,
             commands::toggle_clip_pin,
+            commands::update_clip_text,
             commands::move_to_folder,
             commands::create_folder,
             commands::rename_folder,


### PR DESCRIPTION
Closes SBS-587. Part of the OmniClip epic (SBS-581).

Copy, fix a typo, paste previously meant pasting first and editing at the destination, because a clip's text was immutable once captured.

`update_clip_text` re-encrypts the new text, rewrites the preview, and re-derives `content_hash` from it. Images are refused.

## The dedup question the issue left open

Whether an edited clip dedupes against existing clips or is always distinct — **the hash follows the content**, exactly as for any other clip. Re-copying that text later matches this row instead of adding a third.

A collision with an unrelated clip that happens to hold the same text is **allowed rather than rejected**. Refusing someone's edit because of a row they were not thinking about would be the more surprising behavior, and `content_hash` is deliberately non-unique already (see AGENTS.md).

## The subtler part: stale rich formats

A clip captured as html/rtf keeps those bytes alongside the plain text, and **they describe the pre-edit wording**. Left in place they would be restored by anything that prefers a rich format — so you would edit the clip, paste it into Word, and get the old text back. The edit would look like it had silently failed.

Editing therefore drops the extra formats and the clip becomes plain text, which is what was actually edited. That is also why the new hash is computed over no extra formats: it has to describe what the clip now *is*.

## Two more things that would have gone stale

- **The search index** holds the pre-edit text, so search would keep matching words the clip no longer contains. It is updated on save.
- **Capture dedup** remembers the old content, so re-copying the original text would be swallowed as a duplicate of what the row used to hold. It is reset.

## UI

Edit / Save / Cancel in the History window preview pane. It edits the **full text**, not the row's truncated preview, so saving cannot silently chop a long clip — the button waits for the full payload to load. An unsaved draft is abandoned when the selection moves rather than following onto a different clip and being saved there.

## Testing

130 Rust tests, `tsc`, `vite build`, `cargo clippy`, `cargo fmt` — all clean. New coverage for the text, preview, and hash all being rewritten together; stale rich formats being dropped; search following the edit rather than the original wording; and images and unknown ids being refused.

Not driven in a live build — the backend is covered end to end by tests; the pane wiring is verified by typecheck.