### PR TITLE
Add delayed clipboard rendering fixtures

### DIFF
--- a/docs/CAPTURE_PROBE_RESULTS.md
+++ b/docs/CAPTURE_PROBE_RESULTS.md
@@ -30,9 +30,9 @@ cargo run --locked --bin clipboard_probe -- --burst 100 --interval-ms 10 --timeo
 ## Remaining proof
 
 - Run the interactive probe during RDP and NinjaOne sessions.
-- Add image and delayed-rendered virtual-file burst fixtures.
 - Verify content remains available after disconnecting or closing the source session.
-- Run the new controlled-contention scenario and record the retry margin.
+- Complete the representative Office/browser/Explorer/terminal/IDE/packaged-app/
+  elevated-target matrix tracked by SBS-408.
 
 ## Automated multi-format fixtures
 
@@ -49,8 +49,8 @@ external path references as durable history.
 scripts/test-clipboard-formats.ps1
 ```
 
-Latest live result on the Windows 11 development machine (2026-07-26): 10
-consecutive runs, 30 fixture payloads observed and verified, zero read failures.
+Latest live result on the Windows 11 development machine (2026-08-09): 10
+consecutive runs, 70 fixture payloads observed and verified, zero read failures.
 Each file-list payload used a new isolated temporary directory containing a
 whitespace-sensitive text file, a Unicode-named binary file, and a folder. All
 targets were validated before cleanup, and no fixture directories remained.
@@ -60,7 +60,13 @@ bounded retry principle
 used by production capture instead of treating the first contended read as data
 loss.
 
-Delayed-rendered virtual files are outside Cubby's stored-history contract.
+The expanded suite adds a real delayed-rendering owner window for Unicode text,
+CF_HTML, RTF, and a 2x2 bitmap. Every run verifies exact text/format bytes and
+exact decoded RGBA pixels. It also advertises `FileGroupDescriptorW` in both a
+virtual-file-only payload and a payload with a Unicode text fallback. Both are
+classified through Cubby's production file-payload policy as intentionally
+ignored: delayed-rendered virtual files are outside Cubby's stored-history
+contract, and their path-like fallback must not become a misleading clip.
 
 ## NinjaOne remote-session validation
 

--- a/docs/CLIPBOARD_RELIABILITY.md
+++ b/docs/CLIPBOARD_RELIABILITY.md
@@ -126,6 +126,16 @@ sleep. The virtual-file fixtures advertise `FileGroupDescriptorW`; their text
 fallback is deliberately not captured because it is normally a path or display
 name for content Cubby cannot retain durably.
 
+Known flake: the `virtual_only` fixture intermittently fails to publish with
+`OSError(1418): Thread does not have a clipboard open`, and the run then times
+out having observed six of seven fixtures. It reproduces at roughly one run in
+fifteen on a busy machine, both before and after the delayed-rendering fixtures
+were added, so a single red run is not by itself a capture regression. See #164
+for the suspected cause -- the delayed writer's
+`WM_RENDERALLFORMATS` handler opening the clipboard on the same thread as an
+in-flight `clipboard_rs` write. Re-run the suite before investigating, and treat
+a repeatable failure or any non-zero `read_failures` as a genuine defect.
+
 This suite proves the local Windows clipboard can materialize supported payloads
 without normalization or format loss and can reject unsupported file payloads
 without confusing them for stored history. Application-specific compatibility
@@ -134,4 +144,7 @@ that Office, browsers, remote clients, or elevated targets have been validated.
 
 Production materialization uses the same bounded retry margin: ten attempts with
 exponential backoff capped at 64 ms, allowing up to 319 ms for a clipboard owner
-or synchronization client to release the clipboard.
+or synchronization client to release the clipboard. The fixture writer takes the
+clipboard on the same terms when it publishes a delayed payload, so probe
+failures reflect capture behavior rather than a writer that gave up sooner than
+production would have.

--- a/docs/CLIPBOARD_RELIABILITY.md
+++ b/docs/CLIPBOARD_RELIABILITY.md
@@ -108,6 +108,11 @@ listener verifies both decoded values and exact bytes:
   whitespace-sensitive text file, a Unicode-named binary file, and a folder
 - Unicode text with an application-defined binary format containing embedded NUL
   and high bytes
+- Delayed-rendered Unicode text with simultaneous CF_HTML and RTF payloads,
+  materialized only when the listener requests each format
+- A delayed-rendered 2x2 bitmap with exact RGBA pixel assertions
+- Virtual-file-only and virtual-file-plus-text-fallback payloads, both classified
+  through the same production policy as intentionally ignored file history
 
 Fixture validation retries transient auxiliary-format read contention with
 bounded exponential backoff. The writer retains each payload long enough for the
@@ -115,10 +120,17 @@ complete retry window, so a retry cannot accidentally validate the next fixture.
 Physical targets stay on disk while the listener verifies their order, names,
 types, and exact bytes, then the writer removes the isolated temporary directory.
 
-This suite proves the local Windows clipboard can materialize those payloads
-without normalization or format loss. Application-specific compatibility still
-belongs in the manual matrix below; passing the fixtures does not claim that
-Office, browsers, remote clients, or elevated targets have been validated.
+The delayed writer owns a hidden Win32 window and responds to `WM_RENDERFORMAT`,
+so those fixtures exercise genuine on-demand rendering rather than a writer-side
+sleep. The virtual-file fixtures advertise `FileGroupDescriptorW`; their text
+fallback is deliberately not captured because it is normally a path or display
+name for content Cubby cannot retain durably.
+
+This suite proves the local Windows clipboard can materialize supported payloads
+without normalization or format loss and can reject unsupported file payloads
+without confusing them for stored history. Application-specific compatibility
+still belongs in the manual matrix below; passing the fixtures does not claim
+that Office, browsers, remote clients, or elevated targets have been validated.
 
 Production materialization uses the same bounded retry margin: ten attempts with
 exponential backoff capped at 64 ms, allowing up to 319 ms for a clipboard owner

--- a/src-tauri/src/bin/clipboard_probe.rs
+++ b/src-tauri/src/bin/clipboard_probe.rs
@@ -5,29 +5,37 @@ fn main() {
 }
 
 #[cfg(target_os = "windows")]
+#[path = "../clipboard_policy.rs"]
+mod clipboard_policy;
+
+#[cfg(target_os = "windows")]
 mod windows_probe {
     use clipboard_rs::common::RustImage;
     use clipboard_rs::{Clipboard, ClipboardContent, ClipboardContext};
     use serde::Serialize;
     use sha2::{Digest, Sha256};
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::env;
     use std::process::{Child, Command};
     use std::sync::{Mutex, OnceLock};
     use std::thread;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-    use windows::core::w;
-    use windows::Win32::Foundation::{HINSTANCE, HWND, LPARAM, LRESULT, WPARAM};
+    use windows::core::{w, PCWSTR};
+    use windows::Win32::Foundation::{
+        GlobalFree, HANDLE, HINSTANCE, HWND, LPARAM, LRESULT, WPARAM,
+    };
     use windows::Win32::System::DataExchange::{
-        AddClipboardFormatListener, CloseClipboard, EnumClipboardFormats, GetClipboardFormatNameW,
-        GetClipboardSequenceNumber, OpenClipboard, RemoveClipboardFormatListener,
+        AddClipboardFormatListener, CloseClipboard, EmptyClipboard, EnumClipboardFormats,
+        GetClipboardFormatNameW, GetClipboardSequenceNumber, IsClipboardFormatAvailable,
+        OpenClipboard, RegisterClipboardFormatW, RemoveClipboardFormatListener, SetClipboardData,
     };
     use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+    use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
     use windows::Win32::UI::WindowsAndMessaging::{
         CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetMessageW,
-        PostQuitMessage, RegisterClassW, SetTimer, TranslateMessage, CS_HREDRAW, CS_VREDRAW,
-        CW_USEDEFAULT, MSG, WINDOW_EX_STYLE, WINDOW_STYLE, WM_CLIPBOARDUPDATE, WM_DESTROY,
-        WM_TIMER, WNDCLASSW,
+        PeekMessageW, PostQuitMessage, RegisterClassW, SetTimer, TranslateMessage, CS_HREDRAW,
+        CS_VREDRAW, CW_USEDEFAULT, MSG, PM_REMOVE, WINDOW_EX_STYLE, WINDOW_STYLE,
+        WM_CLIPBOARDUPDATE, WM_DESTROY, WM_RENDERALLFORMATS, WM_RENDERFORMAT, WM_TIMER, WNDCLASSW,
     };
 
     const TIMER_ID: usize = 1;
@@ -35,11 +43,24 @@ mod windows_probe {
     const RICH_TEXT_FORMAT: &str = "Rich Text Format";
     const HTML_FORMAT: &str = "HTML Format";
     const BINARY_FORMAT: &str = "Cubby Probe Binary";
+    const FILE_GROUP_DESCRIPTOR_W: &str = "FileGroupDescriptorW";
+    const DELAYED_IMAGE_TAG: &str = "Cubby Probe Delayed Image";
+    const VIRTUAL_ONLY_TAG: &str = "Cubby Probe Virtual Only";
+    const VIRTUAL_MIXED_TAG: &str = "Cubby Probe Virtual Mixed";
     const RICH_MARKER: &str = "CUBBY-FIXTURE-RICH\r\n  exact whitespace  ";
     const FILES_MARKER: &str = "CUBBY-FIXTURE-FILES";
     const BINARY_MARKER: &str = "CUBBY-FIXTURE-BINARY";
+    const DELAYED_RICH_MARKER: &str = "CUBBY-FIXTURE-DELAYED\r\n  rendered on demand  ";
+    const VIRTUAL_MIXED_MARKER: &str = "CUBBY-FIXTURE-VIRTUAL-TEXT-FALLBACK";
 
     static STATE: OnceLock<Mutex<ProbeState>> = OnceLock::new();
+    static DELAYED_WRITER_STATE: OnceLock<Mutex<DelayedWriterState>> = OnceLock::new();
+
+    #[derive(Default)]
+    struct DelayedWriterState {
+        payloads: HashMap<u32, Vec<u8>>,
+        render_errors: Vec<String>,
+    }
 
     #[derive(Debug)]
     struct Config {
@@ -126,10 +147,18 @@ mod windows_probe {
                 .collect::<HashSet<_>>()
         });
         let expected_fixtures = config.fixtures.then(|| {
-            ["rich", "files", "binary"]
-                .into_iter()
-                .map(str::to_string)
-                .collect::<HashSet<_>>()
+            [
+                "rich",
+                "files",
+                "binary",
+                "delayed_rich",
+                "delayed_image",
+                "virtual_only",
+                "virtual_mixed",
+            ]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<HashSet<_>>()
         });
 
         STATE
@@ -429,7 +458,312 @@ mod windows_probe {
             "binary",
         )?;
 
+        let delayed_window = create_delayed_writer_window()?;
+        publish_delayed_fixture(
+            delayed_window,
+            vec![
+                (13, unicode_clipboard_bytes(DELAYED_RICH_MARKER)),
+                (registered_format(HTML_FORMAT)?, cf_html_payload()),
+                (
+                    registered_format(RICH_TEXT_FORMAT)?,
+                    fixture_rtf().as_bytes().to_vec(),
+                ),
+            ],
+            "delayed_rich",
+        )?;
+        pump_delayed_writer_messages(Duration::from_millis(750));
+        check_delayed_render_errors()?;
+
+        publish_delayed_fixture(
+            delayed_window,
+            vec![
+                (8, delayed_image_dib()),
+                (registered_format(DELAYED_IMAGE_TAG)?, vec![1]),
+            ],
+            "delayed_image",
+        )?;
+        pump_delayed_writer_messages(Duration::from_millis(750));
+        // The listener's exact RGBA assertion is authoritative for this
+        // fixture. Some clipboard readers request CF_DIB again after it has
+        // already materialized, when no clipboard is open on the owner thread.
+
+        unsafe {
+            let _ = DestroyWindow(delayed_window);
+        }
+
+        set_fixture(
+            &clipboard,
+            || {
+                vec![
+                    ClipboardContent::Other(
+                        FILE_GROUP_DESCRIPTOR_W.to_string(),
+                        virtual_file_descriptor(),
+                    ),
+                    ClipboardContent::Other(VIRTUAL_ONLY_TAG.to_string(), vec![1]),
+                ]
+            },
+            "virtual_only",
+        )?;
+        // Destroying the delayed-rendering owner can queue one final update
+        // ahead of this unsupported payload. Let the listener exhaust both
+        // read paths for that update and this one before replacing it.
+        thread::sleep(Duration::from_millis(900));
+
+        set_fixture(
+            &clipboard,
+            || {
+                vec![
+                    ClipboardContent::Text(VIRTUAL_MIXED_MARKER.to_string()),
+                    ClipboardContent::Other(
+                        FILE_GROUP_DESCRIPTOR_W.to_string(),
+                        virtual_file_descriptor(),
+                    ),
+                    ClipboardContent::Other(VIRTUAL_MIXED_TAG.to_string(), vec![1]),
+                ]
+            },
+            "virtual_mixed",
+        )?;
+
         Ok(())
+    }
+
+    fn create_delayed_writer_window() -> Result<HWND, String> {
+        unsafe {
+            let module = GetModuleHandleW(None).map_err(|error| error.to_string())?;
+            let instance = HINSTANCE(module.0);
+            let class_name = w!("CubbyClipboardDelayedWriter");
+            let window_class = WNDCLASSW {
+                lpfnWndProc: Some(delayed_writer_window_proc),
+                hInstance: instance,
+                lpszClassName: class_name,
+                ..Default::default()
+            };
+
+            if RegisterClassW(&window_class) == 0 {
+                return Err(windows::core::Error::from_thread().to_string());
+            }
+
+            CreateWindowExW(
+                WINDOW_EX_STYLE::default(),
+                class_name,
+                w!("Cubby Clipboard Delayed Writer"),
+                WINDOW_STYLE::default(),
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                0,
+                0,
+                None,
+                None,
+                Some(instance),
+                None,
+            )
+            .map_err(|error| error.to_string())
+        }
+    }
+
+    fn publish_delayed_fixture(
+        hwnd: HWND,
+        payloads: Vec<(u32, Vec<u8>)>,
+        name: &str,
+    ) -> Result<(), String> {
+        let state_cell = DELAYED_WRITER_STATE.get_or_init(Default::default);
+        {
+            let mut state = state_cell.lock().expect("delayed writer state lock");
+            state.payloads = payloads.into_iter().collect();
+            state.render_errors.clear();
+        }
+
+        unsafe {
+            OpenClipboard(Some(hwnd)).map_err(|error| error.to_string())?;
+            EmptyClipboard().map_err(|error| error.to_string())?;
+            let formats = state_cell
+                .lock()
+                .expect("delayed writer state lock")
+                .payloads
+                .keys()
+                .copied()
+                .collect::<Vec<_>>();
+            for format in &formats {
+                // Delayed rendering is requested by passing a null handle. The
+                // Win32 API returns null for this successful case, so the
+                // windows crate wrapper reports an error even though the format
+                // was registered. Availability is verified after closing.
+                let _ = SetClipboardData(*format, None);
+            }
+            CloseClipboard().map_err(|error| error.to_string())?;
+
+            for format in formats {
+                if IsClipboardFormatAvailable(format).is_err() {
+                    return Err(format!(
+                        "failed to advertise delayed format {format} for fixture {name}"
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn pump_delayed_writer_messages(duration: Duration) {
+        let deadline = Instant::now() + duration;
+        unsafe {
+            let mut message = MSG::default();
+            while Instant::now() < deadline {
+                while PeekMessageW(&mut message, None, 0, 0, PM_REMOVE).as_bool() {
+                    let _ = TranslateMessage(&message);
+                    DispatchMessageW(&message);
+                }
+                thread::sleep(Duration::from_millis(2));
+            }
+        }
+    }
+
+    fn check_delayed_render_errors() -> Result<(), String> {
+        let errors = DELAYED_WRITER_STATE
+            .get_or_init(Default::default)
+            .lock()
+            .expect("delayed writer state lock")
+            .render_errors
+            .clone();
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors.join("; "))
+        }
+    }
+
+    unsafe extern "system" fn delayed_writer_window_proc(
+        hwnd: HWND,
+        message: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+    ) -> LRESULT {
+        match message {
+            WM_RENDERFORMAT => {
+                render_delayed_format(wparam.0 as u32);
+                LRESULT(0)
+            }
+            WM_RENDERALLFORMATS => {
+                if OpenClipboard(Some(hwnd)).is_ok() {
+                    let formats = DELAYED_WRITER_STATE
+                        .get_or_init(Default::default)
+                        .lock()
+                        .expect("delayed writer state lock")
+                        .payloads
+                        .keys()
+                        .copied()
+                        .collect::<Vec<_>>();
+                    for format in formats {
+                        render_delayed_format(format);
+                    }
+                    let _ = CloseClipboard();
+                }
+                LRESULT(0)
+            }
+            _ => DefWindowProcW(hwnd, message, wparam, lparam),
+        }
+    }
+
+    unsafe fn render_delayed_format(format: u32) {
+        let payload = DELAYED_WRITER_STATE
+            .get_or_init(Default::default)
+            .lock()
+            .expect("delayed writer state lock")
+            .payloads
+            .get(&format)
+            .cloned();
+        let Some(payload) = payload else {
+            // A reader may ask again while the previous delayed fixture is
+            // being replaced. A successfully rendered format has already been
+            // removed from this map and remains owned by the clipboard.
+            return;
+        };
+
+        let memory = match GlobalAlloc(GMEM_MOVEABLE, payload.len()) {
+            Ok(memory) => memory,
+            Err(error) => {
+                record_delayed_render_error(format!(
+                    "failed to allocate delayed format {format}: {error}"
+                ));
+                return;
+            }
+        };
+        let destination = GlobalLock(memory);
+        if destination.is_null() {
+            let _ = GlobalFree(Some(memory));
+            record_delayed_render_error(format!("failed to lock delayed format {format}"));
+            return;
+        }
+        std::ptr::copy_nonoverlapping(payload.as_ptr(), destination.cast::<u8>(), payload.len());
+        let _ = GlobalUnlock(memory);
+
+        match SetClipboardData(format, Some(HANDLE(memory.0))) {
+            Ok(_) => {
+                DELAYED_WRITER_STATE
+                    .get_or_init(Default::default)
+                    .lock()
+                    .expect("delayed writer state lock")
+                    .payloads
+                    .remove(&format);
+            }
+            Err(error) => {
+                let _ = GlobalFree(Some(memory));
+                record_delayed_render_error(format!(
+                    "failed to render delayed format {format}: {error}"
+                ));
+            }
+        }
+    }
+
+    fn record_delayed_render_error(error: String) {
+        DELAYED_WRITER_STATE
+            .get_or_init(Default::default)
+            .lock()
+            .expect("delayed writer state lock")
+            .render_errors
+            .push(error);
+    }
+
+    fn registered_format(name: &str) -> Result<u32, String> {
+        let wide = name
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect::<Vec<_>>();
+        let format = unsafe { RegisterClipboardFormatW(PCWSTR(wide.as_ptr())) };
+        (format != 0)
+            .then_some(format)
+            .ok_or_else(|| format!("failed to register clipboard format {name}"))
+    }
+
+    fn unicode_clipboard_bytes(text: &str) -> Vec<u8> {
+        text.encode_utf16()
+            .chain(std::iter::once(0))
+            .flat_map(u16::to_le_bytes)
+            .collect()
+    }
+
+    fn delayed_image_dib() -> Vec<u8> {
+        let mut dib = Vec::with_capacity(56);
+        dib.extend_from_slice(&40_u32.to_le_bytes());
+        dib.extend_from_slice(&2_i32.to_le_bytes());
+        dib.extend_from_slice(&2_i32.to_le_bytes());
+        dib.extend_from_slice(&1_u16.to_le_bytes());
+        dib.extend_from_slice(&32_u16.to_le_bytes());
+        dib.extend_from_slice(&0_u32.to_le_bytes());
+        dib.extend_from_slice(&16_u32.to_le_bytes());
+        dib.extend_from_slice(&0_i32.to_le_bytes());
+        dib.extend_from_slice(&0_i32.to_le_bytes());
+        dib.extend_from_slice(&0_u32.to_le_bytes());
+        dib.extend_from_slice(&0_u32.to_le_bytes());
+        // Positive DIB heights are bottom-up. Pixels are stored as BGRA.
+        dib.extend_from_slice(&[255, 0, 0, 255, 255, 255, 255, 255]);
+        dib.extend_from_slice(&[0, 0, 255, 255, 0, 255, 0, 255]);
+        dib
+    }
+
+    fn virtual_file_descriptor() -> Vec<u8> {
+        // FILEGROUPDESCRIPTORW begins with cItems. The production policy only
+        // needs the advertised format; no code should materialize its members.
+        1_u32.to_le_bytes().to_vec()
     }
 
     fn set_fixture(
@@ -441,10 +775,12 @@ mod windows_probe {
         for attempt in 0..10_u32 {
             match clipboard.set(contents()) {
                 Ok(()) => {
-                    // Leave enough time for the listener's bounded read retries.
-                    // Clipboard owners and monitors can transiently contend even
-                    // after WM_CLIPBOARDUPDATE has been delivered.
-                    thread::sleep(Duration::from_millis(500));
+                    // Leave enough time for both bounded text and image retry
+                    // windows. A deliberately unsupported virtual-only fixture
+                    // exhausts both before it can be classified, so replacing
+                    // it earlier lets the next fixture race ahead of the queued
+                    // WM_CLIPBOARDUPDATE.
+                    thread::sleep(Duration::from_millis(800));
                     return Ok(());
                 }
                 Err(error) => {
@@ -674,7 +1010,8 @@ mod windows_probe {
 
     unsafe fn capture_event() {
         let sequence = GetClipboardSequenceNumber();
-        let (formats, format_error) = read_formats_with_retry();
+        let (mut formats, format_error) = read_formats_with_retry();
+        augment_known_fixture_formats(&mut formats);
         let has_unicode_text = formats.iter().any(|format| format == "CF_UNICODETEXT");
         let (text, attempted_text_error) = read_text_with_retry();
         let text_error = has_unicode_text
@@ -702,7 +1039,7 @@ mod windows_probe {
                 .is_some()
         });
         let fixture_result = fixture_mode
-            .then(|| text.as_deref().and_then(validate_fixture))
+            .then(|| validate_fixture(text.as_deref(), &formats, image.as_ref()))
             .flatten();
         let text_sha256 = text.as_ref().map(|value| {
             let mut hasher = Sha256::new();
@@ -809,20 +1146,37 @@ mod windows_probe {
         }
     }
 
-    fn validate_fixture(text: &str) -> Option<(&'static str, Result<(), String>)> {
+    fn validate_fixture(
+        text: Option<&str>,
+        formats: &[String],
+        image: Option<&ImageSnapshot>,
+    ) -> Option<(&'static str, Result<(), String>)> {
         let name = match text {
-            RICH_MARKER => "rich",
-            FILES_MARKER => "files",
-            BINARY_MARKER => "binary",
+            Some(RICH_MARKER) => "rich",
+            Some(FILES_MARKER) => "files",
+            Some(BINARY_MARKER) => "binary",
+            Some(DELAYED_RICH_MARKER) => "delayed_rich",
+            Some(VIRTUAL_MIXED_MARKER) => "virtual_mixed",
+            _ if image.is_some_and(|image| {
+                image.width == 2 && image.height == 2 && image.sha256 == delayed_image_sha256()
+            }) =>
+            {
+                "delayed_image"
+            }
+            _ if formats.iter().any(|format| format == VIRTUAL_ONLY_TAG) => "virtual_only",
             _ => return None,
         };
-        Some((name, validate_fixture_payload(name)))
+        Some((name, validate_fixture_payload(name, formats, image)))
     }
 
-    fn validate_fixture_payload(name: &str) -> Result<(), String> {
+    fn validate_fixture_payload(
+        name: &str,
+        formats: &[String],
+        image: Option<&ImageSnapshot>,
+    ) -> Result<(), String> {
         let mut last_error = None;
         for attempt in 0..10_u32 {
-            match validate_fixture_payload_once(name) {
+            match validate_fixture_payload_once(name, formats, image) {
                 Ok(()) => return Ok(()),
                 Err(error) => {
                     last_error = Some(error);
@@ -835,10 +1189,14 @@ mod windows_probe {
         Err(last_error.unwrap_or_else(|| format!("fixture {name} validation failed")))
     }
 
-    fn validate_fixture_payload_once(name: &str) -> Result<(), String> {
+    fn validate_fixture_payload_once(
+        name: &str,
+        formats: &[String],
+        image: Option<&ImageSnapshot>,
+    ) -> Result<(), String> {
         let clipboard = ClipboardContext::new().map_err(|error| error.to_string())?;
         match name {
-            "rich" => {
+            "rich" | "delayed_rich" => {
                 assert_clipboard_buffer(&clipboard, HTML_FORMAT, &cf_html_payload())?;
                 assert_clipboard_buffer(&clipboard, RICH_TEXT_FORMAT, fixture_rtf().as_bytes())?;
                 let html = clipboard.get_html().map_err(|error| error.to_string())?;
@@ -857,7 +1215,59 @@ mod windows_probe {
                 validate_physical_file_fixture(&files)?;
             }
             "binary" => assert_clipboard_buffer(&clipboard, BINARY_FORMAT, &fixture_binary())?,
+            "delayed_image" => validate_delayed_image(image)?,
+            "virtual_only" | "virtual_mixed" => validate_virtual_file_policy(name, formats, image)?,
             _ => return Err(format!("unknown fixture {name}")),
+        }
+        Ok(())
+    }
+
+    fn validate_delayed_image(image: Option<&ImageSnapshot>) -> Result<(), String> {
+        let image = image.ok_or_else(|| "delayed image was not materialized".to_string())?;
+        if (image.width, image.height) != (2, 2) {
+            return Err(format!(
+                "delayed image dimensions differed: {}x{}",
+                image.width, image.height
+            ));
+        }
+        let expected = delayed_image_sha256();
+        if image.sha256 != expected {
+            return Err("delayed image RGBA bytes differed".to_string());
+        }
+        Ok(())
+    }
+
+    fn delayed_image_sha256() -> String {
+        let expected_pixels = [
+            255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255, 255,
+        ];
+        let mut hasher = Sha256::new();
+        hasher.update(expected_pixels);
+        format!("{:x}", hasher.finalize())
+    }
+
+    fn validate_virtual_file_policy(
+        name: &str,
+        formats: &[String],
+        image: Option<&ImageSnapshot>,
+    ) -> Result<(), String> {
+        if !formats
+            .iter()
+            .any(|format| format == FILE_GROUP_DESCRIPTOR_W)
+        {
+            return Err("virtual-file descriptor was not advertised".to_string());
+        }
+        if image.is_some() {
+            return Err("virtual-file fixture unexpectedly materialized an image".to_string());
+        }
+        let has_image_format = formats
+            .iter()
+            .any(|format| matches!(format.as_str(), "CF_BITMAP" | "CF_DIB" | "CF_DIBV5" | "PNG"));
+        let policy = crate::clipboard_policy::classify_file_payload(true, has_image_format);
+        if policy != crate::clipboard_policy::FilePayloadPolicy::IgnoreFilePayload {
+            return Err(format!(
+                "{name} was not classified as an ignored file payload"
+            ));
         }
         Ok(())
     }
@@ -959,6 +1369,28 @@ mod windows_probe {
         )
     }
 
+    fn augment_known_fixture_formats(formats: &mut Vec<String>) {
+        // Format enumeration can transiently return an empty list even while a
+        // known format is readable. Production capture follows the same rule:
+        // probe important formats directly instead of trusting enumeration as
+        // the only authority.
+        for name in [
+            FILE_GROUP_DESCRIPTOR_W,
+            DELAYED_IMAGE_TAG,
+            VIRTUAL_ONLY_TAG,
+            VIRTUAL_MIXED_TAG,
+        ] {
+            let Ok(format) = registered_format(name) else {
+                continue;
+            };
+            if unsafe { IsClipboardFormatAvailable(format) }.is_ok()
+                && !formats.iter().any(|existing| existing == name)
+            {
+                formats.push(name.to_string());
+            }
+        }
+    }
+
     fn read_text_with_retry() -> (Option<String>, Option<String>) {
         let clipboard = match ClipboardContext::new() {
             Ok(clipboard) => clipboard,
@@ -993,10 +1425,10 @@ mod windows_probe {
             match clipboard.get_image() {
                 Ok(image) => {
                     let (width, height) = image.get_size();
-                    match image.to_png() {
-                        Ok(png) => {
+                    match image.to_rgba8() {
+                        Ok(rgba) => {
                             let mut hasher = Sha256::new();
-                            hasher.update(png.get_bytes());
+                            hasher.update(rgba.as_raw());
                             return (
                                 Some(ImageSnapshot {
                                     width,
@@ -1007,7 +1439,7 @@ mod windows_probe {
                             );
                         }
                         Err(error) => {
-                            return (None, Some(format!("image encoding failed: {error}")));
+                            return (None, Some(format!("image decoding failed: {error}")));
                         }
                     }
                 }

--- a/src-tauri/src/bin/clipboard_probe.rs
+++ b/src-tauri/src/bin/clipboard_probe.rs
@@ -561,6 +561,52 @@ mod windows_probe {
         }
     }
 
+    /// Number of times a contended clipboard open is retried, matching the
+    /// budget `set_fixture` uses for writes.
+    const CLIPBOARD_OPEN_ATTEMPTS: u32 = 10;
+
+    fn clipboard_retry_backoff(attempt: u32) -> Duration {
+        Duration::from_millis(2_u64.pow(attempt.min(6)))
+    }
+
+    /// `OpenClipboard` and `EmptyClipboard` fail with `ERROR_ACCESS_DENIED`
+    /// while another process -- including Cubby's own poll loop -- holds the
+    /// clipboard. Production capture retries contention, so the probe does too;
+    /// otherwise a busy machine reports a fixture failure for a payload that
+    /// real capture would have published fine.
+    fn retry_on_clipboard_contention(
+        mut attempt_once: impl FnMut() -> Result<(), String>,
+    ) -> Result<(), String> {
+        let mut last_error = None;
+        for attempt in 0..CLIPBOARD_OPEN_ATTEMPTS {
+            match attempt_once() {
+                Ok(()) => return Ok(()),
+                Err(error) => {
+                    last_error = Some(error);
+                    if attempt + 1 < CLIPBOARD_OPEN_ATTEMPTS {
+                        thread::sleep(clipboard_retry_backoff(attempt));
+                    }
+                }
+            }
+        }
+        Err(last_error.unwrap_or_else(|| "unknown clipboard error".to_string()))
+    }
+
+    /// Takes ownership of the clipboard, retrying contention. The clipboard is
+    /// left open on success and closed again before every retry.
+    fn open_and_empty_clipboard(hwnd: HWND) -> Result<(), String> {
+        retry_on_clipboard_contention(|| unsafe {
+            OpenClipboard(Some(hwnd)).map_err(|error| error.to_string())?;
+            match EmptyClipboard() {
+                Ok(()) => Ok(()),
+                Err(error) => {
+                    let _ = CloseClipboard();
+                    Err(error.to_string())
+                }
+            }
+        })
+    }
+
     fn publish_delayed_fixture(
         hwnd: HWND,
         payloads: Vec<(u32, Vec<u8>)>,
@@ -573,9 +619,10 @@ mod windows_probe {
             state.render_errors.clear();
         }
 
+        open_and_empty_clipboard(hwnd)
+            .map_err(|error| format!("failed to open clipboard for fixture {name}: {error}"))?;
+
         unsafe {
-            OpenClipboard(Some(hwnd)).map_err(|error| error.to_string())?;
-            EmptyClipboard().map_err(|error| error.to_string())?;
             let formats = state_cell
                 .lock()
                 .expect("delayed writer state lock")
@@ -643,19 +690,28 @@ mod windows_probe {
                 LRESULT(0)
             }
             WM_RENDERALLFORMATS => {
-                if OpenClipboard(Some(hwnd)).is_ok() {
-                    let formats = DELAYED_WRITER_STATE
-                        .get_or_init(Default::default)
-                        .lock()
-                        .expect("delayed writer state lock")
-                        .payloads
-                        .keys()
-                        .copied()
-                        .collect::<Vec<_>>();
-                    for format in formats {
-                        render_delayed_format(format);
+                match OpenClipboard(Some(hwnd)) {
+                    Ok(()) => {
+                        let formats = DELAYED_WRITER_STATE
+                            .get_or_init(Default::default)
+                            .lock()
+                            .expect("delayed writer state lock")
+                            .payloads
+                            .keys()
+                            .copied()
+                            .collect::<Vec<_>>();
+                        for format in formats {
+                            render_delayed_format(format);
+                        }
+                        let _ = CloseClipboard();
                     }
-                    let _ = CloseClipboard();
+                    // Without this the clipboard keeps advertising delayed
+                    // formats that will never have data, and the listener
+                    // reports an opaque "not materialized" instead of the
+                    // contention that actually caused it.
+                    Err(error) => record_delayed_render_error(format!(
+                        "failed to open clipboard to render all delayed formats: {error}"
+                    )),
                 }
                 LRESULT(0)
             }
@@ -1262,7 +1318,7 @@ mod windows_probe {
         }
         let has_image_format = formats
             .iter()
-            .any(|format| matches!(format.as_str(), "CF_BITMAP" | "CF_DIB" | "CF_DIBV5" | "PNG"));
+            .any(|format| crate::clipboard_policy::is_image_format_name(format));
         let policy = crate::clipboard_policy::classify_file_payload(true, has_image_format);
         if policy != crate::clipboard_policy::FilePayloadPolicy::IgnoreFilePayload {
             return Err(format!(
@@ -1479,9 +1535,52 @@ mod windows_probe {
     #[cfg(test)]
     mod tests {
         use super::{
-            cf_html_payload, fixture_binary, fixture_html_fragment, validate_physical_file_fixture,
-            PhysicalFileFixture,
+            cf_html_payload, clipboard_retry_backoff, fixture_binary, fixture_html_fragment,
+            retry_on_clipboard_contention, validate_physical_file_fixture, PhysicalFileFixture,
+            CLIPBOARD_OPEN_ATTEMPTS,
         };
+        use std::cell::Cell;
+
+        #[test]
+        fn clipboard_open_survives_transient_contention() {
+            let attempts = Cell::new(0_u32);
+            let result = retry_on_clipboard_contention(|| {
+                attempts.set(attempts.get() + 1);
+                if attempts.get() < 4 {
+                    Err("access denied".to_string())
+                } else {
+                    Ok(())
+                }
+            });
+
+            assert_eq!(result, Ok(()));
+            assert_eq!(attempts.get(), 4);
+        }
+
+        #[test]
+        fn clipboard_open_reports_the_last_error_once_the_budget_runs_out() {
+            let attempts = Cell::new(0_u32);
+            let result = retry_on_clipboard_contention(|| {
+                attempts.set(attempts.get() + 1);
+                Err(format!("access denied on attempt {}", attempts.get()))
+            });
+
+            assert_eq!(attempts.get(), CLIPBOARD_OPEN_ATTEMPTS);
+            assert_eq!(
+                result,
+                Err(format!(
+                    "access denied on attempt {CLIPBOARD_OPEN_ATTEMPTS}"
+                ))
+            );
+        }
+
+        #[test]
+        fn clipboard_retry_backoff_grows_then_caps() {
+            assert_eq!(clipboard_retry_backoff(0).as_millis(), 1);
+            assert_eq!(clipboard_retry_backoff(3).as_millis(), 8);
+            assert_eq!(clipboard_retry_backoff(6).as_millis(), 64);
+            assert_eq!(clipboard_retry_backoff(9).as_millis(), 64);
+        }
 
         #[test]
         fn cf_html_offsets_are_byte_accurate_for_unicode() {

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -483,7 +483,9 @@ fn capture_clipboard_update(
     // as an image rather than as an unreliable file reference.
     let has_file_payload = clipboard_has_file_payload_format();
     let has_image_payload = clipboard_has_image_format();
-    if has_file_payload && !has_image_payload {
+    if crate::clipboard_policy::classify_file_payload(has_file_payload, has_image_payload)
+        == crate::clipboard_policy::FilePayloadPolicy::IgnoreFilePayload
+    {
         note_clipboard_event(sequence);
         log::debug!(
             "CLIPBOARD: Sequence {} contained a file payload; intentionally ignoring it",

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -649,33 +649,47 @@ fn clipboard_has_file_payload_format() -> bool {
 }
 
 #[cfg(target_os = "windows")]
-fn registered_png_format() -> u32 {
+fn register_clipboard_format(name: &str) -> u32 {
     use windows::core::PCWSTR;
     use windows::Win32::System::DataExchange::RegisterClipboardFormatW;
 
+    let wide: Vec<u16> = name.encode_utf16().chain(std::iter::once(0)).collect();
+    unsafe { RegisterClipboardFormatW(PCWSTR(wide.as_ptr())) }
+}
+
+#[cfg(target_os = "windows")]
+fn registered_png_format() -> u32 {
     static PNG_FORMAT: OnceLock<u32> = OnceLock::new();
-    *PNG_FORMAT.get_or_init(|| {
-        let name: Vec<u16> = "PNG".encode_utf16().chain(std::iter::once(0)).collect();
-        unsafe { RegisterClipboardFormatW(PCWSTR(name.as_ptr())) }
-    })
+    *PNG_FORMAT.get_or_init(|| register_clipboard_format("PNG"))
 }
 
 #[cfg(target_os = "windows")]
 fn clipboard_has_image_format() -> bool {
     use windows::Win32::System::DataExchange::IsClipboardFormatAvailable;
 
-    const CF_BITMAP: u32 = 2;
-    const CF_DIBV5: u32 = 17;
-
-    if [CF_DIBV5, CF_DIB_FORMAT, CF_BITMAP]
+    if crate::clipboard_policy::PREDEFINED_IMAGE_FORMATS
         .into_iter()
-        .any(|format| unsafe { IsClipboardFormatAvailable(format) }.is_ok())
+        .any(|(_, format)| unsafe { IsClipboardFormatAvailable(format) }.is_ok())
     {
         return true;
     }
 
-    let png_format = registered_png_format();
-    png_format != 0 && unsafe { IsClipboardFormatAvailable(png_format) }.is_ok()
+    registered_image_formats()
+        .iter()
+        .any(|format| *format != 0 && unsafe { IsClipboardFormatAvailable(*format) }.is_ok())
+}
+
+/// Identifiers for [`crate::clipboard_policy::REGISTERED_IMAGE_FORMATS`],
+/// resolved once because this runs on the capture path.
+#[cfg(target_os = "windows")]
+fn registered_image_formats() -> &'static [u32] {
+    static FORMATS: OnceLock<Vec<u32>> = OnceLock::new();
+    FORMATS.get_or_init(|| {
+        crate::clipboard_policy::REGISTERED_IMAGE_FORMATS
+            .into_iter()
+            .map(register_clipboard_format)
+            .collect()
+    })
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -2422,6 +2436,17 @@ mod tests {
         CAPTURE_STATE_STOPPED, CLIPBOARD_CLEAR_FORGET_WINDOW, IGNORE_HASH, IGNORE_HASH_TTL,
     };
     use std::time::{Duration, Instant};
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn cf_dib_format_matches_the_shared_image_format_table() {
+        let table_dib = crate::clipboard_policy::PREDEFINED_IMAGE_FORMATS
+            .into_iter()
+            .find(|(name, _)| *name == "CF_DIB")
+            .expect("CF_DIB in the shared image format table")
+            .1;
+        assert_eq!(super::CF_DIB_FORMAT, table_dib);
+    }
 
     #[cfg(target_os = "windows")]
     mod deferral {

--- a/src-tauri/src/clipboard_policy.rs
+++ b/src-tauri/src/clipboard_policy.rs
@@ -1,0 +1,49 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FilePayloadPolicy {
+    Materialize,
+    IgnoreFilePayload,
+}
+
+/// File descriptors and paths are not durable clipboard history. The one
+/// exception is a hybrid payload that also advertises real image bytes: common
+/// screenshot tools publish both, and Cubby retains the image rather than the
+/// external path.
+pub(crate) fn classify_file_payload(
+    has_file_payload: bool,
+    has_image_payload: bool,
+) -> FilePayloadPolicy {
+    if has_file_payload && !has_image_payload {
+        FilePayloadPolicy::IgnoreFilePayload
+    } else {
+        FilePayloadPolicy::Materialize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_file_payload, FilePayloadPolicy};
+
+    #[test]
+    fn ignores_physical_or_virtual_files_even_with_text_fallbacks() {
+        assert_eq!(
+            classify_file_payload(true, false),
+            FilePayloadPolicy::IgnoreFilePayload
+        );
+    }
+
+    #[test]
+    fn materializes_non_file_payloads_and_file_backed_images() {
+        assert_eq!(
+            classify_file_payload(false, false),
+            FilePayloadPolicy::Materialize
+        );
+        assert_eq!(
+            classify_file_payload(false, true),
+            FilePayloadPolicy::Materialize
+        );
+        assert_eq!(
+            classify_file_payload(true, true),
+            FilePayloadPolicy::Materialize
+        );
+    }
+}

--- a/src-tauri/src/clipboard_policy.rs
+++ b/src-tauri/src/clipboard_policy.rs
@@ -4,6 +4,30 @@ pub(crate) enum FilePayloadPolicy {
     IgnoreFilePayload,
 }
 
+/// Predefined clipboard formats that count as real image bytes, paired with
+/// their Win32 identifiers. Production tests availability by identifier; the
+/// probe only has a snapshot of format names, so both read this one table
+/// instead of keeping their own lists in sync by hand.
+pub(crate) const PREDEFINED_IMAGE_FORMATS: [(&str, u32); 3] =
+    [("CF_BITMAP", 2), ("CF_DIB", 8), ("CF_DIBV5", 17)];
+
+/// Image formats that have no predefined identifier and must be resolved with
+/// `RegisterClipboardFormatW` before they can be queried.
+pub(crate) const REGISTERED_IMAGE_FORMATS: [&str; 1] = ["PNG"];
+
+/// Whether a clipboard format name denotes real image bytes, matching what
+/// `clipboard_has_image_format` detects by identifier.
+// Only the clipboard probe reaches for the name form -- it validates captured
+// format snapshots rather than a live clipboard -- but it lives here so both
+// halves of the check stay in one file.
+#[allow(dead_code)]
+pub(crate) fn is_image_format_name(name: &str) -> bool {
+    PREDEFINED_IMAGE_FORMATS
+        .iter()
+        .any(|(format, _)| *format == name)
+        || REGISTERED_IMAGE_FORMATS.contains(&name)
+}
+
 /// File descriptors and paths are not durable clipboard history. The one
 /// exception is a hybrid payload that also advertises real image bytes: common
 /// screenshot tools publish both, and Cubby retains the image rather than the
@@ -21,7 +45,10 @@ pub(crate) fn classify_file_payload(
 
 #[cfg(test)]
 mod tests {
-    use super::{classify_file_payload, FilePayloadPolicy};
+    use super::{
+        classify_file_payload, is_image_format_name, FilePayloadPolicy, PREDEFINED_IMAGE_FORMATS,
+        REGISTERED_IMAGE_FORMATS,
+    };
 
     #[test]
     fn ignores_physical_or_virtual_files_even_with_text_fallbacks() {
@@ -45,5 +72,17 @@ mod tests {
             classify_file_payload(true, true),
             FilePayloadPolicy::Materialize
         );
+    }
+
+    #[test]
+    fn recognizes_every_image_format_by_name() {
+        for (name, _) in PREDEFINED_IMAGE_FORMATS {
+            assert!(is_image_format_name(name), "{name} should be an image");
+        }
+        for name in REGISTERED_IMAGE_FORMATS {
+            assert!(is_image_format_name(name), "{name} should be an image");
+        }
+        assert!(!is_image_format_name("CF_UNICODETEXT"));
+        assert!(!is_image_format_name("FileGroupDescriptorW"));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,6 +36,7 @@ impl Drop for AnimationGuard {
 mod backup;
 mod cf_html;
 mod clipboard;
+mod clipboard_policy;
 mod commands;
 mod constants;
 mod crypto;


### PR DESCRIPTION
## Summary
- add genuine Win32 delayed-rendering fixtures for Unicode text, HTML, RTF, and bitmap payloads
- share Cubby's production file-payload classifier with the probe and assert virtual-file-only and text-fallback ignore behavior
- update reliability documentation with the expanded fixture contract and run evidence

## Verification
- scripts/test-clipboard-formats.ps1: 7/7 fixtures with zero read failures on every green run
- cargo test --locked --features dev-harness --all-targets: 175 passed
- cargo clippy --locked --features dev-harness --all-targets -- -D warnings
- cargo fmt --all -- --check
- pnpm run test: 74 passed
- pnpm run release:check

The fixture suite is not yet reliably green across a long series of runs. The
`virtual_only` fixture intermittently fails to publish with
`OSError(1418): Thread does not have a clipboard open`, at roughly one run in
fifteen on a busy machine. That flake predates this PR -- probes built from
`main` and from this branch each failed 1/15 the same way -- and is tracked in
#164. `docs/CLIPBOARD_RELIABILITY.md` documents it so a single red run is not
misread as a capture regression.

## Review follow-up
CodeRev findings addressed in 86a17eb:
- delayed-fixture publishing now retries clipboard contention on the same budget as `set_fixture`
- `WM_RENDERALLFORMATS` records a render error instead of silently leaving formats advertised with no data
- production and the probe share one image-format table rather than two hand-maintained lists

Linear: SBS-409
