### PR TITLE
On-demand Scan Text with an editable correction box

### DIFF
--- a/frontend/src/components/ClipPreview.tsx
+++ b/frontend/src/components/ClipPreview.tsx
@@ -2,7 +2,17 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { clsx } from 'clsx';
 import { format } from 'date-fns';
-import { Check, Clock, Copy, ExternalLink, Pencil, Pin, Trash2, Type } from 'lucide-react';
+import {
+  Check,
+  Clock,
+  Copy,
+  ExternalLink,
+  Pencil,
+  Pin,
+  ScanText,
+  Trash2,
+  Type,
+} from 'lucide-react';
 import { ClipboardItem } from '../types';
 import { ImageTextViewer } from './ImageTextViewer';
 import { OcrLayout } from '../utils/ocrSelection';
@@ -30,6 +40,12 @@ interface ClipPreviewProps {
   onCopySelection: (text: string) => void;
   /** Pops the image out into its own full-size window. */
   onOpenImage: (clipId: string) => void;
+  /** Save a corrected reading of an image's recognized text. */
+  onSaveOcrText: (clipId: string, text: string) => Promise<void>;
+  /** Queue another OCR pass for an image that has no recognized text yet. */
+  onRescanOcr: (clipId: string) => Promise<void>;
+  /** Copy arbitrary text — used for the corrected reading. */
+  onCopyText: (text: string) => void;
   /** Save edited text back to the clip. Text clips only. */
   onSaveText: (clipId: string, text: string) => Promise<void>;
   onTogglePin: (clipId: string) => void;
@@ -51,12 +67,18 @@ export function ClipPreview({
   onCopyOcrText,
   onCopySelection,
   onOpenImage,
+  onSaveOcrText,
+  onRescanOcr,
+  onCopyText,
   onSaveText,
   onTogglePin,
   onDelete,
 }: ClipPreviewProps) {
   // Null when not editing; otherwise the working copy of the text.
   const [draft, setDraft] = useState<string | null>(null);
+  // Working copy of the recognized text while the scan panel is open.
+  const [scanDraft, setScanDraft] = useState<string | null>(null);
+  const [scanBusy, setScanBusy] = useState(false);
   const [saving, setSaving] = useState(false);
   const [details, setDetails] = useState<ClipDetails | null>(null);
   const [detailsError, setDetailsError] = useState<string | null>(null);
@@ -107,6 +129,14 @@ export function ClipPreview({
   // draft onto a different clip and saving it there would be destructive.
   useEffect(() => {
     setDraft(null);
+    // A correction typed for one image must never be saved onto another.
+    setScanDraft(null);
+  }, [clipId]);
+
+  // Close the panel when the selection moves; a correction typed for one image
+  // must never be saved onto another.
+  useEffect(() => {
+    setScanDraft(null);
   }, [clipId]);
 
   const isImage = clip?.clip_type === 'image';
@@ -179,15 +209,79 @@ export function ClipPreview({
               The full image expired by retention. Its recognized text was kept.
             </p>
           )}
-          {details?.ocr_text && (
-            <details className="mt-2 shrink-0 border-t border-white/[0.07] pt-2">
-              <summary className="cursor-pointer text-[11px] text-muted-foreground">
-                All recognized text
-              </summary>
-              <pre className="mt-1.5 max-h-28 overflow-y-auto whitespace-pre-wrap break-words text-[12px] leading-[18px] text-foreground/80">
-                {details.ocr_text}
-              </pre>
-            </details>
+          {scanDraft !== null ? (
+            <div className="mt-2 shrink-0 border-t border-white/[0.07] pt-2">
+              <p className="mb-1.5 text-[11px] text-muted-foreground">
+                Recognized text — fix anything misread, then copy or save.
+              </p>
+              <textarea
+                value={scanDraft}
+                onChange={(event) => setScanDraft(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Escape') {
+                    event.stopPropagation();
+                    setScanDraft(null);
+                  }
+                }}
+                className="h-24 w-full resize-none rounded-md border border-primary/45 bg-black/20 p-2 text-[12px] leading-[18px] text-foreground outline-none"
+              />
+              <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                <button
+                  type="button"
+                  className={actionClass}
+                  onClick={() => onCopyText(scanDraft)}
+                  disabled={scanDraft.trim().length === 0}
+                >
+                  <Copy size={13} />
+                  Copy this text
+                </button>
+                <button
+                  type="button"
+                  className={actionClass}
+                  disabled={scanBusy || scanDraft === (details?.ocr_text ?? '')}
+                  onClick={async () => {
+                    setScanBusy(true);
+                    try {
+                      await onSaveOcrText(clip.id, scanDraft);
+                      setScanDraft(null);
+                    } finally {
+                      setScanBusy(false);
+                    }
+                  }}
+                  title="Also fixes what search matches for this image"
+                >
+                  <Check size={13} />
+                  {scanBusy ? 'Saving…' : 'Save correction'}
+                </button>
+                <button type="button" className={actionClass} onClick={() => setScanDraft(null)}>
+                  Close
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="mt-2 shrink-0 border-t border-white/[0.07] pt-2">
+              <button
+                type="button"
+                className={actionClass}
+                disabled={scanBusy}
+                onClick={async () => {
+                  if (details?.ocr_text) {
+                    setScanDraft(details.ocr_text);
+                    return;
+                  }
+                  // Nothing recognized yet: ask the queue for another pass.
+                  setScanBusy(true);
+                  try {
+                    await onRescanOcr(clip.id);
+                  } finally {
+                    setScanBusy(false);
+                  }
+                }}
+              >
+                <ScanText size={13} />
+                {details?.ocr_text ? 'Scan text' : scanBusy ? 'Scanning…' : 'Scan text'}
+              </button>
+            </div>
           )}
           {detailsError && (
             <p className="shrink-0 pt-2 text-[11px] text-destructive">

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -434,6 +434,33 @@ export function HistoryWindow() {
     [loadClips]
   );
 
+  const handleSaveOcrText = useCallback(async (clipId: string, text: string) => {
+    try {
+      await invoke('set_clip_ocr_text', { id: clipId, text });
+      // Mark the row as having recognized text so the pane refetches and the
+      // "paste text" affordances appear.
+      setClips((current) =>
+        current.map((clip) =>
+          clip.id === clipId ? { ...clip, has_ocr_text: text.trim().length > 0 } : clip
+        )
+      );
+      toast.success('Recognized text updated');
+    } catch (error) {
+      console.error('Failed to save the recognized text:', error);
+      toast.error('Failed to save the recognized text');
+    }
+  }, []);
+
+  const handleRescanOcr = useCallback(async (clipId: string) => {
+    try {
+      await invoke('rescan_clip_ocr', { id: clipId });
+      toast.info('Scanning this image for text…');
+    } catch (error) {
+      console.error('Failed to queue an OCR scan:', error);
+      toast.error('Could not scan this image');
+    }
+  }, []);
+
   const handleTogglePin = useCallback(async (clipId: string) => {
     try {
       const isPinned = await invoke<boolean>('toggle_clip_pin', { id: clipId });
@@ -822,6 +849,9 @@ export function HistoryWindow() {
             onCopyOcrText={handleCopyOcrText}
             onCopySelection={handleCopySelection}
             onOpenImage={handleOpenImage}
+            onSaveOcrText={handleSaveOcrText}
+            onRescanOcr={handleRescanOcr}
+            onCopyText={handleCopySelection}
             onSaveText={handleSaveText}
             onTogglePin={handleTogglePin}
             onDelete={handleDelete}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1386,6 +1386,58 @@ pub async fn toggle_clip_pin(
     toggle_clip_pin_in_pool(&db.pool, &id).await
 }
 
+/// Save a corrected version of an image's recognized text (SOU-590).
+///
+/// The issue left the call open on whether a correction should be transient or
+/// written back. Written back: if the engine misread a character, the same
+/// misreading is what search has indexed, so a transient fix would leave the
+/// clip permanently unfindable by its real text and give the user no way to
+/// mend that. A correction is worth more to search than to one paste.
+///
+/// The per-word boxes are deliberately left alone. They still describe where
+/// words sit on the image, which is what the selection overlay needs; only the
+/// recognized-text block — what search, Copy text, and Shift+Enter use — is
+/// corrected. Selecting a misread word directly off the image therefore still
+/// yields the original reading.
+#[tauri::command]
+pub async fn set_clip_ocr_text(
+    id: String,
+    text: String,
+    db: tauri::State<'_, Arc<Database>>,
+) -> Result<(), String> {
+    set_clip_ocr_text_in_database(db.inner(), &id, &text).await
+}
+
+async fn set_clip_ocr_text_in_database(db: &Database, id: &str, text: &str) -> Result<(), String> {
+    let clip_type: Option<String> =
+        sqlx::query_scalar("SELECT clip_type FROM clips WHERE uuid = ?")
+            .bind(id)
+            .fetch_optional(&db.pool)
+            .await
+            .map_err(|e| e.to_string())?;
+    if clip_type.as_deref() != Some("image") {
+        return Err("Recognized text belongs to image clips".to_string());
+    }
+
+    let trimmed = text.trim();
+    let stored = if trimmed.is_empty() {
+        None
+    } else {
+        db.crypto.encrypt_optional_text(Some(trimmed))?
+    };
+    // A corrected clip counts as processed: leaving it pending would let the
+    // background worker overwrite the correction on its next pass.
+    sqlx::query("UPDATE clips SET ocr_text = ?, ocr_status = 'completed' WHERE uuid = ?")
+        .bind(&stored)
+        .bind(id)
+        .execute(&db.pool)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    db.search_index.update_ocr(id, trimmed);
+    Ok(())
+}
+
 /// Replace a text clip's content in place (SOU-587), for the copy-fix-paste
 /// workflow that otherwise means pasting first and editing at the destination.
 #[tauri::command]
@@ -2533,8 +2585,8 @@ mod tests {
         directory_size_bytes, enforce_retention_in_pool, get_clip_details_in_database,
         get_clips_in_database, load_recognized_text, migrate_clip_format_model,
         migrate_encrypted_storage, ocr_text_layout, remove_clip_image_files, restore_hash_material,
-        search_clips_in_database, toggle_clip_pin_in_pool, update_clip_text_in_database,
-        ClipboardContent, OCR_SNIPPET_CHAR_LIMIT,
+        search_clips_in_database, set_clip_ocr_text_in_database, toggle_clip_pin_in_pool,
+        update_clip_text_in_database, ClipboardContent, OCR_SNIPPET_CHAR_LIMIT,
     };
     use crate::clipboard::CapturedFormat;
     use crate::database::Database;
@@ -2873,6 +2925,73 @@ mod tests {
             .unwrap_err()
             .contains("Image clips cannot be edited"));
         assert!(update_clip_text_in_database(&database, "missing", "nope")
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn a_corrected_reading_replaces_what_search_indexed() {
+        let database = test_database().await;
+        sqlx::query(
+            "INSERT INTO clips (uuid, clip_type, content, text_preview, content_hash, ocr_text, ocr_status) VALUES ('shot', 'image', ?, ?, 'h', ?, 'completed')",
+        )
+        .bind(database.crypto.encrypt(&[1, 2, 3]).unwrap())
+        .bind(database.crypto.encrypt_text("Screenshot").unwrap())
+        // The engine misread a 1 as an l.
+        .bind(database.crypto.encrypt_text("invoice AKlA9").unwrap())
+        .execute(&database.pool)
+        .await
+        .unwrap();
+        database
+            .search_index
+            .ensure_ready(&database.pool, &database.crypto)
+            .await
+            .unwrap();
+        assert!(database.search_index.matches("AKlA9").contains("shot"));
+
+        set_clip_ocr_text_in_database(&database, "shot", "  invoice AK1A9  ")
+            .await
+            .unwrap();
+
+        // The correction is what search now knows, which is the whole reason
+        // for writing it back rather than keeping it transient.
+        assert!(database.search_index.matches("AK1A9").contains("shot"));
+        assert!(database.search_index.matches("AKlA9").is_empty());
+        assert_eq!(
+            load_recognized_text(&database, "shot").await.unwrap(),
+            "invoice AK1A9"
+        );
+
+        // Marked processed, so the background worker cannot overwrite it.
+        let status: Option<String> =
+            sqlx::query_scalar("SELECT ocr_status FROM clips WHERE uuid = 'shot'")
+                .fetch_one(&database.pool)
+                .await
+                .unwrap();
+        assert_eq!(status.as_deref(), Some("completed"));
+
+        // Not stored in the clear.
+        let raw: Option<String> =
+            sqlx::query_scalar("SELECT ocr_text FROM clips WHERE uuid = 'shot'")
+                .fetch_one(&database.pool)
+                .await
+                .unwrap();
+        assert!(!raw.unwrap().contains("invoice"));
+    }
+
+    #[tokio::test]
+    async fn correcting_recognized_text_refuses_a_non_image() {
+        let database = test_database().await;
+        insert_search_clip(
+            &database,
+            SearchFixture::text("plain", "just text", "2026-06-01 09:00:00"),
+        )
+        .await;
+        assert!(set_clip_ocr_text_in_database(&database, "plain", "nope")
+            .await
+            .unwrap_err()
+            .contains("image clips"));
+        assert!(set_clip_ocr_text_in_database(&database, "missing", "nope")
             .await
             .is_err());
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -459,6 +459,7 @@ pub fn run_app() {
             commands::copy_ocr_text,
             commands::delete_clip,
             commands::toggle_clip_pin,
+            commands::set_clip_ocr_text,
             commands::update_clip_text,
             commands::move_to_folder,
             commands::create_folder,
@@ -498,6 +499,7 @@ pub fn run_app() {
             ocr_queue::get_ocr_queue_status,
             ocr_queue::set_ocr_queue_paused,
             ocr_queue::retry_failed_ocr,
+            ocr_queue::rescan_clip_ocr,
             clipboard::get_clipboard_capture_status,
             shortcuts::get_hotkey_startup_notice
         ])

--- a/src-tauri/src/ocr_queue.rs
+++ b/src-tauri/src/ocr_queue.rs
@@ -270,6 +270,36 @@ pub async fn retry_failed_ocr(db: State<'_, Arc<Database>>) -> Result<u64, Strin
     Ok(result.rows_affected())
 }
 
+/// Queue one image for another OCR pass (SOU-590), for the "Scan text" action
+/// on a clip the automatic pass never reached or gave up on.
+///
+/// Goes through the existing durable queue rather than running the engine
+/// inline: the worker already handles pausing, retries, and the process-exit
+/// recovery that an inline call would sidestep.
+#[tauri::command]
+pub async fn rescan_clip_ocr(id: String, db: State<'_, Arc<Database>>) -> Result<(), String> {
+    let result = sqlx::query(
+        r#"
+        UPDATE clips
+        SET ocr_status = 'pending',
+            ocr_attempts = 0,
+            ocr_next_retry_at = NULL,
+            ocr_error_kind = NULL
+        WHERE uuid = ? AND clip_type = 'image'
+        "#,
+    )
+    .bind(&id)
+    .execute(&db.pool)
+    .await
+    .map_err(|error| error.to_string())?;
+
+    if result.rows_affected() == 0 {
+        return Err("That clip is not an image".to_string());
+    }
+    WORK_AVAILABLE.notify_one();
+    Ok(())
+}
+
 async fn load_paused(pool: &SqlitePool) -> Result<bool, String> {
     let value: Option<String> =
         sqlx::query_scalar("SELECT value FROM settings WHERE key = 'ocr_queue_paused'")


### PR DESCRIPTION
Closes SBS-590. Completes the implementable half of the OmniClip epic (SBS-581).

Cubby already OCRs every captured image and uses the result for search and `Shift+Enter` paste-as-text — but the user never *saw* that text, so a misread character could only be fixed by retyping after pasting.

## The call the issue left open

**Transient correction, or written back to the stored `ocr_text` that search uses? Written back.**

If the engine misread a character, that misreading is exactly what search indexed. A transient fix would leave the clip permanently unfindable by its real text, with no way for the user to mend it. A correction is worth more to search than it is to one paste.

Saving marks the clip `completed`, so the background worker cannot overwrite the correction on a later pass.

## What I left alone, deliberately

**The per-word boxes.** They still describe where words sit on the image, which is what the selection overlay (SBS-582) needs — so only the recognized-text *block* is corrected. Selecting a misread word straight off the image still yields the original reading.

Flagging it because it is a real seam rather than something to discover later. Regenerating boxes from corrected text is not possible without re-running OCR, and dropping them would cost the selection feature entirely.

## Rescan

An image with no recognized text yet gets a rescan instead, queued through the **existing durable OCR queue** rather than run inline — so pausing, retries, and process-exit recovery keep working as they already do. This is a UI surface on what is already computed, per the issue constraint, not a second OCR path.

## Testing

132 Rust tests, `tsc`, `vite build`, `cargo clippy`, `cargo fmt` — all clean. New coverage for a correction replacing what search matches (and the old reading no longer matching), the row being marked completed so the worker cannot clobber it, the text not being stored in the clear, and non-images and unknown ids being refused.

Not driven in a live build; the panel wiring is verified by typecheck.