### PR TITLE
Clipboard application-compatibility matrix (SBS-408)

### DIFF
--- a/docs/CLIPBOARD_RELIABILITY.md
+++ b/docs/CLIPBOARD_RELIABILITY.md
@@ -126,21 +126,23 @@ sleep. The virtual-file fixtures advertise `FileGroupDescriptorW`; their text
 fallback is deliberately not captured because it is normally a path or display
 name for content Cubby cannot retain durably.
 
-Known flake: the `virtual_only` fixture intermittently fails to publish with
-`OSError(1418): Thread does not have a clipboard open`, and the run then times
-out having observed six of seven fixtures. It reproduces at roughly one run in
-fifteen on a busy machine, both before and after the delayed-rendering fixtures
-were added, so a single red run is not by itself a capture regression. See #164
-for the suspected cause -- the delayed writer's
-`WM_RENDERALLFORMATS` handler opening the clipboard on the same thread as an
-in-flight `clipboard_rs` write. Re-run the suite before investigating, and treat
-a repeatable failure or any non-zero `read_failures` as a genuine defect.
+The delayed-rendering owner is retired deliberately rather than just destroyed:
+its payloads are dropped, clipboard ownership is released, and the message queue
+is drained before the next fixture is written. Skipping any of that reintroduces
+#164, where the next writer's `EmptyClipboard` made Windows send
+`WM_RENDERALLFORMATS` to the still-owning window, whose handler opened and
+closed the clipboard on the same thread -- closing the one `clipboard_rs` was
+using and failing the `virtual_only` fixture with `ERROR_CLIPBOARD_NOT_OPEN`
+(1418) roughly once every fifteen runs. The handler now also returns without
+touching the clipboard when it has nothing left to render.
 
 This suite proves the local Windows clipboard can materialize supported payloads
 without normalization or format loss and can reject unsupported file payloads
-without confusing them for stored history. Application-specific compatibility
-still belongs in the manual matrix below; passing the fixtures does not claim
-that Office, browsers, remote clients, or elevated targets have been validated.
+without confusing them for stored history. Whether real applications accept
+those payloads is a separate question, answered by the automated compatibility
+matrix in `docs/COMPAT_MATRIX.md`; passing the fixtures on its own does not
+claim that Office, browsers, remote clients, or elevated targets have been
+validated.
 
 Production materialization uses the same bounded retry margin: ten attempts with
 exponential backoff capped at 64 ms, allowing up to 319 ms for a clipboard owner

--- a/docs/CLIPBOARD_RELIABILITY.md
+++ b/docs/CLIPBOARD_RELIABILITY.md
@@ -129,7 +129,7 @@ name for content Cubby cannot retain durably.
 The delayed-rendering owner is retired deliberately rather than just destroyed:
 its payloads are dropped, clipboard ownership is released, and the message queue
 is drained before the next fixture is written. Skipping any of that reintroduces
-#164, where the next writer's `EmptyClipboard` made Windows send
+issue #164, where the next writer's `EmptyClipboard` made Windows send
 `WM_RENDERALLFORMATS` to the still-owning window, whose handler opened and
 closed the clipboard on the same thread -- closing the one `clipboard_rs` was
 using and failing the `virtual_only` fixture with `ERROR_CLIPBOARD_NOT_OPEN`

--- a/docs/COMPAT_MATRIX.md
+++ b/docs/COMPAT_MATRIX.md
@@ -96,6 +96,38 @@ These were all found the hard way; changing them will silently weaken the suite.
 - **Word's content is only readable through the Text pattern.** Its document
   also exposes a Value pattern, which always reads back empty.
 
+## Cleanup
+
+The suite leaves the desktop as it found it: window count is unchanged across
+repeated runs. Getting there takes more than killing the process it spawned,
+because the two obvious approaches each fail on half the rows.
+
+- **Closing the window is not enough.** An editor holding pasted text in an
+  unsaved document answers `WM_CLOSE` with a save prompt and stays on screen.
+- **Killing the spawned child is not enough.** Windows 11 Notepad and every
+  browser hand the launch off to another process and exit, so the child is
+  already gone.
+
+So each row closes its window and then terminates only processes of that
+executable that did not exist before the row started. Two rows deliberately opt
+out of the terminate half:
+
+- **Browsers.** A browser runs a process per renderer and spawns them
+  constantly, so killing every `msedge.exe` that appeared during the run would
+  take the user's own tabs with it. A throwaway profile with a single window
+  exits cleanly on `WM_CLOSE` instead.
+- **Explorer and Windows Terminal.** Their windows belong to long-running host
+  processes -- the shell, and a `WindowsTerminal.exe` that may own the user's
+  other terminals -- so these rows close the window and never the process.
+
+Residual case: if the target application was **already running** when the suite
+started, a row may open a document in that existing process rather than a new
+one. Nothing new is terminated, and that window can be left behind with a save
+prompt. Close the target apps before a full run if that matters.
+
+`-KeepApps` disables all of this, which is what makes it useful for inspecting
+a failure.
+
 ## Interpreting a failure
 
 `office / winword.exe / unicode_text / paste` means Word was found and driven,

--- a/docs/COMPAT_MATRIX.md
+++ b/docs/COMPAT_MATRIX.md
@@ -37,7 +37,7 @@ stops at the clipboard boundary rather than standing up an app instance.
 | `packaged_app` | Notepad (Store-packaged on Windows 11) | Launched through the `notepad.exe` stub, which hands off to another process. |
 | `explorer` | File Explorer | The file-payload row: see below. |
 | `terminal` | PowerShell in Windows Terminal | Needs `wt.exe`. |
-| `browser` | Edge, Chrome, or Firefox | Runs against a generated local page with a labelled textarea. |
+| `browser` | Edge, then Chrome | Runs against a generated local page with a labelled textarea. Chromium-based only; see below. |
 | `ide` | VS Code, then Notepad++ | Skips when neither exposes an automatable control. |
 | `office` | Word, then WordPad | Opens an RTF document. |
 | `remote_session` | The owned `EDIT` control, driven with `PasteStrategy::RemoteSession` | Exercises the remote-session timing path on any machine. |
@@ -80,6 +80,12 @@ These were all found the hard way; changing them will silently weaken the suite.
   line, which would leave the row driving an unrelated window.
 - **Chromium needs `--force-renderer-accessibility`.** Page content is absent
   from the automation tree without it.
+- **The browser row is Chromium-only, deliberately.** `--user-data-dir` and
+  `--force-renderer-accessibility` are Chromium flags. Firefox uses `-profile`
+  and initialises accessibility on demand, so handing it this argument list
+  would let an existing Firefox session take the URL and leave the row driving
+  the wrong window. Adding Firefox means giving it its own arguments and
+  verifying them, not appending to the candidate list.
 - **Activate, then focus, then paste.** Activating a window can move focus
   inside it, so focusing a control first is silently undone.
 - **The terminal row uses PowerShell, not `cmd.exe`.** `cmd`'s `set /p` reads
@@ -109,8 +115,13 @@ because the two obvious approaches each fail on half the rows.
   already gone.
 
 So each row closes its window and then terminates only processes of that
-executable that did not exist before the row started. Two rows deliberately opt
-out of the terminate half:
+executable that did not exist before the row started. This happens in the
+launched application's `Drop`, not at the end of the driving function: a row
+that fails early -- no window appeared, no automatable control -- is the one
+most likely to have left something on screen, and cleanup written after the
+last `?` would skip exactly those cases.
+
+Two rows deliberately opt out of the terminate half:
 
 - **Browsers.** A browser runs a process per renderer and spawns them
   constantly, so killing every `msedge.exe` that appeared during the run would

--- a/docs/COMPAT_MATRIX.md
+++ b/docs/COMPAT_MATRIX.md
@@ -1,0 +1,109 @@
+# Clipboard application-compatibility matrix
+
+SBS-408. Where `scripts/test-clipboard-formats.ps1` proves the *clipboard* can
+carry Cubby's payloads, this matrix proves real *applications* can receive them.
+Each row drives one class of paste target end to end and reports failures with
+the app, format, and step that produced them.
+
+```powershell
+scripts/test-compat-matrix.ps1                 # every class
+scripts/test-compat-matrix.ps1 -Only browser   # one class
+scripts/test-compat-matrix.ps1 -List           # available class names
+scripts/test-compat-matrix.ps1 -KeepApps       # leave apps open to inspect a failure
+```
+
+The suite drives the real desktop: it takes the foreground, opens and closes
+applications, and replaces the clipboard. Do not use the machine while it runs.
+
+## Steps
+
+Every row walks the same three steps, and a failure names the one it stopped in.
+
+| Step | What is asserted |
+| --- | --- |
+| `capture` | Cubby's shared capture policy classifies the payload correctly -- storable text is storable, a bare file payload is ignored. |
+| `restore` | Writing the payload to the clipboard and reading it back returns identical bytes. |
+| `paste` | The real paste engine (`cubby::paste_engine`) drives the target application, and the payload is read back **out of that application**. |
+
+Durable-storage assertions are not part of a row. They are covered by the
+database and clipboard test suites in `cargo test`; this matrix deliberately
+stops at the clipboard boundary rather than standing up an app instance.
+
+## Rows
+
+| Class | Target | Notes |
+| --- | --- | --- |
+| `legacy_win32` | An `EDIT` control the harness owns | No prerequisites. Isolates the paste engine from application quirks. |
+| `packaged_app` | Notepad (Store-packaged on Windows 11) | Launched through the `notepad.exe` stub, which hands off to another process. |
+| `explorer` | File Explorer | The file-payload row: see below. |
+| `terminal` | PowerShell in Windows Terminal | Needs `wt.exe`. |
+| `browser` | Edge, Chrome, or Firefox | Runs against a generated local page with a labelled textarea. |
+| `ide` | VS Code, then Notepad++ | Skips when neither exposes an automatable control. |
+| `office` | Word, then WordPad | Opens an RTF document. |
+| `remote_session` | The owned `EDIT` control, driven with `PasteStrategy::RemoteSession` | Exercises the remote-session timing path on any machine. |
+| `elevated` | The owned `EDIT` control at high integrity | Only runs when the suite itself is elevated. |
+
+The `explorer` row is the one that asserts a *product contract* rather than a
+round trip. Cubby does not store file payloads, so the row checks that the
+payload is classified as ignored, that Explorer still pastes the file (verified
+on disk), and that a following text copy is still captured -- an ignored payload
+must not wedge capture.
+
+## Skips are not passes
+
+A row whose application is missing, or whose environment does not apply, is
+reported as `skipped` with a reason, and its class is listed in
+`classes_not_covered`. A run with no failures and six skips is green but proves
+very little, so the script prints the uncovered classes as a warning. Read that
+line before treating a green run as coverage.
+
+Skip reasons in practice:
+
+- **no candidate application installed** -- install one of the listed apps.
+- **exposed no UI Automation text control** -- the app is installed but cannot
+  be driven. VS Code does this: its launcher exits immediately and the Electron
+  window exposes no text control to UI Automation.
+- **this run is not elevated** -- start an elevated shell and re-run. UIPI
+  blocks synthetic paste into an elevated window from a medium-integrity
+  process by design, so this class can only be demonstrated from elevation.
+
+## Things that are load-bearing
+
+These were all found the hard way; changing them will silently weaken the suite.
+
+- **The browser row targets a labelled textarea, not "the first editable
+  control".** A browser window exposes its address bar in the same automation
+  tree, and it sorts first. Pasting into the omnibox reads the payload back
+  perfectly and looks like a pass while never involving the page.
+- **The browser needs its own `--user-data-dir`.** An already-running browser
+  adopts the URL into its existing process and drops the rest of the command
+  line, which would leave the row driving an unrelated window.
+- **Chromium needs `--force-renderer-accessibility`.** Page content is absent
+  from the automation tree without it.
+- **Activate, then focus, then paste.** Activating a window can move focus
+  inside it, so focusing a control first is silently undone.
+- **The terminal row uses PowerShell, not `cmd.exe`.** `cmd`'s `set /p` reads
+  console input through the console code page and returns `caf?` for `café`
+  even after `chcp 65001`. That is a cmd limitation, and using it would report
+  a Cubby paste bug that does not exist.
+- **The terminal row uses `wt -w new`.** Spawning a console app with
+  `CREATE_NEW_CONSOLE` opens a *tab* in the existing Windows Terminal window on
+  Windows 11, leaving no window of our own to paste into; routing through
+  `conhost.exe` instead makes conhost take over the harness's own console.
+- **Commands passed to a shell contain no double quotes.** Rust escapes inner
+  quotes as `\"` when building a command line, which neither cmd nor PowerShell
+  parses as intended.
+- **Word's content is only readable through the Text pattern.** Its document
+  also exposes a Value pattern, which always reads back empty.
+
+## Interpreting a failure
+
+`office / winword.exe / unicode_text / paste` means Word was found and driven,
+the clipboard round trip succeeded, and the payload did not arrive in the
+document. Re-run that row alone with `-Only office -KeepApps` and inspect the
+window that is left open.
+
+UI automation on a busy desktop is not perfectly deterministic: each row retries
+the activate/focus/paste sequence three times before reporting a failure. A
+single red row that passes on a focused re-run is worth re-running once before
+being treated as a regression.

