### PR TITLE
Notes on a clip

### DIFF
--- a/frontend/src/components/ClipCard.tsx
+++ b/frontend/src/components/ClipCard.tsx
@@ -1,7 +1,15 @@
 import { ClipboardItem } from '../types';
 import { clsx } from 'clsx';
 import { memo, useMemo } from 'react';
-import { Clock, Copy, File, Image as ImageIcon, MoreHorizontal, Pin } from 'lucide-react';
+import {
+  Clock,
+  Copy,
+  File,
+  Image as ImageIcon,
+  MoreHorizontal,
+  Pin,
+  StickyNote,
+} from 'lucide-react';
 import { formatDistanceToNowStrict } from 'date-fns';
 import { PREVIEW_CHAR_LIMIT } from '../constants';
 import { useTimeTick } from '../hooks/useTimeTick';
@@ -274,6 +282,16 @@ export const ClipCard = memo(function ClipCard({
             >
               {preview.slice(0, PREVIEW_CHAR_LIMIT)}
             </p>
+            {clip.notes && (
+              <p
+                data-el="clip-note"
+                className="mt-1 flex min-w-0 items-center gap-1 text-[11px] text-primary/85"
+                title={clip.notes}
+              >
+                <StickyNote size={10} className="shrink-0" />
+                <span className="truncate">{clip.notes}</span>
+              </p>
+            )}
             <div className="mt-1.5 flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
               {clip.is_pinned && (
                 <>

--- a/frontend/src/components/ClipCard.tsx
+++ b/frontend/src/components/ClipCard.tsx
@@ -282,7 +282,10 @@ export const ClipCard = memo(function ClipCard({
             >
               {preview.slice(0, PREVIEW_CHAR_LIMIT)}
             </p>
-            {clip.notes && (
+            {/* Explicit emptiness check: a note of "0" is a real note, and a
+                truthiness test would drop it while search and the title still
+                treated it as present. */}
+            {clip.notes != null && clip.notes !== '' && (
               <p
                 data-el="clip-note"
                 className="mt-1 flex min-w-0 items-center gap-1 text-[11px] text-primary/85"

--- a/frontend/src/components/ClipPreview.tsx
+++ b/frontend/src/components/ClipPreview.tsx
@@ -86,6 +86,10 @@ export function ClipPreview({
   const [saving, setSaving] = useState(false);
   // Local working copy of the note so typing stays responsive; saved on blur.
   const [noteDraft, setNoteDraft] = useState('');
+  // Set synchronously by Escape so the blur it triggers can tell a cancel from
+  // an ordinary focus loss. A ref, not state, because blur runs before a
+  // re-render would deliver the new value.
+  const noteCancelled = useRef(false);
   const [details, setDetails] = useState<ClipDetails | null>(null);
   const [detailsError, setDetailsError] = useState<string | null>(null);
   const clipId = clip?.id ?? null;
@@ -147,6 +151,7 @@ export function ClipPreview({
   // Follow the selection rather than the keystrokes, so switching clips shows
   // the new clip's note instead of carrying the previous one across.
   useEffect(() => {
+    noteCancelled.current = false;
     setNoteDraft(clip?.notes ?? '');
   }, [clipId, clip?.notes]);
 
@@ -343,6 +348,14 @@ export function ClipPreview({
             value={noteDraft}
             onChange={(event) => setNoteDraft(event.target.value)}
             onBlur={() => {
+              // Escape blurs to commit the cancel, so the revert has to happen
+              // here: setNoteDraft has not been applied by the time this runs,
+              // and noteDraft still holds the text the user asked to discard.
+              if (noteCancelled.current) {
+                noteCancelled.current = false;
+                setNoteDraft(clip.notes ?? '');
+                return;
+              }
               const next = noteDraft.trim();
               if (next !== (clip.notes ?? '')) void onSaveNotes(clip.id, next);
             }}
@@ -350,7 +363,7 @@ export function ClipPreview({
               if (event.key === 'Enter') event.currentTarget.blur();
               if (event.key === 'Escape') {
                 event.stopPropagation();
-                setNoteDraft(clip.notes ?? '');
+                noteCancelled.current = true;
                 event.currentTarget.blur();
               }
             }}

--- a/frontend/src/components/ClipPreview.tsx
+++ b/frontend/src/components/ClipPreview.tsx
@@ -415,6 +415,11 @@ export function ClipPreview({
               if (next !== (clip.notes ?? '')) void onSaveNotes(clip.id, next);
             }}
             onKeyDown={(event) => {
+              // While an IME is composing, Enter and Escape belong to the
+              // candidate window, not to this field: Enter accepts a candidate
+              // and Escape abandons one. Acting on either would commit or
+              // discard a note the user is still in the middle of typing.
+              if (event.nativeEvent.isComposing) return;
               if (event.key === 'Enter') event.currentTarget.blur();
               if (event.key === 'Escape') {
                 event.stopPropagation();

--- a/frontend/src/components/ClipPreview.tsx
+++ b/frontend/src/components/ClipPreview.tsx
@@ -15,6 +15,7 @@ import {
   Type,
 } from 'lucide-react';
 import { ClipboardItem } from '../types';
+import { NOTE_CHAR_LIMIT } from '../constants';
 import { ImageTextViewer } from './ImageTextViewer';
 import { OcrLayout } from '../utils/ocrSelection';
 import {
@@ -367,6 +368,7 @@ export function ClipPreview({
                 event.currentTarget.blur();
               }
             }}
+            maxLength={NOTE_CHAR_LIMIT}
             placeholder="Add a note to find this later"
             aria-label="Note"
             className="min-w-0 flex-1 border-b border-transparent bg-transparent pb-0.5 text-[11px] text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-primary/45"

--- a/frontend/src/components/ClipPreview.tsx
+++ b/frontend/src/components/ClipPreview.tsx
@@ -10,6 +10,7 @@ import {
   Pencil,
   Pin,
   ScanText,
+  StickyNote,
   Trash2,
   Type,
 } from 'lucide-react';
@@ -48,6 +49,8 @@ interface ClipPreviewProps {
   onCopyText: (text: string) => void;
   /** Save edited text back to the clip. Text clips only. */
   onSaveText: (clipId: string, text: string) => Promise<void>;
+  /** Save (or clear, when empty) the clip's note. */
+  onSaveNotes: (clipId: string, notes: string) => Promise<void>;
   onTogglePin: (clipId: string) => void;
   onDelete: (clipId: string) => void;
 }
@@ -71,6 +74,7 @@ export function ClipPreview({
   onRescanOcr,
   onCopyText,
   onSaveText,
+  onSaveNotes,
   onTogglePin,
   onDelete,
 }: ClipPreviewProps) {
@@ -80,6 +84,8 @@ export function ClipPreview({
   const [scanDraft, setScanDraft] = useState<string | null>(null);
   const [scanBusy, setScanBusy] = useState(false);
   const [saving, setSaving] = useState(false);
+  // Local working copy of the note so typing stays responsive; saved on blur.
+  const [noteDraft, setNoteDraft] = useState('');
   const [details, setDetails] = useState<ClipDetails | null>(null);
   const [detailsError, setDetailsError] = useState<string | null>(null);
   const clipId = clip?.id ?? null;
@@ -138,6 +144,11 @@ export function ClipPreview({
   useEffect(() => {
     setScanDraft(null);
   }, [clipId]);
+  // Follow the selection rather than the keystrokes, so switching clips shows
+  // the new clip's note instead of carrying the previous one across.
+  useEffect(() => {
+    setNoteDraft(clip?.notes ?? '');
+  }, [clipId, clip?.notes]);
 
   const isImage = clip?.clip_type === 'image';
   const imageMetadata = useMemo(() => parseImageMetadata(clip?.metadata), [clip?.metadata]);
@@ -324,6 +335,31 @@ export function ClipPreview({
           )}
         </div>
       )}
+
+      <div className="shrink-0 border-t border-white/[0.07] px-4 py-3">
+        <label className="flex items-center gap-2">
+          <StickyNote size={12} className="shrink-0 text-muted-foreground" />
+          <input
+            value={noteDraft}
+            onChange={(event) => setNoteDraft(event.target.value)}
+            onBlur={() => {
+              const next = noteDraft.trim();
+              if (next !== (clip.notes ?? '')) void onSaveNotes(clip.id, next);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') event.currentTarget.blur();
+              if (event.key === 'Escape') {
+                event.stopPropagation();
+                setNoteDraft(clip.notes ?? '');
+                event.currentTarget.blur();
+              }
+            }}
+            placeholder="Add a note to find this later"
+            aria-label="Note"
+            className="min-w-0 flex-1 border-b border-transparent bg-transparent pb-0.5 text-[11px] text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-primary/45"
+          />
+        </label>
+      </div>
 
       <div className="shrink-0 space-y-1 border-t border-white/[0.07] px-4 py-3">
         <MetaRow label="Source" value={label} />

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -9,3 +9,11 @@ export const LAYOUT = {
 };
 
 export const PREVIEW_CHAR_LIMIT = 420;
+
+/**
+ * Cap on a clip note. A note is a short reminder of what a clip is, so this is
+ * generous for that job while stopping an accidental paste of a whole document
+ * from being encrypted into the column and trigram-indexed. Mirrored in
+ * `set_clip_notes_in_database`, which enforces it for non-UI callers too.
+ */
+export const NOTE_CHAR_LIMIT = 500;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -17,6 +17,9 @@ export interface ClipboardItem {
   // Retention dropped this image's full-resolution blob but kept its thumbnail
   // and OCR text (SOU-244). It stays searchable; the full image can't be pasted.
   image_expired?: boolean;
+  // A note the user attached to this clip (SOU-588). Searchable, and shown on
+  // the row so a clip with no memorable text can still be recognized.
+  notes?: string | null;
 }
 
 export interface OcrMatch {

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -433,6 +433,19 @@ export function HistoryWindow() {
     },
     [loadClips]
   );
+  const handleSaveNotes = useCallback(async (clipId: string, notes: string) => {
+    try {
+      await invoke('set_clip_notes', { id: clipId, notes });
+      // Cheap local update so the row's note appears immediately; a note also
+      // changes what search matches, but not the current result set.
+      setClips((current) =>
+        current.map((clip) => (clip.id === clipId ? { ...clip, notes: notes || null } : clip))
+      );
+    } catch (error) {
+      console.error('Failed to save the note:', error);
+      toast.error('Failed to save the note');
+    }
+  }, []);
 
   const handleSaveOcrText = useCallback(async (clipId: string, text: string) => {
     try {
@@ -853,6 +866,7 @@ export function HistoryWindow() {
             onRescanOcr={handleRescanOcr}
             onCopyText={handleCopySelection}
             onSaveText={handleSaveText}
+            onSaveNotes={handleSaveNotes}
             onTogglePin={handleTogglePin}
             onDelete={handleDelete}
           />

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -34,6 +34,7 @@ fn clip_to_list_item(clip: &Clip) -> ClipboardItem {
         ocr_match: None,
         ocr_highlights: None,
         image_expired: clip.full_image_expired,
+        notes: clip.notes.clone(),
     }
 }
 
@@ -318,6 +319,10 @@ fn decrypt_clip_fields(db: &Database, clip: &mut Clip) -> Result<(), String> {
         .is_err()
     {
         clip.ocr_words = None;
+    }
+    // A note is auxiliary too: an unreadable one must not stop the clip loading.
+    if db.crypto.decrypt_optional_text(&mut clip.notes).is_err() {
+        clip.notes = None;
     }
     Ok(())
 }
@@ -1514,6 +1519,42 @@ fn truncate_preview(text: &str) -> String {
     text.chars().take(PREVIEW_LIMIT).collect()
 }
 
+/// Attach or clear a clip's note (SOU-588). An empty note clears the field
+/// rather than storing a blank string, so "has a note" stays a real distinction.
+#[tauri::command]
+pub async fn set_clip_notes(
+    id: String,
+    notes: String,
+    db: tauri::State<'_, Arc<Database>>,
+) -> Result<(), String> {
+    set_clip_notes_in_database(db.inner(), &id, &notes).await
+}
+
+async fn set_clip_notes_in_database(db: &Database, id: &str, notes: &str) -> Result<(), String> {
+    let trimmed = notes.trim();
+    let stored = if trimmed.is_empty() {
+        None
+    } else {
+        db.crypto.encrypt_optional_text(Some(trimmed))?
+    };
+
+    let affected = sqlx::query("UPDATE clips SET notes = ? WHERE uuid = ?")
+        .bind(&stored)
+        .bind(id)
+        .execute(&db.pool)
+        .await
+        .map_err(|e| e.to_string())?
+        .rows_affected();
+    if affected == 0 {
+        return Err(format!("Clip {id} not found"));
+    }
+
+    // Notes are searchable, so the index has to learn about them the moment they
+    // change — otherwise a note would only become findable after a rebuild.
+    db.search_index.update_notes(id, trimmed);
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn move_to_folder(
     clip_id: String,
@@ -2585,8 +2626,9 @@ mod tests {
         directory_size_bytes, enforce_retention_in_pool, get_clip_details_in_database,
         get_clips_in_database, load_recognized_text, migrate_clip_format_model,
         migrate_encrypted_storage, ocr_text_layout, remove_clip_image_files, restore_hash_material,
-        search_clips_in_database, set_clip_ocr_text_in_database, toggle_clip_pin_in_pool,
-        update_clip_text_in_database, ClipboardContent, OCR_SNIPPET_CHAR_LIMIT,
+        search_clips_in_database, set_clip_notes_in_database, set_clip_ocr_text_in_database,
+        toggle_clip_pin_in_pool, update_clip_text_in_database, ClipboardContent,
+        OCR_SNIPPET_CHAR_LIMIT,
     };
     use crate::clipboard::CapturedFormat;
     use crate::database::Database;
@@ -2992,6 +3034,82 @@ mod tests {
             .unwrap_err()
             .contains("image clips"));
         assert!(set_clip_ocr_text_in_database(&database, "missing", "nope")
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn a_note_is_stored_encrypted_and_makes_its_clip_findable() {
+        let database = test_database().await;
+        insert_search_clip(
+            &database,
+            SearchFixture::text(
+                "uuid-clip",
+                "9f2c1b7e-40aa-4f11-b0d2-77c9e1f00a31",
+                "2026-06-01 09:00:00",
+            ),
+        )
+        .await;
+        database
+            .search_index
+            .ensure_ready(&database.pool, &database.crypto)
+            .await
+            .unwrap();
+
+        // The whole point: a clip with no memorable text becomes findable by
+        // what the user called it.
+        assert!(database.search_index.matches("staging api key").is_empty());
+        set_clip_notes_in_database(&database, "uuid-clip", "  staging api key  ")
+            .await
+            .unwrap();
+        assert!(database
+            .search_index
+            .matches("staging api key")
+            .contains("uuid-clip"));
+
+        let found = search_clips_in_database(
+            "staging api".into(),
+            None,
+            10,
+            0,
+            None,
+            None,
+            None,
+            None,
+            &database,
+        )
+        .await
+        .unwrap();
+        assert_eq!(found.len(), 1);
+        // Trimmed on the way in, and handed back for the row to show.
+        assert_eq!(found[0].notes.as_deref(), Some("staging api key"));
+
+        // Stored encrypted, like every other clip field.
+        let raw: Option<String> = sqlx::query_scalar("SELECT notes FROM clips WHERE uuid = ?")
+            .bind("uuid-clip")
+            .fetch_one(&database.pool)
+            .await
+            .unwrap();
+        let raw = raw.expect("a note should be stored");
+        assert!(
+            !raw.contains("staging"),
+            "the note must not sit in the clear"
+        );
+
+        // Clearing removes it rather than storing a blank, so "has a note"
+        // stays a real distinction.
+        set_clip_notes_in_database(&database, "uuid-clip", "   ")
+            .await
+            .unwrap();
+        let cleared: Option<String> = sqlx::query_scalar("SELECT notes FROM clips WHERE uuid = ?")
+            .bind("uuid-clip")
+            .fetch_one(&database.pool)
+            .await
+            .unwrap();
+        assert!(cleared.is_none());
+        assert!(database.search_index.matches("staging api key").is_empty());
+
+        assert!(set_clip_notes_in_database(&database, "missing", "x")
             .await
             .is_err());
     }
@@ -3549,6 +3667,7 @@ mod tests {
             ocr_text: None,
             ocr_words: None,
             full_image_expired: false,
+            notes: None,
             created_at: chrono::Utc::now(),
             last_accessed: chrono::Utc::now(),
         };

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -174,6 +174,12 @@ fn build_ocr_highlights(ocr_words_json: &str, query: &str) -> Option<OcrHighligh
 
 const OCR_SNIPPET_CHAR_LIMIT: usize = 96;
 
+/// Cap on a clip note, mirroring `NOTE_CHAR_LIMIT` in the frontend constants.
+/// A note is a short reminder of what a clip is, so this is generous for that
+/// job while keeping an accidental paste of a whole document out of the
+/// encrypted column and the trigram index.
+const NOTE_CHAR_LIMIT: usize = 500;
+
 /// Returned when a clip's full-resolution image was dropped by retention
 /// (SOU-244). Surfaced to the user when they try to paste/copy the full image.
 pub(crate) const IMAGE_EXPIRED_ERROR: &str =
@@ -321,7 +327,11 @@ fn decrypt_clip_fields(db: &Database, clip: &mut Clip) -> Result<(), String> {
         clip.ocr_words = None;
     }
     // A note is auxiliary too: an unreadable one must not stop the clip loading.
-    if db.crypto.decrypt_optional_text(&mut clip.notes).is_err() {
+    // Logged rather than silently dropped — the note vanishes from the UI either
+    // way, and the log is the only signal that something was there to lose.
+    // Matches how the search index reports the same failure.
+    if let Err(error) = db.crypto.decrypt_optional_text(&mut clip.notes) {
+        log::warn!("CLIPS: Ignoring an unreadable note: {error}");
         clip.notes = None;
     }
     Ok(())
@@ -1532,6 +1542,12 @@ pub async fn set_clip_notes(
 
 async fn set_clip_notes_in_database(db: &Database, id: &str, notes: &str) -> Result<(), String> {
     let trimmed = notes.trim();
+    // The input carries maxLength, so this is the guard for anything that is not
+    // that input. Counted in chars, not bytes, so the limit means the same thing
+    // for a note that is not ASCII.
+    if trimmed.chars().count() > NOTE_CHAR_LIMIT {
+        return Err(format!("A note is limited to {NOTE_CHAR_LIMIT} characters"));
+    }
     let stored = if trimmed.is_empty() {
         None
     } else {
@@ -2627,7 +2643,7 @@ mod tests {
         get_clips_in_database, load_recognized_text, migrate_clip_format_model,
         migrate_encrypted_storage, ocr_text_layout, remove_clip_image_files, restore_hash_material,
         search_clips_in_database, set_clip_notes_in_database, set_clip_ocr_text_in_database,
-        toggle_clip_pin_in_pool, update_clip_text_in_database, ClipboardContent,
+        toggle_clip_pin_in_pool, update_clip_text_in_database, ClipboardContent, NOTE_CHAR_LIMIT,
         OCR_SNIPPET_CHAR_LIMIT,
     };
     use crate::clipboard::CapturedFormat;
@@ -3112,6 +3128,27 @@ mod tests {
         assert!(set_clip_notes_in_database(&database, "missing", "x")
             .await
             .is_err());
+
+        // Bounded for callers that are not the capped input. Counted in chars,
+        // so a multi-byte note is measured the same way as an ASCII one.
+        assert!(
+            set_clip_notes_in_database(&database, "uuid-clip", &"a".repeat(NOTE_CHAR_LIMIT))
+                .await
+                .is_ok(),
+            "a note at the limit should be accepted"
+        );
+        assert!(
+            set_clip_notes_in_database(&database, "uuid-clip", &"a".repeat(NOTE_CHAR_LIMIT + 1))
+                .await
+                .is_err(),
+            "a note past the limit should be refused"
+        );
+        assert!(
+            set_clip_notes_in_database(&database, "uuid-clip", &"é".repeat(NOTE_CHAR_LIMIT))
+                .await
+                .is_ok(),
+            "the limit counts characters, not bytes"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -201,6 +201,12 @@ impl Database {
         )
         .await?;
 
+        // A user-written note attached to a clip (SOU-588), so something with no
+        // memorable text — a UUID, half an address — can still be found later.
+        // Encrypted at rest like every other clip field, and NULL for every row
+        // that predates the column.
+        add_column_if_missing(&self.pool, "ALTER TABLE clips ADD COLUMN notes TEXT").await?;
+
         // Existing images without OCR become durable background work. A process
         // that exited while a job was running leaves it as `processing`; reset
         // those jobs so the next launch can recover them.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -461,6 +461,7 @@ pub fn run_app() {
             commands::toggle_clip_pin,
             commands::set_clip_ocr_text,
             commands::update_clip_text,
+            commands::set_clip_notes,
             commands::move_to_folder,
             commands::create_folder,
             commands::rename_folder,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -113,6 +113,9 @@ pub struct Clip {
     // True once retention has dropped this image clip's full-resolution blob but
     // kept its thumbnail + ocr_text (SOU-244). Only ever set for `image` clips.
     pub full_image_expired: bool,
+    // A note the user attached to this clip (SOU-588). Encrypted at rest like
+    // the rest of the clip; None for rows written before the column existed.
+    pub notes: Option<String>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub last_accessed: chrono::DateTime<chrono::Utc>,
 }
@@ -136,6 +139,7 @@ impl<'r> FromRow<'r, SqliteRow> for Clip {
             ocr_text: row.try_get("ocr_text")?,
             ocr_words: row.try_get("ocr_words")?,
             full_image_expired: row.try_get("full_image_expired")?,
+            notes: row.try_get("notes")?,
             created_at: row.try_get("created_at")?,
             last_accessed: row.try_get("last_accessed")?,
         })
@@ -203,6 +207,9 @@ pub struct ClipboardItem {
     // its thumbnail + OCR text were kept (SOU-244). The UI marks it and stops
     // offering the full image for paste/copy.
     pub image_expired: bool,
+    // The user's note for this clip (SOU-588), shown on the row so it can be
+    // recognized without opening it.
+    pub notes: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src-tauri/src/search_index.rs
+++ b/src-tauri/src/search_index.rs
@@ -13,6 +13,7 @@ type IndexedClipRow = (
     String,
     Option<String>,
     Option<String>,
+    Option<String>,
 );
 
 #[derive(Clone, Debug, Default)]
@@ -20,6 +21,9 @@ struct SearchDocument {
     content: String,
     preview: String,
     ocr: String,
+    /// The user's note for this clip (SOU-588). Searchable alongside the
+    /// content and OCR text, which is the point of writing one.
+    notes: String,
     /// Source app exactly as captured, for the History window's per-app filter
     /// and counts. `source_app` is encrypted with a random nonce, so SQL can
     /// neither group nor filter on it; this index already holds the decrypted
@@ -33,11 +37,18 @@ struct SearchDocument {
 }
 
 impl SearchDocument {
-    fn new(content: &str, preview: &str, ocr: Option<&str>, source_app: Option<&str>) -> Self {
+    fn new(
+        content: &str,
+        preview: &str,
+        ocr: Option<&str>,
+        notes: Option<&str>,
+        source_app: Option<&str>,
+    ) -> Self {
         Self {
             content: normalize(content),
             preview: normalize(preview),
             ocr: normalize(ocr.unwrap_or_default()),
+            notes: normalize(notes.unwrap_or_default()),
             source_app: source_app
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
@@ -46,11 +57,14 @@ impl SearchDocument {
     }
 
     fn contains(&self, query: &str) -> bool {
-        self.content.contains(query) || self.preview.contains(query) || self.ocr.contains(query)
+        self.content.contains(query)
+            || self.preview.contains(query)
+            || self.ocr.contains(query)
+            || self.notes.contains(query)
     }
 
     fn trigrams(&self) -> HashSet<String> {
-        [&self.content, &self.preview, &self.ocr]
+        [&self.content, &self.preview, &self.ocr, &self.notes]
             .into_iter()
             .flat_map(|field| trigrams(field))
             .collect()
@@ -155,6 +169,7 @@ impl SearchIndex {
                        CASE WHEN clip_type = 'image' THEN x'' ELSE content END,
                        text_preview,
                        ocr_text,
+                       notes,
                        source_app
                 FROM clips
                 WHERE is_deleted = 0
@@ -170,6 +185,7 @@ impl SearchIndex {
                 encrypted_content,
                 encrypted_preview,
                 encrypted_ocr,
+                encrypted_notes,
                 encrypted_source_app,
             ) in clips
             {
@@ -185,6 +201,12 @@ impl SearchIndex {
                         .map_err(|error| {
                             log::warn!("SEARCH: Ignoring unreadable auxiliary OCR text: {error}")
                         })
+                        .ok()
+                });
+                let notes = encrypted_notes.as_deref().and_then(|value| {
+                    crypto
+                        .decrypt_text(value)
+                        .map_err(|error| log::warn!("SEARCH: Ignoring an unreadable note: {error}"))
                         .ok()
                 });
                 // Like OCR text, the source app is auxiliary: an unreadable one
@@ -208,6 +230,7 @@ impl SearchIndex {
                         &searchable_content,
                         &preview,
                         ocr.as_deref(),
+                        notes.as_deref(),
                         source_app.as_deref(),
                     ),
                 );
@@ -295,14 +318,29 @@ impl SearchIndex {
             } else {
                 String::new()
             };
-            let mut document = SearchDocument::new(&searchable_content, preview, ocr, source_app);
+            let mut document =
+                SearchDocument::new(&searchable_content, preview, ocr, None, source_app);
             if ocr.is_none() {
                 document.ocr = existing.ocr;
             }
+            // Notes are only ever written through update_notes, so an upsert
+            // from a re-capture must not silently drop one.
+            document.notes = existing.notes;
             if source_app.is_none() {
                 document.source_app = existing.source_app;
             }
             state.insert(id.to_string(), document);
+        }
+    }
+
+    /// Replace a clip's note text in the index.
+    pub fn update_notes(&self, id: &str, notes: &str) {
+        self.generation.fetch_add(1, Ordering::AcqRel);
+        if let Some(state) = self.state.write().as_mut() {
+            if let Some(mut document) = state.documents.get(id).cloned() {
+                document.notes = normalize(notes);
+                state.insert(id.to_string(), document);
+            }
         }
     }
 
@@ -350,11 +388,11 @@ mod tests {
         let mut state = IndexState::default();
         state.insert(
             "one".to_string(),
-            SearchDocument::new("Release confirmation 4J7K", "", None, None),
+            SearchDocument::new("Release confirmation 4J7K", "", None, None, None),
         );
         state.insert(
             "two".to_string(),
-            SearchDocument::new("unrelated", "", None, None),
+            SearchDocument::new("unrelated", "", None, None, None),
         );
 
         assert_eq!(


### PR DESCRIPTION
Closes SBS-588. Part of the OmniClip epic (SBS-581).

A clip with no memorable text — a UUID, half an address — was hard to identify weeks later, because the only context a clip carried was its content and source app.

## What it does

A `notes` column added via the existing `add_column_if_missing` pattern, NULL for every pre-migration row. Encrypted at rest like the rest of the clip, and decrypted on the same **auxiliary** path as OCR text: an unreadable note is dropped rather than being allowed to block the clip from loading.

## Searchable, which is the point

Notes join content, preview, and OCR text in **both** the trigram postings and the containment check. `set_clip_notes` updates the index directly — otherwise a note would only become findable after a full rebuild, which is a long time to wait for the thing you just wrote.

The `upsert` path preserves an existing note, so a re-capture of the same clip cannot silently discard one.

## Small decisions

- An empty note **clears** the column rather than storing a blank string, so "has a note" stays a real distinction.
- Input is trimmed on the way in.
- The field commits on blur, and Escape reverts rather than saving a half-typed note.

## UI

An inline field in the History window preview pane, and the note on the row itself so a clip can be recognized without opening it.

## Testing

129 Rust tests, `tsc`, `vite build`, `cargo clippy`, `cargo fmt` — all clean. New coverage for a note making an otherwise unfindable clip searchable end to end, the stored column **not holding the note in the clear**, trimming, clearing removing both the column value and the index entry, and an unknown id being refused.

Not driven in a live build; the pane and row wiring is verified by typecheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added editable notes to clipboard items.
  * Notes appear beneath text clip previews, with truncated text and full-note tooltips.
  * Notes are encrypted and preserved securely.
  * Notes are searchable alongside clip content.
  * Notes save on leaving the field, with Enter and Escape keyboard controls.

* **Bug Fixes**
  * Added clear error feedback when saving notes fails.
  * Existing clips remain compatible through the storage update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->