--- a/scripts/test-compat-matrix.ps1
+++ b/scripts/test-compat-matrix.ps1
@@ -1,0 +1,86 @@
+param(
+    # Comma-separated app classes to run. Omit for all of them.
+    # Use -List to see the available names.
+    [string]$Only = "",
+    [switch]$List,
+    [switch]$KeepApps,
+    [switch]$SkipBuild
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$tauriRoot = Join-Path $repoRoot "src-tauri"
+$matrixPath = Join-Path $tauriRoot "target\debug\compat_matrix.exe"
+
+if (-not $SkipBuild) {
+    Push-Location $tauriRoot
+    try {
+        cargo build --locked --features dev-harness --bin compat_matrix
+        if ($LASTEXITCODE -ne 0) {
+            throw "compat_matrix build failed"
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+if (-not (Test-Path -LiteralPath $matrixPath)) {
+    throw "Compatibility matrix not found at $matrixPath"
+}
+
+if ($List) {
+    & $matrixPath --list
+    return
+}
+
+Write-Warning "This test replaces the current Windows clipboard contents, and opens and closes real applications. Do not use the machine while it runs."
+
+$matrixArgs = @()
+if ($Only) { $matrixArgs += @("--only", $Only) }
+if ($KeepApps) { $matrixArgs += "--keep-apps" }
+
+$output = & $matrixPath @matrixArgs
+$exitCode = $LASTEXITCODE
+
+$events = $output | ForEach-Object { $_ | ConvertFrom-Json }
+$rows = @($events | Where-Object event -eq "row")
+$summary = $events | Where-Object event -eq "summary" | Select-Object -Last 1
+
+if (-not $summary) {
+    $output | Write-Host
+    throw "Compatibility matrix did not produce a summary"
+}
+
+$rows |
+    Select-Object @{ Name = "Class"; Expression = { $_.class } },
+                  @{ Name = "App"; Expression = { $_.app } },
+                  @{ Name = "Status"; Expression = { $_.status } },
+                  @{ Name = "Detail"; Expression = { $_.detail } } |
+    Format-Table -AutoSize -Wrap
+
+[pscustomobject]@{
+    Passed            = $summary.passed
+    RowsPassed        = $summary.rows_passed
+    RowsFailed        = $summary.rows_failed
+    RowsSkipped       = $summary.rows_skipped
+    Checks            = $summary.checks
+    ClassesNotCovered = ($summary.classes_not_covered -join ", ")
+} | Format-List
+
+# Skipped rows do not fail the run: a machine without Word cannot prove anything
+# about Word. They are printed instead, because a green run that skipped six
+# classes is not the same result as a green run that covered them.
+if ($summary.classes_not_covered.Count -gt 0) {
+    Write-Warning "Classes with no executed row: $($summary.classes_not_covered -join ', '). This run proved nothing about them."
+}
+
+if (-not $summary.passed) {
+    Write-Host "`nFailures:" -ForegroundColor Red
+    foreach ($failure in $summary.failures) {
+        Write-Host ("  {0} / {1} / {2} / {3}: {4}" -f $failure.class, $failure.app, $failure.format, $failure.step, $failure.detail)
+    }
+    exit 1
+}
+
+exit $exitCode

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,7 +53,7 @@ clipboard-win = { version = "5.4.1", features = ["monitor"] }
 
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.62.2", features = ["UI_ViewManagement", "Win32_UI_Accessibility", "Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Win32_System_Threading", "Win32_System_ProcessStatus", "Win32_System_LibraryLoader", "Win32_Security", "Win32_Security_Cryptography", "Win32_System_DataExchange", "Win32_UI_Shell", "Win32_Graphics_Gdi", "Win32_Graphics_Dwm", "Win32_Storage_FileSystem", "Win32_System_SystemInformation", "Win32_System_Memory", "Win32_UI_Input_KeyboardAndMouse", "Win32_System_Com", "Foundation", "Foundation_Collections", "Media_Ocr", "Graphics_Imaging", "Security_Cryptography", "Storage_Streams"] }
+windows = { version = "0.62.2", features = ["UI_ViewManagement", "Win32_UI_Accessibility", "Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Win32_System_Threading", "Win32_System_ProcessStatus", "Win32_System_LibraryLoader", "Win32_Security", "Win32_Security_Cryptography", "Win32_System_DataExchange", "Win32_UI_Shell", "Win32_Graphics_Gdi", "Win32_Graphics_Dwm", "Win32_Storage_FileSystem", "Win32_System_SystemInformation", "Win32_System_Memory", "Win32_UI_Input_KeyboardAndMouse", "Win32_System_Com", "Win32_System_Variant", "Win32_System_Ole", "Foundation", "Foundation_Collections", "Media_Ocr", "Graphics_Imaging", "Security_Cryptography", "Storage_Streams"] }
 
 
 [features]
@@ -83,6 +83,11 @@ required-features = ["dev-harness"]
 [[bin]]
 name = "paste_compat"
 path = "src/bin/paste_compat.rs"
+required-features = ["dev-harness"]
+
+[[bin]]
+name = "compat_matrix"
+path = "src/bin/compat_matrix.rs"
 required-features = ["dev-harness"]
 
 # Note: win_v_helper.rs is also compiled into cubby.exe via `#[path]` in

--- a/src-tauri/src/bin/clipboard_probe.rs
+++ b/src-tauri/src/bin/clipboard_probe.rs
@@ -487,9 +487,7 @@ mod windows_probe {
         // fixture. Some clipboard readers request CF_DIB again after it has
         // already materialized, when no clipboard is open on the owner thread.
 
-        unsafe {
-            let _ = DestroyWindow(delayed_window);
-        }
+        retire_delayed_writer(delayed_window)?;
 
         set_fixture(
             &clipboard,
@@ -650,6 +648,39 @@ mod windows_probe {
         Ok(())
     }
 
+    /// Take the delayed-rendering owner out of the picture before the next
+    /// fixture is written.
+    ///
+    /// Destroying the window on its own is not enough. While it still owns the
+    /// clipboard, the next writer's `EmptyClipboard` makes Windows send
+    /// `WM_RENDERALLFORMATS` to it, and that handler opens and closes the
+    /// clipboard on this same thread -- closing the one `clipboard_rs` is in
+    /// the middle of using, which surfaces as `ERROR_CLIPBOARD_NOT_OPEN`
+    /// (1418) on the `virtual_only` fixture. Dropping the payloads, releasing
+    /// ownership, and draining the queue first means no render handler can be
+    /// in flight when the next fixture starts.
+    fn retire_delayed_writer(hwnd: HWND) -> Result<(), String> {
+        DELAYED_WRITER_STATE
+            .get_or_init(Default::default)
+            .lock()
+            .expect("delayed writer state lock")
+            .payloads
+            .clear();
+
+        open_and_empty_clipboard(hwnd)
+            .map_err(|error| format!("failed to release the delayed clipboard owner: {error}"))?;
+        unsafe {
+            CloseClipboard().map_err(|error| error.to_string())?;
+        }
+
+        pump_delayed_writer_messages(Duration::from_millis(150));
+        unsafe {
+            let _ = DestroyWindow(hwnd);
+        }
+        pump_delayed_writer_messages(Duration::from_millis(150));
+        Ok(())
+    }
+
     fn pump_delayed_writer_messages(duration: Duration) {
         let deadline = Instant::now() + duration;
         unsafe {
@@ -690,6 +721,21 @@ mod windows_probe {
                 LRESULT(0)
             }
             WM_RENDERALLFORMATS => {
+                // Nothing left to render means nothing to open the clipboard
+                // for. This guard is what keeps the handler from closing a
+                // clipboard that another writer on this thread has open: once
+                // the fixture has been retired, the handler must not touch the
+                // clipboard at all.
+                let pending = DELAYED_WRITER_STATE
+                    .get_or_init(Default::default)
+                    .lock()
+                    .expect("delayed writer state lock")
+                    .payloads
+                    .len();
+                if pending == 0 {
+                    return LRESULT(0);
+                }
+
                 match OpenClipboard(Some(hwnd)) {
                     Ok(()) => {
                         let formats = DELAYED_WRITER_STATE

--- a/src-tauri/src/bin/compat_matrix.rs
+++ b/src-tauri/src/bin/compat_matrix.rs
@@ -1,0 +1,1809 @@
+//! Clipboard application-compatibility matrix (SBS-408).
+//!
+//! Drives real Windows applications through capture -> restore -> paste and
+//! reports every failure with the app, format, and step that produced it. Rows
+//! whose application is not installed, or whose environment does not apply, are
+//! reported as explicit skips with a reason -- never dropped silently, so a
+//! green run can always be told apart from a run that proved nothing.
+//!
+//! The verdict logic lives in `cubby::compat_matrix_model` so it can be unit
+//! tested without a desktop; this file is the driver.
+
+#[cfg(not(target_os = "windows"))]
+fn main() {
+    eprintln!("compat_matrix only runs on Windows");
+    std::process::exit(1);
+}
+
+#[cfg(target_os = "windows")]
+#[path = "../clipboard_policy.rs"]
+mod clipboard_policy;
+
+#[cfg(target_os = "windows")]
+fn main() {
+    windows_matrix::run();
+}
+
+#[cfg(target_os = "windows")]
+mod windows_matrix {
+    use crate::clipboard_policy::{classify_file_payload, FilePayloadPolicy};
+    use clipboard_rs::{Clipboard, ClipboardContent, ClipboardContext};
+    use cubby::compat_matrix_model::{
+        class_selected, parse_class_filter, summarize, AppClass, Failure, Format, MatrixSummary,
+        RowOutcome, RowResult, SkipReason, Step,
+    };
+    use cubby::paste_engine::{
+        paste_settle_delay, restore_previous_foreground_window, send_paste_input,
+        set_previous_target, PasteStrategy,
+    };
+    use std::env;
+    use std::path::{Path, PathBuf};
+    use std::process::{Child, Command};
+    use std::thread;
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+    use windows::core::PCWSTR;
+    use windows::Win32::Foundation::{CloseHandle, HANDLE, HWND, LPARAM, TRUE};
+    use windows::Win32::System::Com::{
+        CoCreateInstance, CoInitializeEx, CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED,
+    };
+    use windows::Win32::System::Variant::VARIANT;
+    use windows::Win32::UI::Accessibility::{
+        CUIAutomation, IUIAutomation, IUIAutomationElement, IUIAutomationTextPattern,
+        IUIAutomationValuePattern, TreeScope_Descendants, UIA_ControlTypePropertyId,
+        UIA_DocumentControlTypeId, UIA_EditControlTypeId, UIA_TextPatternId, UIA_ValuePatternId,
+    };
+    use windows::Win32::UI::WindowsAndMessaging::{
+        EnumWindows, GetWindowTextLengthW, GetWindowTextW, GetWindowThreadProcessId,
+        IsWindowVisible,
+    };
+
+    /// Text payload used for every row that can round-trip a string. It mixes
+    /// scripts, an emoji, and interior punctuation so a lossy transcoder shows
+    /// up as a mismatch rather than passing by luck. Single line, because the
+    /// console row reads exactly one line.
+    const TEXT_PAYLOAD: &str = "Cubby SBS-408 — café · Ελληνικά · 日本語 · 😀 · end";
+
+    const DEFAULT_TIMEOUT: Duration = Duration::from_secs(20);
+
+    /// Office and Electron editors take noticeably longer than a Notepad to go
+    /// from process start to a usable document.
+    const APP_LAUNCH_TIMEOUT: Duration = Duration::from_secs(60);
+
+    /// How many times a row re-tries the activate/focus/paste sequence before
+    /// calling it a compatibility failure.
+    const PASTE_ATTEMPTS: u32 = 3;
+
+    /// Per-attempt budget for the pasted text to show up in the target.
+    const PASTE_READBACK_TIMEOUT: Duration = Duration::from_secs(6);
+
+    struct Options {
+        filter: Vec<AppClass>,
+        list_only: bool,
+        keep_apps: bool,
+    }
+
+    pub fn run() {
+        let options = match parse_args() {
+            Ok(options) => options,
+            Err(error) => {
+                eprintln!("{error}");
+                std::process::exit(2);
+            }
+        };
+
+        if options.list_only {
+            for class in AppClass::ALL {
+                println!("{}", class.slug());
+            }
+            return;
+        }
+
+        // UI Automation and the shell paste both need COM on this thread.
+        unsafe {
+            let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+        }
+
+        let mut results = Vec::new();
+        for class in AppClass::ALL {
+            if !class_selected(class, &options.filter) {
+                results.push(RowResult {
+                    class,
+                    app: "n/a".to_string(),
+                    formats: Vec::new(),
+                    outcome: RowOutcome::Skipped {
+                        reason: SkipReason::Deselected,
+                    },
+                });
+                continue;
+            }
+
+            let result = run_class(class, &options);
+            emit_row(&result);
+            results.push(result);
+        }
+
+        let summary = summarize(&results);
+        emit_summary(&summary);
+        if !summary.passed {
+            std::process::exit(1);
+        }
+    }
+
+    fn parse_args() -> Result<Options, String> {
+        let mut filter = Vec::new();
+        let mut list_only = false;
+        let mut keep_apps = false;
+        let mut args = env::args().skip(1);
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--only" => {
+                    let raw = args.next().ok_or_else(|| {
+                        "--only requires a comma-separated class list".to_string()
+                    })?;
+                    filter = parse_class_filter(&raw)?;
+                }
+                "--list" => list_only = true,
+                "--keep-apps" => keep_apps = true,
+                other => return Err(format!("unknown argument '{other}'")),
+            }
+        }
+        Ok(Options {
+            filter,
+            list_only,
+            keep_apps,
+        })
+    }
+
+    fn emit_row(result: &RowResult) {
+        let (status, detail) = match &result.outcome {
+            RowOutcome::Passed { checks } => ("passed", format!("{checks} checks")),
+            RowOutcome::Failed { failures } => (
+                "failed",
+                failures
+                    .iter()
+                    .map(Failure::to_string)
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            ),
+            RowOutcome::Skipped { reason } => ("skipped", reason.detail()),
+        };
+        println!(
+            "{}",
+            serde_json::json!({
+                "event": "row",
+                "class": result.class.slug(),
+                "app": result.app,
+                "formats": result.formats.iter().map(|format| format.slug()).collect::<Vec<_>>(),
+                "status": status,
+                "detail": detail,
+            })
+        );
+    }
+
+    fn emit_summary(summary: &MatrixSummary) {
+        println!(
+            "{}",
+            serde_json::json!({
+                "event": "summary",
+                "passed": summary.passed,
+                "rows_total": summary.rows_total,
+                "rows_passed": summary.rows_passed,
+                "rows_failed": summary.rows_failed,
+                "rows_skipped": summary.rows_skipped,
+                "checks": summary.checks,
+                "failures": summary.failures.iter().map(|failure| serde_json::json!({
+                    "class": failure.class.slug(),
+                    "app": failure.app,
+                    "format": failure.format.slug(),
+                    "step": failure.step.slug(),
+                    "detail": failure.detail,
+                })).collect::<Vec<_>>(),
+                "classes_not_covered": summary
+                    .classes_not_covered
+                    .iter()
+                    .map(|class| class.slug())
+                    .collect::<Vec<_>>(),
+            })
+        );
+    }
+
+    fn run_class(class: AppClass, options: &Options) -> RowResult {
+        match class {
+            AppClass::LegacyWin32 => run_owned_edit_row(class, PasteStrategy::Standard),
+            AppClass::RemoteSession => run_owned_edit_row(class, PasteStrategy::RemoteSession),
+            AppClass::PackagedApp => run_uia_app_row(
+                class,
+                &[AppCandidate::new("notepad.exe", &["notepad.exe"], &[])],
+                options,
+            ),
+            AppClass::Browser => run_browser_row(class, options),
+            AppClass::Ide => run_uia_app_row(
+                class,
+                &[
+                    // Electron exposes a UIA tree only when renderer
+                    // accessibility is on; without the flag VS Code has no
+                    // editable element to find.
+                    AppCandidate::with_document("code.exe", &["code.exe"], &[], "txt"),
+                    AppCandidate::with_document("notepad++.exe", &["notepad++.exe"], &[], "txt"),
+                ],
+                options,
+            ),
+            AppClass::Office => run_uia_app_row(
+                class,
+                &[
+                    // Word opens on a start screen with no document when it is
+                    // launched bare, so the row hands it a file to open.
+                    AppCandidate::with_document("winword.exe", &["winword.exe"], &["/q"], "rtf"),
+                    AppCandidate::with_document("wordpad.exe", &["wordpad.exe"], &[], "rtf"),
+                ],
+                options,
+            ),
+            AppClass::Terminal => run_terminal_row(class),
+            AppClass::Explorer => run_explorer_row(class),
+            AppClass::Elevated => run_elevated_row(class),
+        }
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    fn failure(class: AppClass, app: &str, format: Format, step: Step, detail: String) -> Failure {
+        Failure {
+            class,
+            app: app.to_string(),
+            format,
+            step,
+            detail,
+        }
+    }
+
+    fn passed(class: AppClass, app: &str, formats: Vec<Format>, checks: usize) -> RowResult {
+        RowResult {
+            class,
+            app: app.to_string(),
+            formats,
+            outcome: RowOutcome::Passed { checks },
+        }
+    }
+
+    fn failed(
+        class: AppClass,
+        app: &str,
+        formats: Vec<Format>,
+        failures: Vec<Failure>,
+    ) -> RowResult {
+        RowResult {
+            class,
+            app: app.to_string(),
+            formats,
+            outcome: RowOutcome::Failed { failures },
+        }
+    }
+
+    fn skipped(class: AppClass, reason: SkipReason) -> RowResult {
+        RowResult {
+            class,
+            app: "n/a".to_string(),
+            formats: Vec::new(),
+            outcome: RowOutcome::Skipped { reason },
+        }
+    }
+
+    fn unique_suffix() -> u128 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    }
+
+    /// Put text on the clipboard the way Cubby restores a stored clip, and read
+    /// it back. This is the `restore` step: if the bytes do not survive the
+    /// round trip there is no point pasting them anywhere.
+    fn restore_text(clipboard: &ClipboardContext, text: &str) -> Result<(), String> {
+        clipboard
+            .set(vec![ClipboardContent::Text(text.to_string())])
+            .map_err(|error| error.to_string())?;
+        // The clipboard owner publishes asynchronously; give it a moment before
+        // reading back rather than racing it.
+        thread::sleep(Duration::from_millis(120));
+        let observed = clipboard.get_text().map_err(|error| error.to_string())?;
+        if observed != text {
+            return Err(format!(
+                "clipboard round trip differed (wrote {} chars, read {} chars)",
+                text.chars().count(),
+                observed.chars().count()
+            ));
+        }
+        Ok(())
+    }
+
+    /// The `capture` step for text: Cubby's capture policy must treat a plain
+    /// text payload as storable history rather than an ignored file payload.
+    fn capture_text_is_storable() -> Result<(), String> {
+        let policy = classify_file_payload(false, false);
+        if policy != FilePayloadPolicy::Materialize {
+            return Err(format!(
+                "text payload classified as {policy:?}, expected Materialize"
+            ));
+        }
+        Ok(())
+    }
+
+    /// Bring the target window to the foreground through the production restore
+    /// path. Split from [`send_paste`] because activating a window can move
+    /// focus within it: any per-control focusing has to happen after the window
+    /// is already frontmost, or the activation undoes it.
+    fn activate_target(hwnd: HWND, strategy: PasteStrategy) -> Result<(), String> {
+        set_previous_target(hwnd.0 as isize, strategy);
+        if !restore_with_activation(hwnd) {
+            return Err("could not restore the target window to the foreground".to_string());
+        }
+        Ok(())
+    }
+
+    fn send_paste(strategy: PasteStrategy) -> Result<(), String> {
+        thread::sleep(paste_settle_delay(strategy));
+        let sent = send_paste_input(strategy);
+        if sent != 4 {
+            return Err(format!("SendInput accepted {sent} of 4 paste events"));
+        }
+        Ok(())
+    }
+
+    fn paste_into(hwnd: HWND, strategy: PasteStrategy) -> Result<(), String> {
+        activate_target(hwnd, strategy)?;
+        send_paste(strategy)
+    }
+
+    /// Windows refuses `SetForegroundWindow` from a process that does not
+    /// already own the foreground, which is exactly the harness's situation once
+    /// it has driven one application and moved on to the next. Production's
+    /// restore is tried first so the row exercises the real code path; only when
+    /// the foreground lock refuses it does the harness fall back to a
+    /// minimize/restore cycle, which reactivates the window and grants the
+    /// foreground rights the next attempt needs.
+    fn restore_with_activation(hwnd: HWND) -> bool {
+        use windows::Win32::UI::WindowsAndMessaging::{ShowWindow, SW_MINIMIZE, SW_RESTORE};
+
+        for attempt in 0..4 {
+            if restore_previous_foreground_window() {
+                return true;
+            }
+            unsafe {
+                let _ = ShowWindow(hwnd, SW_MINIMIZE);
+                thread::sleep(Duration::from_millis(80));
+                let _ = ShowWindow(hwnd, SW_RESTORE);
+            }
+            thread::sleep(Duration::from_millis(150 * (attempt + 1)));
+        }
+        restore_previous_foreground_window()
+    }
+
+    /// Poll a read-back until it matches or the deadline passes. Applications
+    /// apply a paste asynchronously, so a single immediate read is a race.
+    fn wait_for<T, F>(timeout: Duration, mut probe: F) -> Result<T, String>
+    where
+        F: FnMut() -> Result<Option<T>, String>,
+    {
+        let deadline = Instant::now() + timeout;
+        let mut last_error = None;
+        loop {
+            match probe() {
+                Ok(Some(value)) => return Ok(value),
+                Ok(None) => {}
+                Err(error) => last_error = Some(error),
+            }
+            if Instant::now() >= deadline {
+                return Err(
+                    last_error.unwrap_or_else(|| "timed out waiting for the target".to_string())
+                );
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    fn find_executable(name: &str) -> Option<PathBuf> {
+        if let Ok(path) = env::var("PATH") {
+            for directory in env::split_paths(&path) {
+                let candidate = directory.join(name);
+                if candidate.is_file() {
+                    return Some(candidate);
+                }
+            }
+        }
+
+        // Apps that are not on PATH but live in predictable install roots.
+        let roots = [
+            env::var("ProgramFiles").ok(),
+            env::var("ProgramFiles(x86)").ok(),
+            env::var("LOCALAPPDATA")
+                .ok()
+                .map(|base| format!("{base}\\Programs")),
+        ];
+        for root in roots.into_iter().flatten() {
+            let root = PathBuf::from(root);
+            if let Some(found) = search_shallow(&root, name, 3) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    /// Bounded-depth search: install roots are wide, and an unbounded walk of
+    /// Program Files costs seconds per lookup.
+    fn search_shallow(directory: &Path, name: &str, depth: usize) -> Option<PathBuf> {
+        let candidate = directory.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if depth == 0 {
+            return None;
+        }
+        let entries = std::fs::read_dir(directory).ok()?;
+        for entry in entries.flatten() {
+            if entry.file_type().ok()?.is_dir() {
+                if let Some(found) = search_shallow(&entry.path(), name, depth - 1) {
+                    return Some(found);
+                }
+            }
+        }
+        None
+    }
+
+    // ------------------------------------------------------- window discovery
+
+    struct WindowSearch {
+        pid: u32,
+        /// Packaged apps (Win11 Notepad) and browsers hand the launch off to an
+        /// already-running host process, so the window we want frequently
+        /// belongs to a different pid than the one we spawned. Matching the
+        /// executable name as well is what keeps those rows runnable.
+        exe_name: String,
+        found: HWND,
+    }
+
+    unsafe extern "system" fn enum_window_proc(hwnd: HWND, lparam: LPARAM) -> windows::core::BOOL {
+        let search = &mut *(lparam.0 as *mut WindowSearch);
+        if !IsWindowVisible(hwnd).as_bool() || GetWindowTextLengthW(hwnd) == 0 {
+            return TRUE;
+        }
+        let mut pid = 0_u32;
+        GetWindowThreadProcessId(hwnd, Some(&mut pid));
+        let matches = pid == search.pid
+            || process_image_name(pid)
+                .is_some_and(|name| name.eq_ignore_ascii_case(&search.exe_name));
+        if matches {
+            search.found = hwnd;
+            return windows::core::BOOL(0); // stop enumerating
+        }
+        TRUE
+    }
+
+    fn process_image_name(pid: u32) -> Option<String> {
+        use windows::Win32::System::Threading::{
+            OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_FORMAT,
+            PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+        unsafe {
+            let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid).ok()?;
+            let mut buffer = [0_u16; 512];
+            let mut length = buffer.len() as u32;
+            let result = QueryFullProcessImageNameW(
+                handle,
+                PROCESS_NAME_FORMAT(0),
+                windows::core::PWSTR(buffer.as_mut_ptr()),
+                &mut length,
+            );
+            let _ = CloseHandle(handle);
+            result.ok()?;
+            let path = String::from_utf16_lossy(&buffer[..length as usize]);
+            Path::new(&path)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(str::to_string)
+        }
+    }
+
+    fn enum_find_window(pid: u32, exe_name: &str) -> Option<HWND> {
+        let mut search = WindowSearch {
+            pid,
+            exe_name: exe_name.to_string(),
+            found: HWND::default(),
+        };
+        unsafe {
+            let _ = EnumWindows(
+                Some(enum_window_proc),
+                LPARAM(&mut search as *mut WindowSearch as isize),
+            );
+        }
+        (!search.found.0.is_null()).then_some(search.found)
+    }
+
+    fn window_text(hwnd: HWND) -> String {
+        unsafe {
+            let length = GetWindowTextLengthW(hwnd);
+            if length <= 0 {
+                return String::new();
+            }
+            let mut buffer = vec![0_u16; length as usize + 1];
+            let read = GetWindowTextW(hwnd, &mut buffer);
+            String::from_utf16_lossy(&buffer[..read as usize])
+        }
+    }
+
+    // ------------------------------------------------------------ UI Automation
+
+    struct Uia {
+        automation: IUIAutomation,
+    }
+
+    impl Uia {
+        fn new() -> Result<Self, String> {
+            let automation: IUIAutomation = unsafe {
+                CoCreateInstance(&CUIAutomation, None, CLSCTX_INPROC_SERVER).map_err(|error| {
+                    format!("could not create the UI Automation client: {error}")
+                })?
+            };
+            Ok(Self { automation })
+        }
+
+        /// First descendant that can hold editable text. Value pattern is
+        /// preferred because it can both write and read; a document with only a
+        /// text pattern is read-only to us but still verifies a paste.
+        fn editable(&self, hwnd: HWND) -> Result<EditableTarget, String> {
+            let root = unsafe {
+                self.automation
+                    .ElementFromHandle(hwnd)
+                    .map_err(|error| format!("no automation element for the window: {error}"))?
+            };
+
+            // Collect every text-bearing control rather than picking one.
+            // Neither ordering works alone: Word's first Edit is the ribbon
+            // search box while its content lives in the Document, and a
+            // browser's page Document does not report a textarea's live value
+            // while the textarea's own Edit does. Reading across all candidates
+            // is what makes one driver work for both.
+            let mut elements = Vec::new();
+            for control_type in [UIA_DocumentControlTypeId, UIA_EditControlTypeId] {
+                let condition = unsafe {
+                    self.automation
+                        .CreatePropertyCondition(
+                            UIA_ControlTypePropertyId,
+                            &VARIANT::from(control_type.0),
+                        )
+                        .map_err(|error| {
+                            format!("could not build a control-type condition: {error}")
+                        })?
+                };
+                let found = unsafe { root.FindAll(TreeScope_Descendants, &condition) };
+                let Ok(found) = found else { continue };
+                let length = unsafe { found.Length() }.unwrap_or(0);
+                for index in 0..length.min(MAX_TEXT_CANDIDATES) {
+                    if let Ok(element) = unsafe { found.GetElement(index) } {
+                        elements.push(element);
+                    }
+                }
+            }
+
+            if elements.is_empty() {
+                return Err("no Edit or Document control was found in the window".to_string());
+            }
+            Ok(EditableTarget { elements })
+        }
+    }
+
+    /// Enough to cover a document plus the surrounding chrome without walking a
+    /// pathological tree.
+    const MAX_TEXT_CANDIDATES: i32 = 12;
+
+    struct EditableTarget {
+        elements: Vec<IUIAutomationElement>,
+    }
+
+    impl EditableTarget {
+        /// Focus the candidate whose accessible name contains `marker`.
+        ///
+        /// A browser window exposes the address bar and the page's own controls
+        /// in one tree, and the address bar sorts first. Focusing "the first
+        /// editable control" there types into the omnibox -- which still reads
+        /// back the payload, so the row would report a pass having never
+        /// involved the page at all. The test page labels its textarea so the
+        /// row can target it exactly.
+        fn has_named(&self, marker: &str) -> bool {
+            self.elements.iter().any(|element| {
+                unsafe { element.CurrentName() }
+                    .map(|name| name.to_string())
+                    .unwrap_or_default()
+                    .contains(marker)
+            })
+        }
+
+        fn focus_named(&self, marker: &str) -> Result<(), String> {
+            for element in &self.elements {
+                let name = unsafe { element.CurrentName() }
+                    .map(|name| name.to_string())
+                    .unwrap_or_default();
+                if name.contains(marker) {
+                    return unsafe { element.SetFocus() }
+                        .map_err(|error| format!("could not focus '{marker}': {error}"));
+                }
+            }
+            Err(format!("no text control named '{marker}' was found"))
+        }
+
+        /// Focus the first candidate, which is the document for a document-based
+        /// app.
+        fn focus(&self) -> Result<(), String> {
+            let mut last_error = None;
+            for element in &self.elements {
+                match unsafe { element.SetFocus() } {
+                    Ok(()) => return Ok(()),
+                    Err(error) => last_error = Some(error),
+                }
+            }
+            Err(format!(
+                "could not focus any text control: {}",
+                last_error
+                    .map(|error| error.to_string())
+                    .unwrap_or_else(|| "no candidates".to_string())
+            ))
+        }
+
+        fn clear(&self) {
+            for element in &self.elements {
+                unsafe {
+                    if let Ok(pattern) =
+                        element.GetCurrentPatternAs::<IUIAutomationValuePattern>(UIA_ValuePatternId)
+                    {
+                        if pattern
+                            .CurrentIsReadOnly()
+                            .is_ok_and(|read_only| read_only.as_bool())
+                        {
+                            continue;
+                        }
+                        let _ = pattern.SetValue(&windows::core::BSTR::from(""));
+                    }
+                }
+            }
+        }
+
+        /// Text visible across every candidate control. The caller looks for the
+        /// payload as a substring, so joining is enough and avoids having to
+        /// guess which control the paste landed in.
+        fn read(&self) -> Result<String, String> {
+            let mut parts = Vec::new();
+            let mut supported = false;
+
+            for element in &self.elements {
+                unsafe {
+                    // Word's document exposes a Value pattern that always reads
+                    // back empty while the real content is only reachable
+                    // through the Text pattern, so an empty Value must fall
+                    // through instead of being taken as the contents.
+                    if let Ok(pattern) =
+                        element.GetCurrentPatternAs::<IUIAutomationValuePattern>(UIA_ValuePatternId)
+                    {
+                        supported = true;
+                        if let Ok(value) = pattern.CurrentValue() {
+                            let value = value.to_string();
+                            if !value.is_empty() {
+                                parts.push(value);
+                                continue;
+                            }
+                        }
+                    }
+
+                    if let Ok(pattern) =
+                        element.GetCurrentPatternAs::<IUIAutomationTextPattern>(UIA_TextPatternId)
+                    {
+                        supported = true;
+                        if let Ok(range) = pattern.DocumentRange() {
+                            if let Ok(text) = range.GetText(-1) {
+                                parts.push(text.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+
+            if !supported {
+                return Err("no control exposes a Value or Text pattern".to_string());
+            }
+            Ok(parts.join("\n"))
+        }
+    }
+
+    // ------------------------------------------------------------ app launching
+
+    struct AppCandidate {
+        label: &'static str,
+        executables: &'static [&'static str],
+        args: &'static [&'static str],
+        /// When set, a temporary file with this extension is created and passed
+        /// as the last argument. Editors that open on a start screen or a
+        /// welcome tab have no editable control until a document exists.
+        document_ext: Option<&'static str>,
+    }
+
+    impl AppCandidate {
+        const fn new(
+            label: &'static str,
+            executables: &'static [&'static str],
+            args: &'static [&'static str],
+        ) -> Self {
+            Self {
+                label,
+                executables,
+                args,
+                document_ext: None,
+            }
+        }
+
+        const fn with_document(
+            label: &'static str,
+            executables: &'static [&'static str],
+            args: &'static [&'static str],
+            document_ext: &'static str,
+        ) -> Self {
+            Self {
+                label,
+                executables,
+                args,
+                document_ext: Some(document_ext),
+            }
+        }
+    }
+
+    /// A launched process that is killed when the row finishes, so a failed run
+    /// does not leave Word or a browser sitting on the desktop.
+    struct LaunchedApp {
+        child: Option<Child>,
+        keep: bool,
+    }
+
+    impl LaunchedApp {
+        fn spawn(path: &Path, args: &[&str], keep: bool) -> Result<Self, String> {
+            let child = Command::new(path)
+                .args(args)
+                .spawn()
+                .map_err(|error| format!("could not launch {}: {error}", path.display()))?;
+            Ok(Self {
+                child: Some(child),
+                keep,
+            })
+        }
+
+        fn pid(&self) -> u32 {
+            self.child.as_ref().map(Child::id).unwrap_or_default()
+        }
+    }
+
+    impl Drop for LaunchedApp {
+        fn drop(&mut self) {
+            if self.keep {
+                return;
+            }
+            if let Some(mut child) = self.child.take() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------- rows
+
+    /// Legacy Win32 and remote-session rows both paste into a plain EDIT control
+    /// we own. Owning the target is what makes these two rows dependency-free:
+    /// they run on any machine and isolate the paste engine from app quirks.
+    fn run_owned_edit_row(class: AppClass, strategy: PasteStrategy) -> RowResult {
+        let app = match strategy {
+            PasteStrategy::RemoteSession => "owned EDIT control (remote-session strategy)",
+            _ => "owned EDIT control",
+        };
+        let formats = vec![Format::UnicodeText];
+
+        let target = match owned_edit_window() {
+            Ok(target) => target,
+            Err(error) => {
+                return failed(
+                    class,
+                    app,
+                    formats,
+                    vec![failure(class, app, Format::UnicodeText, Step::Paste, error)],
+                )
+            }
+        };
+
+        let clipboard = match ClipboardContext::new() {
+            Ok(clipboard) => clipboard,
+            Err(error) => {
+                return failed(
+                    class,
+                    app,
+                    formats,
+                    vec![failure(
+                        class,
+                        app,
+                        Format::UnicodeText,
+                        Step::Restore,
+                        error.to_string(),
+                    )],
+                )
+            }
+        };
+
+        let mut failures = Vec::new();
+        let mut checks = 0;
+
+        match capture_text_is_storable() {
+            Ok(()) => checks += 1,
+            Err(error) => failures.push(failure(
+                class,
+                app,
+                Format::UnicodeText,
+                Step::Capture,
+                error,
+            )),
+        }
+        match restore_text(&clipboard, TEXT_PAYLOAD) {
+            Ok(()) => checks += 1,
+            Err(error) => failures.push(failure(
+                class,
+                app,
+                Format::UnicodeText,
+                Step::Restore,
+                error,
+            )),
+        }
+
+        if failures.is_empty() {
+            match owned_edit_paste(&target, strategy) {
+                Ok(()) => checks += 1,
+                Err(error) => {
+                    failures.push(failure(class, app, Format::UnicodeText, Step::Paste, error))
+                }
+            }
+        }
+
+        if failures.is_empty() {
+            passed(class, app, formats, checks)
+        } else {
+            failed(class, app, formats, failures)
+        }
+    }
+
+    /// Generic row: launch a real application, find its editable control, paste,
+    /// and read the text back out of the app itself.
+    fn run_uia_app_row(
+        class: AppClass,
+        candidates: &[AppCandidate],
+        options: &Options,
+    ) -> RowResult {
+        let mut looked_for = Vec::new();
+        let mut chosen = None;
+        for candidate in candidates {
+            for executable in candidate.executables {
+                looked_for.push((*executable).to_string());
+                if let Some(path) = find_executable(executable) {
+                    chosen = Some((candidate, path));
+                    break;
+                }
+            }
+            if chosen.is_some() {
+                break;
+            }
+        }
+
+        let Some((candidate, path)) = chosen else {
+            return skipped(
+                class,
+                SkipReason::NoAppInstalled {
+                    candidates: looked_for,
+                },
+            );
+        };
+
+        let app = candidate.label;
+        let formats = vec![Format::UnicodeText];
+
+        let mut args: Vec<String> = candidate
+            .args
+            .iter()
+            .map(|arg| (*arg).to_string())
+            .collect();
+        let mut document = None;
+        if let Some(extension) = candidate.document_ext {
+            let path =
+                env::temp_dir().join(format!("cubby-compat-{}.{extension}", unique_suffix()));
+            if let Err(error) = std::fs::write(&path, b"") {
+                return failed(
+                    class,
+                    app,
+                    formats,
+                    vec![failure(
+                        class,
+                        app,
+                        Format::UnicodeText,
+                        Step::Paste,
+                        format!("could not create a document for {app}: {error}"),
+                    )],
+                );
+            }
+            args.push(path.to_string_lossy().into_owned());
+            document = Some(path);
+        }
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+
+        // Located by pid/executable rather than by window title: editors that
+        // put the document name in the title bar do exist, but matching on it
+        // costs more than it buys -- Word's window is titled before it is ready
+        // to accept a paste.
+        let outcome = drive_uia_app(class, app, &path, &arg_refs, options.keep_apps, None, None);
+        if let Some(document) = document {
+            let _ = std::fs::remove_file(document);
+        }
+        match outcome {
+            DriveOutcome::Passed(checks) => passed(class, app, formats, checks),
+            DriveOutcome::Failed(failures) => failed(class, app, formats, failures),
+            // An app that never exposes an editable element cannot be driven
+            // through UI Automation at all. That is a limit of the harness on
+            // this machine, not evidence that Cubby's paste is broken, so it is
+            // reported as an uncovered class rather than a red run.
+            DriveOutcome::NotAutomatable(detail) => skipped(
+                class,
+                SkipReason::EnvironmentNotApplicable {
+                    detail: format!(
+                        "{app} exposed no UI Automation text control to paste into: {detail}"
+                    ),
+                },
+            ),
+        }
+    }
+
+    enum DriveOutcome {
+        Passed(usize),
+        NotAutomatable(String),
+        Failed(Vec<Failure>),
+    }
+
+    fn drive_uia_app(
+        class: AppClass,
+        app: &str,
+        path: &Path,
+        args: &[&str],
+        keep: bool,
+        focus_marker: Option<&str>,
+        title_marker: Option<&str>,
+    ) -> DriveOutcome {
+        let mut failures = Vec::new();
+        let mut checks = 0;
+
+        let clipboard = match ClipboardContext::new() {
+            Ok(clipboard) => clipboard,
+            Err(error) => {
+                return DriveOutcome::Failed(vec![failure(
+                    class,
+                    app,
+                    Format::UnicodeText,
+                    Step::Restore,
+                    error.to_string(),
+                )])
+            }
+        };
+
+        match capture_text_is_storable() {
+            Ok(()) => checks += 1,
+            Err(error) => failures.push(failure(
+                class,
+                app,
+                Format::UnicodeText,
+                Step::Capture,
+                error,
+            )),
+        }
+        match restore_text(&clipboard, TEXT_PAYLOAD) {
+            Ok(()) => checks += 1,
+            Err(error) => failures.push(failure(
+                class,
+                app,
+                Format::UnicodeText,
+                Step::Restore,
+                error,
+            )),
+        }
+        if !failures.is_empty() {
+            return DriveOutcome::Failed(failures);
+        }
+
+        let launched = match LaunchedApp::spawn(path, args, keep) {
+            Ok(launched) => launched,
+            Err(error) => {
+                return DriveOutcome::Failed(vec![failure(
+                    class,
+                    app,
+                    Format::UnicodeText,
+                    Step::Paste,
+                    error,
+                )])
+            }
+        };
+
+        let exe_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default();
+        let uia = match Uia::new() {
+            Ok(uia) => uia,
+            Err(error) => return DriveOutcome::NotAutomatable(error),
+        };
+
+        // Resolve the window and its editable control together, re-reading the
+        // window on every attempt. A big application shows a splash or
+        // start-screen window first, and latching onto that one means querying
+        // an element that never gains a document.
+        //
+        // Failing to find any editable element is deliberately NOT a row
+        // failure: it means the harness cannot drive this app, which is a
+        // different claim from "the paste did not work".
+        let resolved = wait_for(APP_LAUNCH_TIMEOUT, || {
+            // A title marker takes precedence when the caller has one. Browsers
+            // are the reason: the launcher process exits once it has handed the
+            // URL to the browser, so there is no window under our pid, and
+            // falling back to the executable name finds whichever Edge window
+            // happened to be open already -- a different profile, without our
+            // page in it.
+            let window = match title_marker {
+                Some(marker) => window_with_title(marker),
+                None => {
+                    enum_find_window(launched.pid(), "").or_else(|| enum_find_window(0, exe_name))
+                }
+            };
+            let Some(hwnd) = window else {
+                return Err(match title_marker {
+                    Some(marker) => format!("no visible window titled '{marker}'"),
+                    None => format!(
+                        "no visible top-level window for pid {} or any {exe_name} process",
+                        launched.pid()
+                    ),
+                });
+            };
+            match uia.editable(hwnd) {
+                // Keep waiting until the specific control exists. A browser
+                // exposes its address bar immediately but builds the page's
+                // accessibility tree only after the document renders, so
+                // accepting the first tree that has any text control at all
+                // snapshots the window before the page is in it.
+                Ok(target) => match focus_marker {
+                    Some(marker) if !target.has_named(marker) => {
+                        Err(format!("no text control named '{marker}' yet"))
+                    }
+                    _ => Ok(Some((hwnd, target))),
+                },
+                Err(error) => Err(error),
+            }
+        });
+        let (hwnd, target) = match resolved {
+            Ok(resolved) => resolved,
+            Err(error) => return DriveOutcome::NotAutomatable(error),
+        };
+
+        let paste_result = (|| -> Result<(), String> {
+            // Activating a window, focusing a control inside it, and having the
+            // keystrokes arrive are three separate asynchronous events, and a
+            // desktop that has just had several other applications raised in
+            // front of it loses these races. Retry the whole sequence rather
+            // than reporting a flake as a compatibility failure.
+            let mut last = String::new();
+            for attempt in 0..PASTE_ATTEMPTS {
+                target.clear();
+
+                // Activate first, focus second, paste third. Activating the
+                // window can move focus inside it, so focusing a specific
+                // control before the window is frontmost is silently undone.
+                activate_target(hwnd, PasteStrategy::Standard)?;
+                thread::sleep(Duration::from_millis(250));
+                match focus_marker {
+                    // A named target must be focusable: otherwise the paste
+                    // lands elsewhere in the window and the row silently tests
+                    // the wrong control -- a browser's address bar, typically,
+                    // which reads the payload back and looks like a pass.
+                    Some(marker) => target.focus_named(marker)?,
+                    // Best effort otherwise: some documents refuse programmatic
+                    // focus while still accepting a paste, and the read-back is
+                    // the real assertion.
+                    None => {
+                        let _ = target.focus();
+                    }
+                }
+                send_paste(PasteStrategy::Standard)?;
+
+                let observed = wait_for(PASTE_READBACK_TIMEOUT, || {
+                    let text = target.read()?;
+                    Ok(text.contains(TEXT_PAYLOAD).then_some(text))
+                });
+                match observed {
+                    Ok(text) => {
+                        if text.contains(TEXT_PAYLOAD) {
+                            return Ok(());
+                        }
+                        last = text;
+                    }
+                    Err(error) => last = error,
+                }
+                if attempt + 1 < PASTE_ATTEMPTS {
+                    thread::sleep(Duration::from_millis(500));
+                }
+            }
+
+            Err(format!(
+                "pasted text never appeared in the target control after {PASTE_ATTEMPTS} attempts (last read: {:?})",
+                truncate(&last)
+            ))
+        })();
+
+        match paste_result {
+            Ok(()) => checks += 1,
+            Err(error) => {
+                failures.push(failure(class, app, Format::UnicodeText, Step::Paste, error))
+            }
+        }
+
+        // Killing the child is not enough for apps whose launcher hands off to
+        // another process and exits -- a browser being the usual case -- so the
+        // window itself is asked to close. Without this every run leaves one
+        // more window on the desktop.
+        if !keep {
+            close_window(hwnd);
+        }
+
+        if failures.is_empty() {
+            DriveOutcome::Passed(checks)
+        } else {
+            DriveOutcome::Failed(failures)
+        }
+    }
+
+    fn close_window(hwnd: HWND) {
+        use windows::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
+        unsafe {
+            let _ = PostMessageW(Some(hwnd), WM_CLOSE, Default::default(), Default::default());
+        }
+    }
+
+    fn truncate(text: &str) -> String {
+        let trimmed: String = text.chars().take(80).collect();
+        if text.chars().count() > 80 {
+            format!("{trimmed}...")
+        } else {
+            trimmed
+        }
+    }
+
+    /// Browsers refuse top-level `data:` navigation, so the row writes a real
+    /// HTML file with a textarea and opens it over `file://`.
+    fn run_browser_row(class: AppClass, options: &Options) -> RowResult {
+        let candidates = ["msedge.exe", "chrome.exe", "firefox.exe"];
+        let mut looked_for = Vec::new();
+        let mut chosen = None;
+        for executable in candidates {
+            looked_for.push(executable.to_string());
+            if let Some(path) = find_executable(executable) {
+                chosen = Some((executable, path));
+                break;
+            }
+        }
+        let Some((app, path)) = chosen else {
+            return skipped(
+                class,
+                SkipReason::NoAppInstalled {
+                    candidates: looked_for,
+                },
+            );
+        };
+
+        let page_title = format!("CubbyCompatPage{}", unique_suffix());
+        let page = match write_browser_page(&page_title) {
+            Ok(page) => page,
+            Err(error) => {
+                return failed(
+                    class,
+                    app,
+                    vec![Format::UnicodeText],
+                    vec![failure(class, app, Format::UnicodeText, Step::Paste, error)],
+                )
+            }
+        };
+        let url = format!("file:///{}", page.to_string_lossy().replace('\\', "/"));
+        // A private profile directory is what makes the other flags mean
+        // anything: an already-running browser would otherwise adopt the URL
+        // into its existing process and silently drop the command line, leaving
+        // the row driving somebody else's window.
+        let profile = env::temp_dir().join(format!("cubby-compat-profile-{}", unique_suffix()));
+        let profile_arg = format!("--user-data-dir={}", profile.to_string_lossy());
+        // Chromium only builds an accessibility tree for page content when an
+        // assistive client asks for it. Without this flag the textarea is
+        // invisible to UI Automation and the only Edit control in the window is
+        // the address bar -- which a naive driver will happily paste into and
+        // call a pass.
+        let args: Vec<&str> = vec![
+            &profile_arg,
+            "--no-first-run",
+            "--no-default-browser-check",
+            "--new-window",
+            "--force-renderer-accessibility",
+            &url,
+        ];
+
+        let formats = vec![Format::UnicodeText];
+        let outcome = drive_uia_app(
+            class,
+            app,
+            &path,
+            &args,
+            options.keep_apps,
+            Some(BROWSER_TARGET_LABEL),
+            Some(&page_title),
+        );
+        let _ = std::fs::remove_file(&page);
+        if !options.keep_apps {
+            let _ = std::fs::remove_dir_all(&profile);
+        }
+        match outcome {
+            DriveOutcome::Passed(checks) => passed(class, app, formats, checks),
+            DriveOutcome::Failed(failures) => failed(class, app, formats, failures),
+            DriveOutcome::NotAutomatable(detail) => skipped(
+                class,
+                SkipReason::EnvironmentNotApplicable {
+                    detail: format!(
+                        "{app} exposed no UI Automation text control to paste into: {detail}"
+                    ),
+                },
+            ),
+        }
+    }
+
+    /// Accessible name of the test page's textarea, used to focus exactly that
+    /// control rather than the address bar.
+    const BROWSER_TARGET_LABEL: &str = "cubby paste target";
+
+    /// The page carries a unique title so the row can find its own browser
+    /// window, and a labelled textarea so it can find the right control inside
+    /// that window.
+    fn write_browser_page(title: &str) -> Result<PathBuf, String> {
+        let path = env::temp_dir().join(format!("cubby-compat-{}.html", unique_suffix()));
+        let html = format!(
+            "<!doctype html><meta charset=\"utf-8\"><title>{title}</title>\
+             <textarea id=\"t\" autofocus rows=\"8\" cols=\"60\" \
+             aria-label=\"{BROWSER_TARGET_LABEL}\"></textarea>"
+        );
+        std::fs::write(&path, html).map_err(|error| error.to_string())?;
+        Ok(path)
+    }
+
+    /// Console paste goes through conhost rather than the window's edit control,
+    /// so the row lets `cmd.exe` read one line and write it to a file. The file
+    /// is the assertion: it proves the console actually received the text.
+    fn run_terminal_row(class: AppClass) -> RowResult {
+        let app = "powershell.exe in Windows Terminal";
+        let Some(terminal_path) = find_executable("wt.exe") else {
+            return skipped(
+                class,
+                SkipReason::NoAppInstalled {
+                    candidates: vec!["wt.exe".to_string()],
+                },
+            );
+        };
+        let formats = vec![Format::UnicodeText];
+        match drive_terminal(class, app, &terminal_path) {
+            Ok(checks) => passed(class, app, formats, checks),
+            Err(failures) => failed(class, app, formats, failures),
+        }
+    }
+
+    fn drive_terminal(
+        class: AppClass,
+        app: &str,
+        terminal_path: &Path,
+    ) -> Result<usize, Vec<Failure>> {
+        let mut checks = 0;
+        let clipboard = ClipboardContext::new().map_err(|error| {
+            vec![failure(
+                class,
+                app,
+                Format::UnicodeText,
+                Step::Restore,
+                error.to_string(),
+            )]
+        })?;
+
+        capture_text_is_storable().map_err(|error| {
+            vec![failure(
+                class,
+                app,
+                Format::UnicodeText,
+                Step::Capture,
+                error,
+            )]
+        })?;
+        checks += 1;
+        restore_text(&clipboard, TEXT_PAYLOAD).map_err(|error| {
+            vec![failure(
+                class,
+                app,
+                Format::UnicodeText,
+                Step::Restore,
+                error,
+            )]
+        })?;
+        checks += 1;
+
+        let suffix = unique_suffix();
+        let file_name = format!("cubby-compat-console-{suffix}.txt");
+        let output = env::temp_dir().join(&file_name);
+        let _ = std::fs::remove_file(&output);
+        // Three Windows details are load-bearing here:
+        //  * the console is launched with `wt -w new`. Spawning cmd.exe with
+        //    CREATE_NEW_CONSOLE opens a new *tab* in the existing Windows
+        //    Terminal window on Windows 11, leaving no top-level window of our
+        //    own to paste into, and routing through conhost.exe instead makes
+        //    conhost take over this process's console. `-w new` forces a fresh
+        //    window and `--title` makes it findable, since the window belongs to
+        //    WindowsTerminal.exe rather than to the pid we spawned;
+        //  * `/v:on` plus `!line!` is required, because `%line%` would be
+        //    expanded when the command line is parsed -- before `set /p` reads;
+        //  * the command must contain no double quotes. Rust escapes inner
+        //    quotes as \" when it builds the command line, which cmd.exe does
+        //    not understand, so `cd /d` moves to the temp directory (taking the
+        //    rest of the line, spaces and all) and the redirect target is then a
+        //    bare file name that never needs quoting.
+        let title = format!("CubbyCompatConsole{suffix}");
+        // PowerShell rather than cmd.exe. `cmd`'s `set /p` reads console input
+        // through the console code page and returns "caf?" for "café" even
+        // after `chcp 65001`, which would report a Cubby paste bug that is
+        // really a cmd.exe limitation. `Read-Host` is UTF-16 throughout, so a
+        // mismatch here is a genuine paste failure.
+        //
+        // `$env:TEMP\<name>` keeps the command free of double quotes: Rust
+        // escapes inner quotes as \" when building the command line, which
+        // neither cmd nor PowerShell parses the way it is intended.
+        let command =
+            format!("Read-Host | Set-Content -LiteralPath $env:TEMP\\{file_name} -Encoding utf8");
+
+        let result = (|| -> Result<(), String> {
+            let mut launched = LaunchedApp::spawn(
+                terminal_path,
+                &[
+                    "-w",
+                    "new",
+                    "--title",
+                    &title,
+                    "powershell.exe",
+                    "-NoProfile",
+                    "-Command",
+                    &command,
+                ],
+                false,
+            )?;
+            let hwnd = wait_for(DEFAULT_TIMEOUT, || Ok(window_with_title(&title)))
+                .map_err(|_| "the cmd.exe console window never appeared".to_string())?;
+            paste_into(hwnd, PasteStrategy::Standard)?;
+            thread::sleep(Duration::from_millis(300));
+            send_enter()?;
+
+            let observed = wait_for(DEFAULT_TIMEOUT, || match std::fs::read(&output) {
+                Ok(bytes) if !bytes.is_empty() => Ok(Some(decode_console_bytes(&bytes))),
+                _ => Ok(None),
+            })
+            .map_err(|_| "the shell never wrote the pasted line".to_string())?;
+
+            if let Some(child) = launched.child.as_mut() {
+                let _ = child.wait();
+            }
+
+            let observed = observed.trim_end_matches(['\r', '\n']).to_string();
+            if observed != TEXT_PAYLOAD {
+                return Err(format!(
+                    "console received {:?} instead of the payload",
+                    truncate(&observed)
+                ));
+            }
+            Ok(())
+        })();
+
+        let _ = std::fs::remove_file(&output);
+        match result {
+            Ok(()) => Ok(checks + 1),
+            Err(error) => Err(vec![failure(
+                class,
+                app,
+                Format::UnicodeText,
+                Step::Paste,
+                error,
+            )]),
+        }
+    }
+
+    /// `echo` writes the console's OEM code page. Try UTF-8 first (which modern
+    /// Windows consoles use) and fall back to a lossy read so a decode problem
+    /// surfaces as a text mismatch rather than an unrelated error.
+    fn decode_console_bytes(bytes: &[u8]) -> String {
+        let bytes = bytes.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or(bytes);
+        match std::str::from_utf8(bytes) {
+            Ok(text) => text.to_string(),
+            Err(_) => String::from_utf8_lossy(bytes).into_owned(),
+        }
+    }
+
+    fn send_enter() -> Result<(), String> {
+        use windows::Win32::UI::Input::KeyboardAndMouse::{
+            SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP, VK_RETURN,
+        };
+        let inputs = [
+            INPUT {
+                r#type: INPUT_KEYBOARD,
+                Anonymous: INPUT_0 {
+                    ki: KEYBDINPUT {
+                        wVk: VK_RETURN,
+                        ..Default::default()
+                    },
+                },
+            },
+            INPUT {
+                r#type: INPUT_KEYBOARD,
+                Anonymous: INPUT_0 {
+                    ki: KEYBDINPUT {
+                        wVk: VK_RETURN,
+                        dwFlags: KEYEVENTF_KEYUP,
+                        ..Default::default()
+                    },
+                },
+            },
+        ];
+        let sent = unsafe { SendInput(&inputs, std::mem::size_of::<INPUT>() as i32) };
+        if sent as usize != inputs.len() {
+            return Err(format!(
+                "SendInput accepted {sent} of {} events",
+                inputs.len()
+            ));
+        }
+        Ok(())
+    }
+
+    /// Explorer is the file-payload row. Cubby deliberately does not store file
+    /// payloads, so the assertion is the product contract: the payload is
+    /// classified as ignored, Explorer still pastes it, and a later text copy is
+    /// still captured -- an ignored payload must not wedge capture.
+    fn run_explorer_row(class: AppClass) -> RowResult {
+        let app = "explorer.exe";
+        let formats = vec![Format::FilePayload, Format::UnicodeText];
+        match drive_explorer(class, app) {
+            Ok(checks) => passed(class, app, formats, checks),
+            Err(failures) => failed(class, app, formats, failures),
+        }
+    }
+
+    fn drive_explorer(class: AppClass, app: &str) -> Result<usize, Vec<Failure>> {
+        let mut checks = 0;
+        let suffix = unique_suffix();
+        let source_dir = env::temp_dir().join(format!("cubby-compat-src-{suffix}"));
+        let dest_dir = env::temp_dir().join(format!("cubby-compat-dst-{suffix}"));
+        let file_name = "cubby-compat-payload.txt";
+        let source_file = source_dir.join(file_name);
+
+        let setup = (|| -> Result<(), String> {
+            std::fs::create_dir_all(&source_dir).map_err(|error| error.to_string())?;
+            std::fs::create_dir_all(&dest_dir).map_err(|error| error.to_string())?;
+            std::fs::write(&source_file, TEXT_PAYLOAD).map_err(|error| error.to_string())
+        })();
+        if let Err(error) = setup {
+            return Err(vec![failure(
+                class,
+                app,
+                Format::FilePayload,
+                Step::Restore,
+                error,
+            )]);
+        }
+
+        // capture: a file payload with no image alongside it is not durable
+        // history, so Cubby must classify it as ignored.
+        let policy = classify_file_payload(true, false);
+        if policy != FilePayloadPolicy::IgnoreFilePayload {
+            return Err(vec![failure(
+                class,
+                app,
+                Format::FilePayload,
+                Step::Capture,
+                format!("file payload classified as {policy:?}, expected IgnoreFilePayload"),
+            )]);
+        }
+        checks += 1;
+
+        let clipboard = ClipboardContext::new().map_err(|error| {
+            vec![failure(
+                class,
+                app,
+                Format::FilePayload,
+                Step::Restore,
+                error.to_string(),
+            )]
+        })?;
+
+        let mut failures = Vec::new();
+        let paste_result = (|| -> Result<(), String> {
+            clipboard
+                .set(vec![ClipboardContent::Files(vec![source_file
+                    .to_string_lossy()
+                    .into_owned()])])
+                .map_err(|error| {
+                    format!("could not put the file payload on the clipboard: {error}")
+                })?;
+            thread::sleep(Duration::from_millis(200));
+
+            let mut launched = LaunchedApp::spawn(
+                Path::new("explorer.exe"),
+                &[&dest_dir.to_string_lossy()],
+                false,
+            )?;
+            // explorer.exe hands off to the running shell process and exits, so
+            // the window belongs to a different pid than the one we spawned.
+            let _ = launched.child.as_mut().map(|child| child.wait());
+            let hwnd = wait_for(DEFAULT_TIMEOUT, || Ok(explorer_window_for(&dest_dir)))
+                .map_err(|_| format!("no Explorer window opened on {}", dest_dir.display()))?;
+
+            paste_into(hwnd, PasteStrategy::Standard)?;
+
+            wait_for(DEFAULT_TIMEOUT, || {
+                Ok(dest_dir.join(file_name).is_file().then_some(()))
+            })
+            .map_err(|_| "Explorer did not paste the file into the destination".to_string())?;
+            Ok(())
+        })();
+
+        match paste_result {
+            Ok(()) => checks += 1,
+            Err(error) => {
+                failures.push(failure(class, app, Format::FilePayload, Step::Paste, error))
+            }
+        }
+
+        // The contract's second half: an ignored payload must not block the next
+        // real capture.
+        match restore_text(&clipboard, TEXT_PAYLOAD) {
+            Ok(()) => checks += 1,
+            Err(error) => failures.push(failure(
+                class,
+                app,
+                Format::UnicodeText,
+                Step::Capture,
+                format!("clipboard was left unusable after an ignored file payload: {error}"),
+            )),
+        }
+
+        let _ = std::fs::remove_dir_all(&source_dir);
+        let _ = std::fs::remove_dir_all(&dest_dir);
+
+        if failures.is_empty() {
+            Ok(checks)
+        } else {
+            Err(failures)
+        }
+    }
+
+    /// Explorer windows are owned by the long-running shell process, so they are
+    /// found by title rather than by the pid we spawned.
+    fn explorer_window_for(directory: &Path) -> Option<HWND> {
+        let leaf = directory.file_name()?.to_string_lossy().into_owned();
+        window_with_title(&leaf)
+    }
+
+    /// Find a visible top-level window whose title contains `needle`. Used for
+    /// windows that are not owned by the process we launched: Explorer windows
+    /// belong to the running shell, and console windows belong to conhost.
+    fn window_with_title(needle: &str) -> Option<HWND> {
+        let mut search = TitleSearch {
+            needle: needle.to_string(),
+            found: HWND::default(),
+        };
+        unsafe {
+            let _ = EnumWindows(
+                Some(enum_title_proc),
+                LPARAM(&mut search as *mut TitleSearch as isize),
+            );
+        }
+        (!search.found.0.is_null()).then_some(search.found)
+    }
+
+    struct TitleSearch {
+        needle: String,
+        found: HWND,
+    }
+
+    unsafe extern "system" fn enum_title_proc(hwnd: HWND, lparam: LPARAM) -> windows::core::BOOL {
+        let search = &mut *(lparam.0 as *mut TitleSearch);
+        if IsWindowVisible(hwnd).as_bool() && window_text(hwnd).contains(&search.needle) {
+            search.found = hwnd;
+            return windows::core::BOOL(0);
+        }
+        TRUE
+    }
+
+    /// UIPI blocks synthetic input from a medium-integrity process into an
+    /// elevated window. The row asserts whichever half of that contract this
+    /// machine can actually demonstrate, and skips when it can demonstrate
+    /// neither.
+    fn run_elevated_row(class: AppClass) -> RowResult {
+        if !process_is_elevated() {
+            return skipped(
+                class,
+                SkipReason::EnvironmentNotApplicable {
+                    detail: "this run is not elevated; start an elevated shell and re-run to \
+                             exercise elevated targets (UIPI blocks synthetic paste into an \
+                             elevated window from a medium-integrity process by design)"
+                        .to_string(),
+                },
+            );
+        }
+
+        // Running elevated, an elevated target is reachable: exercise the same
+        // owned-control paste, which now happens at high integrity.
+        let mut result = run_owned_edit_row(class, PasteStrategy::Standard);
+        result.app = "owned EDIT control (elevated)".to_string();
+        result
+    }
+
+    fn process_is_elevated() -> bool {
+        use windows::Win32::Security::{
+            GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY,
+        };
+        use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+        unsafe {
+            let mut token = HANDLE::default();
+            if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token).is_err() {
+                return false;
+            }
+            let mut elevation = TOKEN_ELEVATION::default();
+            let mut size = 0_u32;
+            let ok = GetTokenInformation(
+                token,
+                TokenElevation,
+                Some(&mut elevation as *mut TOKEN_ELEVATION as *mut std::ffi::c_void),
+                std::mem::size_of::<TOKEN_ELEVATION>() as u32,
+                &mut size,
+            )
+            .is_ok();
+            let _ = CloseHandle(token);
+            ok && elevation.TokenIsElevated != 0
+        }
+    }
+
+    // ------------------------------------------------- owned EDIT control target
+
+    struct OwnedEdit {
+        window: HWND,
+        edit: HWND,
+    }
+
+    fn owned_edit_window() -> Result<OwnedEdit, String> {
+        use windows::core::w;
+        use windows::Win32::Foundation::HINSTANCE;
+        use windows::Win32::Graphics::Gdi::UpdateWindow;
+        use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+        use windows::Win32::UI::WindowsAndMessaging::{
+            CreateWindowExW, DefWindowProcW, RegisterClassW, ShowWindow, CS_HREDRAW, CS_VREDRAW,
+            CW_USEDEFAULT, ES_AUTOHSCROLL, ES_AUTOVSCROLL, ES_MULTILINE, SW_SHOW, WINDOW_EX_STYLE,
+            WINDOW_STYLE, WNDCLASSW, WS_CHILD, WS_OVERLAPPEDWINDOW, WS_VISIBLE,
+        };
+
+        unsafe extern "system" fn window_proc(
+            hwnd: HWND,
+            message: u32,
+            wparam: windows::Win32::Foundation::WPARAM,
+            lparam: LPARAM,
+        ) -> windows::Win32::Foundation::LRESULT {
+            DefWindowProcW(hwnd, message, wparam, lparam)
+        }
+
+        unsafe {
+            let module = GetModuleHandleW(None).map_err(|error| error.to_string())?;
+            let instance = HINSTANCE(module.0);
+            let class_name = w!("CubbyCompatMatrixTarget");
+            RegisterClassW(&WNDCLASSW {
+                style: CS_HREDRAW | CS_VREDRAW,
+                hInstance: instance,
+                lpszClassName: class_name,
+                lpfnWndProc: Some(window_proc),
+                ..Default::default()
+            });
+
+            let window = CreateWindowExW(
+                WINDOW_EX_STYLE::default(),
+                class_name,
+                w!("Cubby Compatibility Target"),
+                WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                600,
+                300,
+                None,
+                None,
+                Some(instance),
+                None,
+            )
+            .map_err(|error| error.to_string())?;
+
+            let edit = CreateWindowExW(
+                WINDOW_EX_STYLE::default(),
+                w!("EDIT"),
+                PCWSTR::null(),
+                WS_CHILD
+                    | WS_VISIBLE
+                    | WINDOW_STYLE(ES_MULTILINE as u32)
+                    | WINDOW_STYLE(ES_AUTOVSCROLL as u32)
+                    | WINDOW_STYLE(ES_AUTOHSCROLL as u32),
+                10,
+                10,
+                560,
+                240,
+                Some(window),
+                None,
+                Some(instance),
+                None,
+            )
+            .map_err(|error| error.to_string())?;
+
+            let _ = ShowWindow(window, SW_SHOW);
+            let _ = UpdateWindow(window);
+            pump_messages();
+            Ok(OwnedEdit { window, edit })
+        }
+    }
+
+    fn owned_edit_paste(target: &OwnedEdit, strategy: PasteStrategy) -> Result<(), String> {
+        use windows::core::w;
+        use windows::Win32::UI::Input::KeyboardAndMouse::SetFocus;
+        use windows::Win32::UI::WindowsAndMessaging::{
+            DestroyWindow, SetForegroundWindow, SetWindowTextW,
+        };
+
+        unsafe {
+            SetWindowTextW(target.edit, w!("")).map_err(|error| error.to_string())?;
+            let _ = SetForegroundWindow(target.window);
+            SetFocus(Some(target.edit)).map_err(|error| error.to_string())?;
+            pump_messages();
+
+            paste_into(target.window, strategy)?;
+            SetFocus(Some(target.edit)).map_err(|error| error.to_string())?;
+
+            let observed = wait_for(DEFAULT_TIMEOUT, || {
+                pump_messages();
+                let text = window_text(target.edit);
+                Ok((!text.is_empty()).then_some(text))
+            })
+            .map_err(|_| "the paste never reached the owned EDIT control".to_string())?;
+
+            let _ = DestroyWindow(target.window);
+
+            if observed != TEXT_PAYLOAD {
+                return Err(format!(
+                    "control received {:?} instead of the payload",
+                    truncate(&observed)
+                ));
+            }
+            Ok(())
+        }
+    }
+
+    fn pump_messages() {
+        use windows::Win32::UI::WindowsAndMessaging::{
+            DispatchMessageW, PeekMessageW, TranslateMessage, MSG, PM_REMOVE,
+        };
+        unsafe {
+            let mut message = MSG::default();
+            while PeekMessageW(&mut message, None, 0, 0, PM_REMOVE).as_bool() {
+                let _ = TranslateMessage(&message);
+                DispatchMessageW(&message);
+            }
+        }
+    }
+}

--- a/src-tauri/src/bin/compat_matrix.rs
+++ b/src-tauri/src/bin/compat_matrix.rs
@@ -440,7 +440,13 @@ mod windows_matrix {
         }
         let entries = std::fs::read_dir(directory).ok()?;
         for entry in entries.flatten() {
-            if entry.file_type().ok()?.is_dir() {
+            // `?` here would abandon the entire search on the first entry whose
+            // type cannot be read -- a protected or vanished item -- and report
+            // the application as not installed.
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
                 if let Some(found) = search_shallow(&entry.path(), name, depth - 1) {
                     return Some(found);
                 }
@@ -758,10 +764,37 @@ mod windows_matrix {
     struct LaunchedApp {
         child: Option<Child>,
         keep: bool,
+        /// Executable name, for finding processes this run created.
+        exe_name: String,
+        /// Processes of `exe_name` that existed before the launch. Anything not
+        /// in this list is ours to clean up.
+        pids_before: Vec<u32>,
+        /// Whether leftover processes may be terminated. False for browsers and
+        /// for windows owned by a long-running host.
+        terminate_leftovers: bool,
+        /// The window this row drove, once it has been resolved.
+        window: std::cell::Cell<Option<isize>>,
     }
 
     impl LaunchedApp {
         fn spawn(path: &Path, args: &[&str], keep: bool) -> Result<Self, String> {
+            Self::spawn_tracked(path, args, keep, false)
+        }
+
+        fn spawn_tracked(
+            path: &Path,
+            args: &[&str],
+            keep: bool,
+            terminate_leftovers: bool,
+        ) -> Result<Self, String> {
+            let exe_name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .to_string();
+            // Snapshot before spawning, so cleanup can tell this run's
+            // processes from ones the user already had open.
+            let pids_before = pids_for_exe(&exe_name);
             let child = Command::new(path)
                 .args(args)
                 .spawn()
@@ -769,22 +802,52 @@ mod windows_matrix {
             Ok(Self {
                 child: Some(child),
                 keep,
+                exe_name,
+                pids_before,
+                terminate_leftovers,
+                window: std::cell::Cell::new(None),
             })
         }
 
         fn pid(&self) -> u32 {
             self.child.as_ref().map(Child::id).unwrap_or_default()
         }
+
+        /// Record the window to close on cleanup. Set as soon as the row
+        /// resolves it, so a later failure still closes it.
+        fn track_window(&self, hwnd: HWND) {
+            self.window.set(Some(hwnd.0 as isize));
+        }
     }
 
+    /// Cleanup lives in `Drop` rather than at the end of the happy path.
+    ///
+    /// The earlier version closed the window and swept leftover processes after
+    /// the last `?` in the driving function, so every early return -- a window
+    /// that never appeared, an app with no automatable control -- skipped it and
+    /// left the application running. Cleanup that only happens when the row
+    /// succeeds is exactly backwards: a failing row is the one most likely to
+    /// have left something on screen.
     impl Drop for LaunchedApp {
         fn drop(&mut self) {
             if self.keep {
                 return;
             }
+
+            if let Some(hwnd) = self.window.get() {
+                close_window(HWND(hwnd as *mut std::ffi::c_void));
+            }
+
             if let Some(mut child) = self.child.take() {
                 let _ = child.kill();
                 let _ = child.wait();
+            }
+
+            if self.terminate_leftovers {
+                // Give the window a moment to close on its own before
+                // resorting to terminating whatever is left.
+                thread::sleep(Duration::from_millis(400));
+                kill_new_processes(&self.exe_name, &self.pids_before);
             }
         }
     }
@@ -1049,9 +1112,8 @@ mod windows_matrix {
             .file_name()
             .and_then(|name| name.to_str())
             .unwrap_or_default();
-        let pids_before = pids_for_exe(exe_name);
 
-        let launched = match LaunchedApp::spawn(path, args, keep) {
+        let launched = match LaunchedApp::spawn_tracked(path, args, keep, terminate_leftovers) {
             Ok(launched) => launched,
             Err(error) => {
                 return DriveOutcome::Failed(vec![failure(
@@ -1117,6 +1179,9 @@ mod windows_matrix {
             Ok(resolved) => resolved,
             Err(error) => return DriveOutcome::NotAutomatable(error),
         };
+        // From here on the window is closed by `LaunchedApp::drop`, whichever
+        // way this function returns.
+        launched.track_window(hwnd);
 
         let paste_result = (|| -> Result<(), String> {
             // Activating a window, focusing a control inside it, and having the
@@ -1176,23 +1241,6 @@ mod windows_matrix {
             Ok(()) => checks += 1,
             Err(error) => {
                 failures.push(failure(class, app, Format::UnicodeText, Step::Paste, error))
-            }
-        }
-
-        // Leaving windows behind was a real defect in the first version of this
-        // harness. Killing the spawned child is not enough: Windows 11 Notepad
-        // and every browser hand the launch off to another process and exit, so
-        // the child we hold is already gone. Closing the window is not enough
-        // either, because an application asked to close with text pasted into
-        // an unsaved document puts up a save prompt and stays on screen.
-        //
-        // So: ask the window to close, then terminate any process of this
-        // executable that did not exist before the row started.
-        if !keep {
-            close_window(hwnd);
-            if terminate_leftovers {
-                thread::sleep(Duration::from_millis(400));
-                kill_new_processes(exe_name, &pids_before);
             }
         }
 
@@ -1272,7 +1320,14 @@ mod windows_matrix {
     /// Browsers refuse top-level `data:` navigation, so the row writes a real
     /// HTML file with a textarea and opens it over `file://`.
     fn run_browser_row(class: AppClass, options: &Options) -> RowResult {
-        let candidates = ["msedge.exe", "chrome.exe", "firefox.exe"];
+        // Chromium-based only. The flags below (`--user-data-dir`,
+        // `--force-renderer-accessibility`) are Chromium's; Firefox uses
+        // `-profile` and initialises accessibility on demand instead, so
+        // passing these to it would let an existing Firefox session take the
+        // URL and leave the row driving somebody else's window. Adding Firefox
+        // means giving it its own argument list and verifying it, not extending
+        // this array.
+        let candidates = ["msedge.exe", "chrome.exe"];
         let mut looked_for = Vec::new();
         let mut chosen = None;
         for executable in candidates {

--- a/src-tauri/src/bin/compat_matrix.rs
+++ b/src-tauri/src/bin/compat_matrix.rs
@@ -937,7 +937,18 @@ mod windows_matrix {
         // put the document name in the title bar do exist, but matching on it
         // costs more than it buys -- Word's window is titled before it is ready
         // to accept a paste.
-        let outcome = drive_uia_app(class, app, &path, &arg_refs, options.keep_apps, None, None);
+        let outcome = drive_uia_app(AppRun {
+            class,
+            app,
+            path: &path,
+            args: &arg_refs,
+            keep: options.keep_apps,
+            focus_marker: None,
+            title_marker: None,
+            // Editors hold the pasted text in an unsaved document, so asking
+            // the window to close raises a save prompt and leaves it on screen.
+            terminate_leftovers: true,
+        });
         if let Some(document) = document {
             let _ = std::fs::remove_file(document);
         }
@@ -965,15 +976,35 @@ mod windows_matrix {
         Failed(Vec<Failure>),
     }
 
-    fn drive_uia_app(
+    /// One application-driving run. Grouped into a struct because the knobs are
+    /// easy to transpose at a call site when they are eight positional
+    /// arguments, and getting `focus_marker` and `title_marker` the wrong way
+    /// round fails in a way that looks like an application bug.
+    struct AppRun<'a> {
         class: AppClass,
-        app: &str,
-        path: &Path,
-        args: &[&str],
+        app: &'a str,
+        path: &'a Path,
+        args: &'a [&'a str],
         keep: bool,
-        focus_marker: Option<&str>,
-        title_marker: Option<&str>,
-    ) -> DriveOutcome {
+        /// Accessible name of the control to focus before pasting.
+        focus_marker: Option<&'a str>,
+        /// Window title substring to locate, instead of the launched pid.
+        title_marker: Option<&'a str>,
+        /// Terminate processes of this executable that the run created.
+        terminate_leftovers: bool,
+    }
+
+    fn drive_uia_app(run: AppRun<'_>) -> DriveOutcome {
+        let AppRun {
+            class,
+            app,
+            path,
+            args,
+            keep,
+            focus_marker,
+            title_marker,
+            terminate_leftovers,
+        } = run;
         let mut failures = Vec::new();
         let mut checks = 0;
 
@@ -1014,6 +1045,12 @@ mod windows_matrix {
             return DriveOutcome::Failed(failures);
         }
 
+        let exe_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default();
+        let pids_before = pids_for_exe(exe_name);
+
         let launched = match LaunchedApp::spawn(path, args, keep) {
             Ok(launched) => launched,
             Err(error) => {
@@ -1026,11 +1063,6 @@ mod windows_matrix {
                 )])
             }
         };
-
-        let exe_name = path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or_default();
         let uia = match Uia::new() {
             Ok(uia) => uia,
             Err(error) => return DriveOutcome::NotAutomatable(error),
@@ -1147,12 +1179,21 @@ mod windows_matrix {
             }
         }
 
-        // Killing the child is not enough for apps whose launcher hands off to
-        // another process and exits -- a browser being the usual case -- so the
-        // window itself is asked to close. Without this every run leaves one
-        // more window on the desktop.
+        // Leaving windows behind was a real defect in the first version of this
+        // harness. Killing the spawned child is not enough: Windows 11 Notepad
+        // and every browser hand the launch off to another process and exit, so
+        // the child we hold is already gone. Closing the window is not enough
+        // either, because an application asked to close with text pasted into
+        // an unsaved document puts up a save prompt and stays on screen.
+        //
+        // So: ask the window to close, then terminate any process of this
+        // executable that did not exist before the row started.
         if !keep {
             close_window(hwnd);
+            if terminate_leftovers {
+                thread::sleep(Duration::from_millis(400));
+                kill_new_processes(exe_name, &pids_before);
+            }
         }
 
         if failures.is_empty() {
@@ -1166,6 +1207,56 @@ mod windows_matrix {
         use windows::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
         unsafe {
             let _ = PostMessageW(Some(hwnd), WM_CLOSE, Default::default(), Default::default());
+        }
+    }
+
+    /// Process ids currently running `exe_name`.
+    ///
+    /// Snapshotted before a row launches its application so cleanup can tell
+    /// the processes this run created from ones the user already had open. A
+    /// harness that kills every `msedge.exe` would close the user's browser.
+    fn pids_for_exe(exe_name: &str) -> Vec<u32> {
+        use windows::Win32::System::ProcessStatus::EnumProcesses;
+
+        let mut pids = vec![0_u32; 2048];
+        let mut needed = 0_u32;
+        let ok = unsafe {
+            EnumProcesses(
+                pids.as_mut_ptr(),
+                (pids.len() * std::mem::size_of::<u32>()) as u32,
+                &mut needed,
+            )
+        }
+        .is_ok();
+        if !ok {
+            return Vec::new();
+        }
+        let count = needed as usize / std::mem::size_of::<u32>();
+        pids.truncate(count);
+        pids.retain(|pid| {
+            *pid != 0
+                && process_image_name(*pid).is_some_and(|name| name.eq_ignore_ascii_case(exe_name))
+        });
+        pids
+    }
+
+    /// Terminate processes running `exe_name` that were not present in
+    /// `before`. Closing the window is not enough for an application that shows
+    /// a save prompt for the text this suite just pasted, and it does nothing
+    /// at all for one whose launcher handed off to another process.
+    fn kill_new_processes(exe_name: &str, before: &[u32]) {
+        use windows::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
+
+        for pid in pids_for_exe(exe_name) {
+            if before.contains(&pid) {
+                continue;
+            }
+            unsafe {
+                if let Ok(handle) = OpenProcess(PROCESS_TERMINATE, false, pid) {
+                    let _ = TerminateProcess(handle, 0);
+                    let _ = CloseHandle(handle);
+                }
+            }
         }
     }
 
@@ -1234,15 +1325,21 @@ mod windows_matrix {
         ];
 
         let formats = vec![Format::UnicodeText];
-        let outcome = drive_uia_app(
+        let outcome = drive_uia_app(AppRun {
             class,
             app,
-            &path,
-            &args,
-            options.keep_apps,
-            Some(BROWSER_TARGET_LABEL),
-            Some(&page_title),
-        );
+            path: &path,
+            args: &args,
+            keep: options.keep_apps,
+            focus_marker: Some(BROWSER_TARGET_LABEL),
+            title_marker: Some(&page_title),
+            // Deliberately not terminated by name. A browser runs a process per
+            // renderer and spawns them constantly, so killing every msedge.exe
+            // that appeared during the run would take the user's own tabs with
+            // it. A throwaway profile with one window exits cleanly on WM_CLOSE
+            // instead.
+            terminate_leftovers: false,
+        });
         let _ = std::fs::remove_file(&page);
         if !options.keep_apps {
             let _ = std::fs::remove_dir_all(&profile);
@@ -1368,6 +1465,10 @@ mod windows_matrix {
         let command =
             format!("Read-Host | Set-Content -LiteralPath $env:TEMP\\{file_name} -Encoding utf8");
 
+        // Recorded inside the closure so cleanup can still reach the window on
+        // the error paths. The shell exits on its own once it has read a line,
+        // but a row that failed before that leaves the window sitting open.
+        let terminal_window: std::cell::Cell<Option<isize>> = std::cell::Cell::new(None);
         let result = (|| -> Result<(), String> {
             let mut launched = LaunchedApp::spawn(
                 terminal_path,
@@ -1384,7 +1485,8 @@ mod windows_matrix {
                 false,
             )?;
             let hwnd = wait_for(DEFAULT_TIMEOUT, || Ok(window_with_title(&title)))
-                .map_err(|_| "the cmd.exe console window never appeared".to_string())?;
+                .map_err(|_| "the terminal window never appeared".to_string())?;
+            terminal_window.set(Some(hwnd.0 as isize));
             paste_into(hwnd, PasteStrategy::Standard)?;
             thread::sleep(Duration::from_millis(300));
             send_enter()?;
@@ -1410,6 +1512,12 @@ mod windows_matrix {
         })();
 
         let _ = std::fs::remove_file(&output);
+        // The window, not the process: `-w new` can open a window inside an
+        // already-running WindowsTerminal.exe, so terminating that process
+        // would close the user's other terminals with it.
+        if let Some(hwnd) = terminal_window.get() {
+            close_window(HWND(hwnd as *mut std::ffi::c_void));
+        }
         match result {
             Ok(()) => Ok(checks + 1),
             Err(error) => Err(vec![failure(
@@ -1556,6 +1664,11 @@ mod windows_matrix {
                 Ok(dest_dir.join(file_name).is_file().then_some(()))
             })
             .map_err(|_| "Explorer did not paste the file into the destination".to_string())?;
+
+            // Close the window, never the process: Explorer windows belong to
+            // the long-running shell, and terminating it would take the user's
+            // taskbar and desktop with it.
+            close_window(hwnd);
             Ok(())
         })();
 

--- a/src-tauri/src/compat_matrix_model.rs
+++ b/src-tauri/src/compat_matrix_model.rs
@@ -1,0 +1,471 @@
+//! Pure model for the clipboard application-compatibility matrix (SBS-408).
+//!
+//! The runner in `src/bin/compat_matrix.rs` drives real applications and is
+//! therefore only meaningful on a live Windows desktop. Everything that decides
+//! *what* to run, *which* rows apply, and *how a failure is attributed* lives
+//! here so it can be unit tested without a desktop.
+
+use std::fmt;
+
+/// Classes of paste target the matrix has to cover. These are the application
+/// families named in the acceptance criteria; a class is not the same thing as
+/// a single app, because which concrete app is present varies by machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum AppClass {
+    LegacyWin32,
+    PackagedApp,
+    Explorer,
+    Terminal,
+    Browser,
+    Ide,
+    Office,
+    RemoteSession,
+    Elevated,
+}
+
+impl AppClass {
+    pub const ALL: [AppClass; 9] = [
+        AppClass::LegacyWin32,
+        AppClass::PackagedApp,
+        AppClass::Explorer,
+        AppClass::Terminal,
+        AppClass::Browser,
+        AppClass::Ide,
+        AppClass::Office,
+        AppClass::RemoteSession,
+        AppClass::Elevated,
+    ];
+
+    pub fn slug(self) -> &'static str {
+        match self {
+            AppClass::LegacyWin32 => "legacy_win32",
+            AppClass::PackagedApp => "packaged_app",
+            AppClass::Explorer => "explorer",
+            AppClass::Terminal => "terminal",
+            AppClass::Browser => "browser",
+            AppClass::Ide => "ide",
+            AppClass::Office => "office",
+            AppClass::RemoteSession => "remote_session",
+            AppClass::Elevated => "elevated",
+        }
+    }
+
+    pub fn from_slug(slug: &str) -> Option<AppClass> {
+        AppClass::ALL
+            .into_iter()
+            .find(|class| class.slug().eq_ignore_ascii_case(slug))
+    }
+}
+
+impl fmt::Display for AppClass {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.slug())
+    }
+}
+
+/// Clipboard formats the matrix exercises. `FilePayload` is deliberately part
+/// of the matrix even though Cubby never stores file payloads: the assertion is
+/// that an ignored payload does not wedge later capture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Format {
+    UnicodeText,
+    Html,
+    Rtf,
+    Image,
+    FilePayload,
+}
+
+impl Format {
+    pub fn slug(self) -> &'static str {
+        match self {
+            Format::UnicodeText => "unicode_text",
+            Format::Html => "html",
+            Format::Rtf => "rtf",
+            Format::Image => "image",
+            Format::FilePayload => "file_payload",
+        }
+    }
+}
+
+impl fmt::Display for Format {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.slug())
+    }
+}
+
+/// The pipeline stages a row walks. A failure names the stage it happened in so
+/// "Word broke" becomes "Word / html / restore".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Step {
+    Capture,
+    Restore,
+    Paste,
+}
+
+impl Step {
+    pub const ALL: [Step; 3] = [Step::Capture, Step::Restore, Step::Paste];
+
+    pub fn slug(self) -> &'static str {
+        match self {
+            Step::Capture => "capture",
+            Step::Restore => "restore",
+            Step::Paste => "paste",
+        }
+    }
+}
+
+impl fmt::Display for Step {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.slug())
+    }
+}
+
+/// Why a row could not run. Every variant names something a reader can act on:
+/// install the app, run the suite in a remote session, start an elevated
+/// target. A row is never silently dropped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkipReason {
+    /// No candidate application for the class was found on this machine.
+    NoAppInstalled { candidates: Vec<String> },
+    /// The class only means something under a condition this machine does not
+    /// meet (a real remote session, an elevated foreground target).
+    EnvironmentNotApplicable { detail: String },
+    /// The operator excluded the class with `--only`.
+    Deselected,
+}
+
+impl SkipReason {
+    pub fn detail(&self) -> String {
+        match self {
+            SkipReason::NoAppInstalled { candidates } => {
+                format!(
+                    "no candidate application installed (looked for: {})",
+                    candidates.join(", ")
+                )
+            }
+            SkipReason::EnvironmentNotApplicable { detail } => detail.clone(),
+            SkipReason::Deselected => "not selected by --only".to_string(),
+        }
+    }
+
+    /// Deselected rows are an operator choice, not a coverage gap, so they do
+    /// not count against the matrix being complete.
+    pub fn is_coverage_gap(&self) -> bool {
+        !matches!(self, SkipReason::Deselected)
+    }
+}
+
+/// A single attributable failure: which app, which format, which step.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Failure {
+    pub class: AppClass,
+    pub app: String,
+    pub format: Format,
+    pub step: Step,
+    pub detail: String,
+}
+
+impl fmt::Display for Failure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{} / {} / {} / {}: {}",
+            self.class, self.app, self.format, self.step, self.detail
+        )
+    }
+}
+
+/// What happened to one row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RowOutcome {
+    Passed { checks: usize },
+    Failed { failures: Vec<Failure> },
+    Skipped { reason: SkipReason },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RowResult {
+    pub class: AppClass,
+    pub app: String,
+    pub formats: Vec<Format>,
+    pub outcome: RowOutcome,
+}
+
+impl RowResult {
+    pub fn passed(&self) -> bool {
+        matches!(self.outcome, RowOutcome::Passed { .. })
+    }
+
+    pub fn failures(&self) -> &[Failure] {
+        match &self.outcome {
+            RowOutcome::Failed { failures } => failures,
+            _ => &[],
+        }
+    }
+}
+
+/// Aggregate verdict for a whole run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatrixSummary {
+    pub passed: bool,
+    pub rows_total: usize,
+    pub rows_passed: usize,
+    pub rows_failed: usize,
+    pub rows_skipped: usize,
+    pub checks: usize,
+    pub failures: Vec<Failure>,
+    /// Classes with no row that actually executed. These are the honest
+    /// coverage gaps: the matrix ran, but this class proved nothing.
+    pub classes_not_covered: Vec<AppClass>,
+}
+
+/// Fold row results into a verdict.
+///
+/// A run passes when nothing failed. Skipped rows do not fail the run -- a
+/// machine without Office cannot prove anything about Word -- but they are
+/// reported as uncovered classes so a green run is never mistaken for full
+/// coverage.
+pub fn summarize(results: &[RowResult]) -> MatrixSummary {
+    let mut failures = Vec::new();
+    let mut rows_passed = 0;
+    let mut rows_failed = 0;
+    let mut rows_skipped = 0;
+    let mut checks = 0;
+
+    for result in results {
+        match &result.outcome {
+            RowOutcome::Passed { checks: count } => {
+                rows_passed += 1;
+                checks += count;
+            }
+            RowOutcome::Failed {
+                failures: row_failures,
+            } => {
+                rows_failed += 1;
+                failures.extend(row_failures.iter().cloned());
+            }
+            RowOutcome::Skipped { .. } => rows_skipped += 1,
+        }
+    }
+
+    let mut classes_not_covered: Vec<AppClass> = AppClass::ALL
+        .into_iter()
+        .filter(|class| {
+            !results.iter().any(|result| {
+                result.class == *class && !matches!(result.outcome, RowOutcome::Skipped { .. })
+            })
+        })
+        .collect();
+    classes_not_covered.sort();
+
+    MatrixSummary {
+        passed: failures.is_empty(),
+        rows_total: results.len(),
+        rows_passed,
+        rows_failed,
+        rows_skipped,
+        checks,
+        failures,
+        classes_not_covered,
+    }
+}
+
+/// Parse `--only a,b,c` into a class filter. An empty selection means "all".
+pub fn parse_class_filter(raw: &str) -> Result<Vec<AppClass>, String> {
+    let mut selected = Vec::new();
+    for token in raw.split(',') {
+        let token = token.trim();
+        if token.is_empty() {
+            continue;
+        }
+        let class = AppClass::from_slug(token).ok_or_else(|| {
+            format!(
+                "unknown app class '{token}' (expected one of: {})",
+                AppClass::ALL
+                    .into_iter()
+                    .map(AppClass::slug)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })?;
+        if !selected.contains(&class) {
+            selected.push(class);
+        }
+    }
+    Ok(selected)
+}
+
+/// Whether a class runs given the operator's `--only` selection.
+pub fn class_selected(class: AppClass, filter: &[AppClass]) -> bool {
+    filter.is_empty() || filter.contains(&class)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn failure(class: AppClass, app: &str, format: Format, step: Step) -> Failure {
+        Failure {
+            class,
+            app: app.to_string(),
+            format,
+            step,
+            detail: "detail".to_string(),
+        }
+    }
+
+    fn passed_row(class: AppClass, app: &str, checks: usize) -> RowResult {
+        RowResult {
+            class,
+            app: app.to_string(),
+            formats: vec![Format::UnicodeText],
+            outcome: RowOutcome::Passed { checks },
+        }
+    }
+
+    fn skipped_row(class: AppClass, reason: SkipReason) -> RowResult {
+        RowResult {
+            class,
+            app: "n/a".to_string(),
+            formats: Vec::new(),
+            outcome: RowOutcome::Skipped { reason },
+        }
+    }
+
+    #[test]
+    fn every_class_has_a_unique_round_trippable_slug() {
+        let mut seen = Vec::new();
+        for class in AppClass::ALL {
+            assert!(
+                !seen.contains(&class.slug()),
+                "duplicate slug {}",
+                class.slug()
+            );
+            seen.push(class.slug());
+            assert_eq!(AppClass::from_slug(class.slug()), Some(class));
+        }
+        assert_eq!(
+            AppClass::from_slug("LEGACY_WIN32"),
+            Some(AppClass::LegacyWin32)
+        );
+        assert_eq!(AppClass::from_slug("nonsense"), None);
+    }
+
+    #[test]
+    fn a_run_with_no_failures_passes() {
+        let results: Vec<RowResult> = AppClass::ALL
+            .into_iter()
+            .map(|class| passed_row(class, "app", 2))
+            .collect();
+
+        let summary = summarize(&results);
+        assert!(summary.passed);
+        assert_eq!(summary.rows_passed, 9);
+        assert_eq!(summary.checks, 18);
+        assert!(summary.classes_not_covered.is_empty());
+    }
+
+    #[test]
+    fn failures_are_collected_with_full_attribution() {
+        let results = vec![
+            passed_row(AppClass::LegacyWin32, "edit", 1),
+            RowResult {
+                class: AppClass::Office,
+                app: "winword.exe".to_string(),
+                formats: vec![Format::Html, Format::Rtf],
+                outcome: RowOutcome::Failed {
+                    failures: vec![
+                        failure(AppClass::Office, "winword.exe", Format::Html, Step::Restore),
+                        failure(AppClass::Office, "winword.exe", Format::Rtf, Step::Paste),
+                    ],
+                },
+            },
+        ];
+
+        let summary = summarize(&results);
+        assert!(!summary.passed);
+        assert_eq!(summary.rows_failed, 1);
+        assert_eq!(summary.failures.len(), 2);
+        assert_eq!(
+            summary.failures[0].to_string(),
+            "office / winword.exe / html / restore: detail"
+        );
+    }
+
+    #[test]
+    fn skipped_rows_do_not_fail_the_run_but_are_reported_as_uncovered() {
+        let results = vec![
+            passed_row(AppClass::LegacyWin32, "edit", 1),
+            skipped_row(
+                AppClass::Office,
+                SkipReason::NoAppInstalled {
+                    candidates: vec!["winword.exe".to_string()],
+                },
+            ),
+        ];
+
+        let summary = summarize(&results);
+        assert!(summary.passed, "a missing app must not fail the run");
+        assert_eq!(summary.rows_skipped, 1);
+        assert!(summary.classes_not_covered.contains(&AppClass::Office));
+        assert!(!summary.classes_not_covered.contains(&AppClass::LegacyWin32));
+    }
+
+    #[test]
+    fn a_class_counts_as_covered_only_when_a_row_actually_ran() {
+        // Same class skipped once and run once: the executed row wins.
+        let results = vec![
+            skipped_row(AppClass::Browser, SkipReason::Deselected),
+            passed_row(AppClass::Browser, "msedge.exe", 3),
+        ];
+        let summary = summarize(&results);
+        assert!(!summary.classes_not_covered.contains(&AppClass::Browser));
+
+        // Only skipped: not covered.
+        let results = vec![skipped_row(AppClass::Browser, SkipReason::Deselected)];
+        let summary = summarize(&results);
+        assert!(summary.classes_not_covered.contains(&AppClass::Browser));
+    }
+
+    #[test]
+    fn skip_reasons_explain_themselves() {
+        let reason = SkipReason::NoAppInstalled {
+            candidates: vec!["winword.exe".to_string(), "wordpad.exe".to_string()],
+        };
+        assert_eq!(
+            reason.detail(),
+            "no candidate application installed (looked for: winword.exe, wordpad.exe)"
+        );
+        assert!(reason.is_coverage_gap());
+
+        assert!(!SkipReason::Deselected.is_coverage_gap());
+        assert_eq!(SkipReason::Deselected.detail(), "not selected by --only");
+    }
+
+    #[test]
+    fn class_filter_parses_and_rejects_unknown_names() {
+        assert_eq!(
+            parse_class_filter("browser, office").unwrap(),
+            vec![AppClass::Browser, AppClass::Office]
+        );
+        assert_eq!(parse_class_filter("browser,browser").unwrap().len(), 1);
+        assert_eq!(parse_class_filter("").unwrap(), Vec::new());
+        assert_eq!(parse_class_filter("  ,  ").unwrap(), Vec::new());
+
+        let error = parse_class_filter("browser,teapot").unwrap_err();
+        assert!(error.contains("unknown app class 'teapot'"), "{error}");
+        assert!(
+            error.contains("legacy_win32"),
+            "error should list valid names: {error}"
+        );
+    }
+
+    #[test]
+    fn an_empty_filter_selects_everything() {
+        for class in AppClass::ALL {
+            assert!(class_selected(class, &[]));
+        }
+        assert!(class_selected(AppClass::Browser, &[AppClass::Browser]));
+        assert!(!class_selected(AppClass::Office, &[AppClass::Browser]));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,6 +38,13 @@ mod cf_html;
 mod clipboard;
 mod clipboard_policy;
 mod commands;
+// SBS-408 compatibility-matrix model. Compiled under `test` as well as
+// `dev-harness` on purpose: CI runs `cargo test --all-targets` without the
+// feature, so a dev-harness-only module would never have its unit tests run on
+// a pull request. Release builds compile neither arm, so none of this reaches
+// cubby.exe.
+#[cfg(any(test, feature = "dev-harness"))]
+pub mod compat_matrix_model;
 mod constants;
 mod crypto;
 mod database;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -52,9 +52,9 @@ mod ditto_import;
 mod models;
 mod ocr;
 mod ocr_queue;
+pub mod paste_engine;
 // SBS-219 budgets. Compiled for tests (which measure them) and for the
 // dev-harness binaries; a release build compiles neither arm.
-pub mod paste_engine;
 #[cfg(any(test, feature = "dev-harness"))]
 pub mod perf_budget;
 mod search_index;


### PR DESCRIPTION
## Summary
- add an automated application-compatibility matrix (`compat_matrix`) covering the nine app classes in SBS-408, each row walking capture -> restore -> paste with per-app/format/step failure attribution
- drive real applications through UI Automation and the production paste engine, reading the payload back out of the application itself
- fix the `virtual_only` clipboard race tracked in #164

Linear: SBS-408

## What a row actually asserts

| Step | Assertion |
| --- | --- |
| `capture` | Cubby's shared capture policy classifies the payload correctly |
| `restore` | clipboard write/read round trip is byte-identical |
| `paste` | `cubby::paste_engine` drives the live app and the payload is read back **out of that app** |

The `explorer` row asserts the product contract rather than a round trip: an
ignored file payload still pastes in Explorer (verified on disk) and does not
wedge the next capture.

## Run on this machine

```
legacy_win32    owned EDIT control                    passed   3 checks
packaged_app    notepad.exe                           passed   3 checks
explorer        explorer.exe                          passed   3 checks
terminal        powershell.exe in Windows Terminal    passed   3 checks
browser         msedge.exe                            passed   3 checks
ide             n/a                                   skipped  code.exe exposed no UIA text control
office          winword.exe                           passed   3 checks
remote_session  owned EDIT (remote-session strategy)  passed   3 checks
elevated        n/a                                   skipped  run is not elevated

Passed: True   RowsPassed: 7   RowsFailed: 0   RowsSkipped: 2   Checks: 21
ClassesNotCovered: ide, elevated
```

**Two classes are not covered, and the run says so.** A skip is never a pass:
each one carries a reason and its class is listed in `classes_not_covered`,
which the script re-prints as a warning. `ide` skips because VS Code's launcher
exits immediately and its window exposes no UI Automation text control;
`elevated` skips because UIPI blocks synthetic paste into an elevated window
from a medium-integrity process by design, so it can only be demonstrated from
an elevated shell.

## Scope note

Rows cover capture, restore, and paste. They do **not** assert durable storage:
reaching Cubby's database from an external harness would mean standing up an app
instance, so storage stays covered by the existing `cargo test` suites. SBS-408
lists "capture / storage / restore / paste", so that quarter is deliberately not
claimed here.

## #164

The fixture writer destroyed the delayed-rendering owner and immediately wrote
the next fixture. While that window still owned the clipboard, the next writer's
`EmptyClipboard` made Windows send `WM_RENDERALLFORMATS` to it, whose handler
opened and closed the clipboard on the same thread -- closing the one
`clipboard_rs` was using, which is the `ERROR_CLIPBOARD_NOT_OPEN` (1418) seen on
`virtual_only`. The owner is now retired deliberately (payloads dropped,
ownership released, queue drained, then destroyed) and the handler no longer
touches the clipboard when it has nothing to render.

Measured on the same machine: **1 failure in 15 runs before, 0 in 45 after.**

## Things worth a reviewer's attention

- `compat_matrix_model` is compiled under `cfg(test)` as well as `dev-harness`.
  `ci.yml` runs `cargo test --all-targets` *without* the feature, so a
  dev-harness-only module would never have its unit tests run on a PR. Release
  builds compile neither arm, so nothing reaches `cubby.exe`.
- Two `windows` crate features (`Win32_System_Variant`, `Win32_System_Ole`) are
  added for UI Automation. Cargo features are crate-wide, so this marginally
  affects the production build as well; there is no per-target feature gate.
- The browser row targets a labelled textarea rather than "the first editable
  control" on purpose. A browser exposes its address bar in the same automation
  tree and it sorts first -- pasting into the omnibox reads the payload back
  perfectly and looks like a pass while never involving the page. An earlier
  revision of this PR did exactly that.
- `docs/COMPAT_MATRIX.md` records the load-bearing details found the hard way
  (why PowerShell instead of `cmd`, why `wt -w new`, why activate-then-focus).

## Verification
- `scripts/test-compat-matrix.ps1`: 7 passed, 0 failed, 2 skipped, 21 checks
- `scripts/test-clipboard-formats.ps1`: 45 consecutive clean runs
- `cargo test --locked --all-targets` (PR CI config, no dev-harness): 163 passed
- `cargo test --locked --features dev-harness --all-targets`: 186 passed
- `cargo clippy -D warnings` in both configurations, `cargo fmt --check`
- `pnpm run test`: 74 passed; `pnpm run release:check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Windows clipboard compatibility matrix covering desktop apps, browsers, terminals, Office, remote sessions, and elevated environments.
  * Added tools to run, filter, list, and review compatibility checks with structured results and clear skip or failure reporting.

* **Bug Fixes**
  * Improved clipboard cleanup to prevent intermittent rendering and clipboard access failures.

* **Documentation**
  * Added compatibility-matrix instructions and clarified deterministic cleanup and validation procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->