### PR TITLE
Cut search index memory from 5.2 KiB to 998 B per clip

### DIFF
--- a/docs/PERFORMANCE_BUDGETS.md
+++ b/docs/PERFORMANCE_BUDGETS.md
@@ -40,8 +40,8 @@ tight enough that a real regression does.
 | --- | --- | --- | --- |
 | `db_growth_per_text_clip` | 922 B | 2 KiB | enforced |
 | `image_thumbnail_bytes` | 86.8 KiB | 192 KiB | enforced |
-| `search_index_bytes_per_clip` | 5.2 KiB | 8 KiB | reported |
-| `first_searchable_result` | 4–10 ms over 2,000 clips | 100 ms | reported |
+| `search_index_bytes_per_clip` | 998 B | 2 KiB | reported |
+| `first_searchable_result` | 2–5 ms over 2,000 clips | 100 ms | reported |
 | `process_startup` | not yet measured | 2,000 ms | reported |
 | `shortcut_to_visible` | not yet measured | 150 ms | reported |
 | `paste_completion` | not yet measured | 800 ms | reported |
@@ -59,15 +59,18 @@ exits, which would make the startup number meaningless.
 
 ## What the numbers say
 
-**Search index memory is the scaling constraint.** At 5.2 KiB per clip the
-in-memory trigram index costs roughly 10 MiB at 2,000 clips, but around 500 MiB
-at 100,000. History is uncapped by default. The index is held in memory because
-the database is encrypted and cannot be searched by SQL (SBS-211), so this is a
-consequence of the privacy design rather than an oversight — but it means idle
-memory on a very large history is dominated by it, and the `idle_memory` budget
-will be met or missed by this number rather than by the WebView. Tracked in
-#169, which records where the bytes go and the cheapest directions to reduce
-them.
+**Search index memory was the scaling constraint, and is now much less of
+one.** It began at 5.2 KiB per clip — roughly 500 MiB at 100,000 clips, against
+a 200 MiB `idle_memory` budget — because each trigram held a `HashSet` of
+reference-counted clip ids. Issue #169 replaced that with sorted `u32` slots and
+stopped storing a preview the content already contains, bringing it to 998 B per
+clip: about 95 MiB at 100,000 clips, and search got faster rather than slower.
+
+The index is still held in memory for the life of the process, because the
+database is encrypted and cannot be searched by SQL (SBS-211), so it remains
+the largest resident structure and the thing `idle_memory` will be decided by.
+It now leaves room for a large history rather than consuming the whole budget
+before the WebView is counted.
 
 **Per-clip database cost is not the problem.** 922 B for a 170-byte clip is
 mostly encryption overhead and the content hash, and it grows linearly.

--- a/src-tauri/src/perf_budget.rs
+++ b/src-tauri/src/perf_budget.rs
@@ -87,7 +87,10 @@ pub const BUDGETS: &[Budget] = &[
     Budget {
         id: "search_index_bytes_per_clip",
         what: "in-memory search index bytes per indexed clip",
-        limit: 8192.0,
+        // Observed 998 B after the postings rework (#169), down from 5.2 KiB
+        // when postings were a HashSet<Arc<str>> per trigram. Set at roughly 2x
+        // so the old representation could not come back unnoticed.
+        limit: 2048.0,
         unit: Unit::Bytes,
         // Reported, not enforced, despite being a byte count: measuring it
         // needs a process-wide allocation counter, which other tests running in

--- a/src-tauri/src/search_index.rs
+++ b/src-tauri/src/search_index.rs
@@ -44,9 +44,10 @@ impl SearchDocument {
         notes: Option<&str>,
         source_app: Option<&str>,
     ) -> Self {
+        let content = normalize(content);
         Self {
-            content: normalize(content),
-            preview: normalize(preview),
+            preview: redundant_preview(&content, &normalize(preview)),
+            content,
             ocr: normalize(ocr.unwrap_or_default()),
             notes: normalize(notes.unwrap_or_default()),
             source_app: source_app
@@ -71,71 +72,144 @@ impl SearchDocument {
     }
 }
 
+/// A document plus the id it was indexed under.
+struct IndexedDocument {
+    id: Arc<str>,
+    document: SearchDocument,
+}
+
+/// Slot number for a document. Postings store these rather than clip ids.
+///
+/// A `HashSet<Arc<str>>` per trigram costs a 16-byte fat pointer plus the set's
+/// own per-slot overhead for every posting, and a clip of ordinary prose
+/// produces well over a hundred trigrams -- which made postings, not the stored
+/// text, the dominant cost of the index. A `u32` in a sorted `Vec` is four bytes
+/// with no per-entry overhead, and intersects faster besides.
+type Slot = u32;
+
 #[derive(Default)]
 struct IndexState {
-    documents: HashMap<Arc<str>, SearchDocument>,
-    postings: HashMap<String, HashSet<Arc<str>>>,
+    /// Indexed by [`Slot`]. A removed document leaves a hole, which the next
+    /// insert reuses, so slots stay dense and postings stay small.
+    documents: Vec<Option<IndexedDocument>>,
+    slots: HashMap<Arc<str>, Slot>,
+    free_slots: Vec<Slot>,
+    /// Sorted, deduplicated slots per trigram. Sorted so intersection is a
+    /// linear merge rather than a hash lookup per candidate.
+    postings: HashMap<Box<str>, Vec<Slot>>,
 }
 
 impl IndexState {
+    fn document(&self, id: &str) -> Option<&SearchDocument> {
+        let slot = *self.slots.get(id)?;
+        self.documents
+            .get(slot as usize)
+            .and_then(Option::as_ref)
+            .map(|entry| &entry.document)
+    }
+
+    fn documents(&self) -> impl Iterator<Item = (&Arc<str>, &SearchDocument)> {
+        self.documents
+            .iter()
+            .flatten()
+            .map(|entry| (&entry.id, &entry.document))
+    }
+
+    fn len(&self) -> usize {
+        self.slots.len()
+    }
+
     fn insert(&mut self, id: String, document: SearchDocument) {
         self.remove(&id);
+
         let id: Arc<str> = Arc::from(id);
+        let slot = match self.free_slots.pop() {
+            Some(slot) => slot,
+            None => {
+                self.documents.push(None);
+                (self.documents.len() - 1) as Slot
+            }
+        };
+
         for trigram in document.trigrams() {
-            self.postings.entry(trigram).or_default().insert(id.clone());
+            let postings = self.postings.entry(trigram.into_boxed_str()).or_default();
+            // Kept sorted on insert so `matches` can merge without sorting.
+            if let Err(position) = postings.binary_search(&slot) {
+                postings.insert(position, slot);
+            }
         }
-        self.documents.insert(id, document);
+
+        self.slots.insert(id.clone(), slot);
+        self.documents[slot as usize] = Some(IndexedDocument { id, document });
     }
 
     fn remove(&mut self, id: &str) {
-        let Some(document) = self.documents.remove(id) else {
+        let Some(slot) = self.slots.remove(id) else {
             return;
         };
-        for trigram in document.trigrams() {
-            let remove_posting = self.postings.get_mut(&trigram).is_some_and(|ids| {
-                ids.remove(id);
-                ids.is_empty()
-            });
-            if remove_posting {
-                self.postings.remove(&trigram);
+        let Some(entry) = self.documents[slot as usize].take() else {
+            return;
+        };
+
+        for trigram in entry.document.trigrams() {
+            let empty = self
+                .postings
+                .get_mut(trigram.as_str())
+                .is_some_and(|slots| {
+                    if let Ok(position) = slots.binary_search(&slot) {
+                        slots.remove(position);
+                    }
+                    slots.is_empty()
+                });
+            if empty {
+                self.postings.remove(trigram.as_str());
             }
         }
+
+        self.free_slots.push(slot);
     }
 
     fn matches(&self, query: &str) -> HashSet<String> {
         let query = normalize(query);
         let query_trigrams = trigrams(&query);
         if query_trigrams.is_empty() {
+            // Queries shorter than a trigram cannot use the index at all.
             return self
-                .documents
-                .iter()
+                .documents()
                 .filter(|(_, document)| document.contains(&query))
                 .map(|(id, _)| id.to_string())
                 .collect();
         }
 
-        let mut postings = query_trigrams
-            .iter()
-            .map(|trigram| self.postings.get(trigram))
-            .collect::<Vec<_>>();
-        if postings.iter().any(|posting| posting.is_none()) {
-            return HashSet::new();
-        }
-        postings.sort_by_key(|posting| posting.map_or(0, HashSet::len));
-
-        let mut candidates = postings[0].cloned().unwrap_or_default().clone();
-        for posting in postings.into_iter().skip(1).flatten() {
-            candidates.retain(|id| posting.contains(id));
-            if candidates.is_empty() {
-                break;
+        let mut postings = Vec::with_capacity(query_trigrams.len());
+        for trigram in &query_trigrams {
+            match self.postings.get(trigram.as_str()) {
+                // A trigram nothing has means nothing can match all of them.
+                None => return HashSet::new(),
+                Some(slots) => postings.push(slots.as_slice()),
             }
         }
-        candidates.retain(|id| {
-            self.documents
-                .get(id)
-                .is_some_and(|document| document.contains(&query))
-        });
-        candidates.into_iter().map(|id| id.to_string()).collect()
+        // Start from the rarest trigram so the first intersection is as small
+        // as possible.
+        postings.sort_by_key(|slots| slots.len());
+
+        let mut candidates = postings[0].to_vec();
+        for slots in postings.into_iter().skip(1) {
+            candidates = intersect_sorted(&candidates, slots);
+            if candidates.is_empty() {
+                return HashSet::new();
+            }
+        }
+
+        // Trigram agreement is necessary but not sufficient -- the trigrams of
+        // a query can all be present in a document in the wrong order -- so the
+        // surviving candidates are still checked for the literal substring.
+        candidates
+            .into_iter()
+            .filter_map(|slot| self.documents[slot as usize].as_ref())
+            .filter(|entry| entry.document.contains(&query))
+            .map(|entry| entry.id.to_string())
+            .collect()
     }
 }
 
@@ -240,7 +314,7 @@ impl SearchIndex {
             // cannot slip in between the check and the publish and get lost.
             let mut state = self.state.write();
             if self.generation.load(Ordering::Acquire) == generation {
-                let count = next.documents.len();
+                let count = next.len();
                 *state = Some(next);
                 log::info!("SEARCH: Built encrypted-safe in-memory index for {count} clips");
                 return Ok(());
@@ -263,7 +337,7 @@ impl SearchIndex {
             return Vec::new();
         };
         let mut counts: HashMap<&str, usize> = HashMap::new();
-        for document in state.documents.values() {
+        for (_, document) in state.documents() {
             if let Some(app) = document.source_app.as_deref() {
                 *counts.entry(app).or_default() += 1;
             }
@@ -288,8 +362,7 @@ impl SearchIndex {
         let state = self.state.read();
         state.as_ref().map_or_else(HashSet::new, |state| {
             state
-                .documents
-                .iter()
+                .documents()
                 .filter(|(_, document)| {
                     document
                         .source_app
@@ -312,7 +385,7 @@ impl SearchIndex {
     ) {
         self.generation.fetch_add(1, Ordering::AcqRel);
         if let Some(state) = self.state.write().as_mut() {
-            let existing = state.documents.get(id).cloned().unwrap_or_default();
+            let existing = state.document(id).cloned().unwrap_or_default();
             let searchable_content = if clip_type != "image" {
                 String::from_utf8_lossy(content).into_owned()
             } else {
@@ -337,7 +410,7 @@ impl SearchIndex {
     pub fn update_notes(&self, id: &str, notes: &str) {
         self.generation.fetch_add(1, Ordering::AcqRel);
         if let Some(state) = self.state.write().as_mut() {
-            if let Some(mut document) = state.documents.get(id).cloned() {
+            if let Some(mut document) = state.document(id).cloned() {
                 document.notes = normalize(notes);
                 state.insert(id.to_string(), document);
             }
@@ -347,7 +420,7 @@ impl SearchIndex {
     pub fn update_ocr(&self, id: &str, ocr: &str) {
         self.generation.fetch_add(1, Ordering::AcqRel);
         if let Some(state) = self.state.write().as_mut() {
-            if let Some(mut document) = state.documents.get(id).cloned() {
+            if let Some(mut document) = state.document(id).cloned() {
                 document.ocr = normalize(ocr);
                 state.insert(id.to_string(), document);
             }
@@ -369,6 +442,42 @@ impl SearchIndex {
 
 fn normalize(value: &str) -> String {
     value.to_lowercase()
+}
+
+/// Drop a preview that the content already contains.
+///
+/// `text_preview` is a truncated copy of the clip's own text, so for a text
+/// clip it is a substring of `content` and storing it doubles the resident cost
+/// of the clip while adding nothing searchable: both `contains` and `trigrams`
+/// take the union of the fields, and the union with a subset is the set.
+///
+/// Image clips are the case that keeps this field alive at all -- their content
+/// is empty and the preview is the only text they have -- as is any preview
+/// that is not a clean prefix, such as one with an ellipsis appended.
+fn redundant_preview(content: &str, preview: &str) -> String {
+    if preview.is_empty() || content.contains(preview) {
+        String::new()
+    } else {
+        preview.to_string()
+    }
+}
+
+/// Linear merge of two sorted, deduplicated slot lists.
+fn intersect_sorted(left: &[Slot], right: &[Slot]) -> Vec<Slot> {
+    let mut result = Vec::with_capacity(left.len().min(right.len()));
+    let (mut i, mut j) = (0, 0);
+    while i < left.len() && j < right.len() {
+        match left[i].cmp(&right[j]) {
+            std::cmp::Ordering::Less => i += 1,
+            std::cmp::Ordering::Greater => j += 1,
+            std::cmp::Ordering::Equal => {
+                result.push(left[i]);
+                i += 1;
+                j += 1;
+            }
+        }
+    }
+    result
 }
 
 fn trigrams(value: &str) -> HashSet<String> {
@@ -399,6 +508,166 @@ mod tests {
             state.matches("CONFIRMATION 4j7"),
             HashSet::from(["one".to_string()])
         );
+    }
+
+    /// The index must return exactly what a brute-force scan would.
+    ///
+    /// Trigram filtering is an optimisation over "check every document", so any
+    /// disagreement is a bug -- a missing hit means a clip the user cannot find.
+    #[test]
+    fn index_agrees_with_a_brute_force_scan() {
+        let corpus = [
+            ("a", "Release confirmation 4J7K for the Wilmore office"),
+            ("b", "release notes: clipboard history and paste engine"),
+            ("c", "unrelated content about gardening"),
+            ("d", "CONFIRMATION of receipt, reference 4J7K"),
+            ("e", "café · Ελληνικά · 日本語 · emoji 😀 tail"),
+            ("f", ""),
+        ];
+
+        let mut state = IndexState::default();
+        for (id, text) in corpus {
+            state.insert(
+                id.to_string(),
+                SearchDocument::new(text, "", None, None, None),
+            );
+        }
+
+        for query in [
+            "release",
+            "RELEASE",
+            "4j7k",
+            "confirmation",
+            "clipboard history",
+            "日本語",
+            "café",
+            "😀",
+            "gardening",
+            "nothing matches this",
+            "ab",
+            "",
+            "  ",
+        ] {
+            let normalized = normalize(query);
+            let expected: HashSet<String> = corpus
+                .iter()
+                .filter(|(_, text)| normalize(text).contains(&normalized))
+                .map(|(id, _)| (*id).to_string())
+                .collect();
+            assert_eq!(
+                state.matches(query),
+                expected,
+                "index and scan disagree for {query:?}"
+            );
+        }
+    }
+
+    /// Slots are reused after a removal, so a stale posting would make a new
+    /// clip answer the deleted clip's queries.
+    #[test]
+    fn a_reused_slot_does_not_inherit_the_removed_clips_matches() {
+        let mut state = IndexState::default();
+        state.insert(
+            "first".to_string(),
+            SearchDocument::new("distinctive alpha payload", "", None, None, None),
+        );
+        assert!(state.matches("distinctive").contains("first"));
+
+        state.remove("first");
+        assert!(state.matches("distinctive").is_empty());
+        assert_eq!(state.free_slots.len(), 1, "the slot should be reusable");
+
+        state.insert(
+            "second".to_string(),
+            SearchDocument::new("completely separate bravo text", "", None, None, None),
+        );
+        assert!(state.matches("bravo").contains("second"));
+        assert!(
+            state.matches("distinctive").is_empty(),
+            "the reused slot answered the removed clip's query"
+        );
+        assert_eq!(state.len(), 1);
+    }
+
+    /// Removing every document must leave no postings behind, or the index
+    /// grows monotonically across a long session of captures and deletions.
+    #[test]
+    fn postings_are_emptied_when_documents_go_away() {
+        let mut state = IndexState::default();
+        for index in 0..8 {
+            state.insert(
+                format!("id{index}"),
+                SearchDocument::new(&format!("payload number {index}"), "", None, None, None),
+            );
+        }
+        assert!(!state.postings.is_empty());
+
+        for index in 0..8 {
+            state.remove(&format!("id{index}"));
+        }
+        assert!(state.postings.is_empty(), "postings leaked after removal");
+        assert_eq!(state.len(), 0);
+    }
+
+    #[test]
+    fn a_preview_the_content_already_holds_is_not_stored_twice() {
+        // Text clip: the preview is a truncation of the content.
+        let document = SearchDocument::new(
+            "the full clip text goes here",
+            "the full clip",
+            None,
+            None,
+            None,
+        );
+        assert!(document.preview.is_empty(), "redundant preview was stored");
+        assert!(
+            document.contains("the full clip"),
+            "still searchable via content"
+        );
+
+        // Image clip: content is empty, so the preview is the only text there
+        // is and must be kept.
+        let image = SearchDocument::new("", "Screenshot of the invoice", None, None, None);
+        assert_eq!(image.preview, "screenshot of the invoice");
+        assert!(image.contains("invoice"));
+
+        // A preview that is not a clean substring is kept as-is.
+        let ellipsis =
+            SearchDocument::new("some longer body text", "some longer…", None, None, None);
+        assert_eq!(ellipsis.preview, "some longer…");
+    }
+
+    #[test]
+    fn sorted_intersection_keeps_only_common_slots() {
+        assert_eq!(intersect_sorted(&[1, 3, 5, 7], &[3, 4, 5, 9]), vec![3, 5]);
+        assert_eq!(intersect_sorted(&[], &[1, 2]), Vec::<Slot>::new());
+        assert_eq!(intersect_sorted(&[1, 2], &[]), Vec::<Slot>::new());
+        assert_eq!(intersect_sorted(&[1, 2, 3], &[1, 2, 3]), vec![1, 2, 3]);
+        assert_eq!(intersect_sorted(&[1, 2], &[3, 4]), Vec::<Slot>::new());
+    }
+
+    #[test]
+    fn postings_stay_sorted_and_deduplicated_across_reinserts() {
+        let mut state = IndexState::default();
+        for index in 0..5 {
+            state.insert(
+                format!("id{index}"),
+                SearchDocument::new("shared trigram body", "", None, None, None),
+            );
+        }
+        // Re-insert an existing id: the slot is reused, not duplicated.
+        state.insert(
+            "id2".to_string(),
+            SearchDocument::new("shared trigram body", "", None, None, None),
+        );
+
+        for slots in state.postings.values() {
+            let mut sorted = slots.clone();
+            sorted.sort_unstable();
+            sorted.dedup();
+            assert_eq!(*slots, sorted, "postings must stay sorted and unique");
+        }
+        assert_eq!(state.matches("shared trigram").len(), 5);
     }
 
     #[test]

--- a/src-tauri/src/search_index.rs
+++ b/src-tauri/src/search_index.rs
@@ -167,6 +167,61 @@ impl IndexState {
         }
 
         self.free_slots.push(slot);
+        self.compact_if_sparse();
+    }
+
+    /// Reclaim slots once most of them are holes.
+    ///
+    /// A freed slot still costs its `Option<IndexedDocument>` header in the
+    /// `documents` vector plus four bytes in `free_slots`, and nothing ever
+    /// returned that memory: a history that peaked at 100k clips and was then
+    /// trimmed to 1k kept 100k slot headers, which is the per-clip budget
+    /// missed by an order of magnitude in the steady state after a cleanup.
+    ///
+    /// Truncating the tail would not help, because retention prunes the
+    /// *oldest* clips and those hold the *lowest* slots. So this compacts
+    /// properly. It is O(documents + postings), which is why it only runs when
+    /// the majority of slots are free -- and because new slots are assigned in
+    /// increasing order of old slot, the remap is monotonic and posting lists
+    /// stay sorted without re-sorting them.
+    fn compact_if_sparse(&mut self) {
+        /// Below this, compaction is not worth the churn -- and it is deliberately
+        /// small, because the threshold is also the floor on how many empty slots
+        /// can be left behind. At 256 a trimmed history settled at 249 slots for
+        /// 10 clips; at 16 it keeps shrinking until the waste is negligible.
+        const MIN_SLOTS: usize = 16;
+
+        if self.documents.len() < MIN_SLOTS || self.free_slots.len() * 2 <= self.documents.len() {
+            return;
+        }
+
+        let mut remap = vec![None; self.documents.len()];
+        let mut compacted = Vec::with_capacity(self.slots.len());
+        for (old_slot, entry) in self.documents.drain(..).enumerate() {
+            if let Some(entry) = entry {
+                remap[old_slot] = Some(compacted.len() as Slot);
+                compacted.push(Some(entry));
+            }
+        }
+        self.documents = compacted;
+
+        for slot in self.slots.values_mut() {
+            *slot = remap[*slot as usize].expect("a live document keeps its slot");
+        }
+
+        for postings in self.postings.values_mut() {
+            postings.retain_mut(|slot| match remap[*slot as usize] {
+                Some(new_slot) => {
+                    *slot = new_slot;
+                    true
+                }
+                None => false,
+            });
+        }
+
+        self.free_slots.clear();
+        self.documents.shrink_to_fit();
+        self.free_slots.shrink_to_fit();
     }
 
     fn matches(&self, query: &str) -> HashSet<String> {
@@ -635,6 +690,80 @@ mod tests {
         let ellipsis =
             SearchDocument::new("some longer body text", "some longer…", None, None, None);
         assert_eq!(ellipsis.preview, "some longer…");
+    }
+
+    /// Trimming a large history must give the memory back.
+    ///
+    /// Retention prunes the oldest clips, which hold the lowest slots, so this
+    /// deletes from the front -- the case tail-truncation would miss.
+    #[test]
+    fn slots_are_reclaimed_after_a_large_history_is_trimmed() {
+        let mut state = IndexState::default();
+        for index in 0..1_000 {
+            state.insert(
+                format!("id{index}"),
+                SearchDocument::new(&format!("clip body number {index}"), "", None, None, None),
+            );
+        }
+        assert_eq!(state.documents.len(), 1_000);
+
+        // Delete the oldest 990, the way retention would.
+        for index in 0..990 {
+            state.remove(&format!("id{index}"));
+        }
+
+        assert_eq!(state.len(), 10, "ten clips should remain");
+        assert!(
+            state.documents.len() <= 32,
+            "slots were not reclaimed: {} slots for 10 clips",
+            state.documents.len()
+        );
+        assert!(state.free_slots.len() <= 32);
+
+        // The survivors are still findable, and the deleted ones are gone.
+        assert!(state.matches("number 995").contains("id995"));
+        assert!(state.matches("number 100").is_empty());
+
+        // Postings must not reference a slot that no longer exists.
+        for slots in state.postings.values() {
+            for slot in slots {
+                assert!(
+                    (*slot as usize) < state.documents.len()
+                        && state.documents[*slot as usize].is_some(),
+                    "posting points at a dead slot"
+                );
+            }
+            let mut sorted = slots.clone();
+            sorted.sort_unstable();
+            assert_eq!(*slots, sorted, "compaction must preserve sorted postings");
+        }
+    }
+
+    /// Compaction rewrites every slot, so the id -> slot map has to move with
+    /// it or lookups silently return the wrong clip.
+    #[test]
+    fn compaction_keeps_id_lookups_pointing_at_the_right_document() {
+        let mut state = IndexState::default();
+        for index in 0..600 {
+            state.insert(
+                format!("id{index}"),
+                SearchDocument::new(&format!("unique marker {index} here"), "", None, None, None),
+            );
+        }
+        for index in 0..500 {
+            state.remove(&format!("id{index}"));
+        }
+
+        for index in 500..600 {
+            let id = format!("id{index}");
+            let document = state
+                .document(&id)
+                .expect("survivor should still be indexed");
+            assert!(
+                document.contains(&format!("unique marker {index}")),
+                "id {id} resolved to the wrong document after compaction"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Closes #169. The in-memory trigram index cost **5.2 KiB per clip** — roughly
500 MiB at 100,000 clips against a 200 MiB `idle_memory` budget, with history
uncapped by default. It now costs **998 B per clip**, and search got faster.

Both changes are internal to `search_index.rs`. Nothing about what search
returns changes.

| | Before | After |
| --- | --- | --- |
| Index memory per clip | 5.2 KiB | **998 B** (5.3x less) |
| Search over 2,000 clips | 5 ms | **2 ms** |
| Projected at 100,000 clips | ~500 MiB | **~95 MiB** |

## What changed

**Postings no longer store clip ids.** Each trigram held a
`HashSet<Arc<str>>`, so every posting cost a 16-byte fat pointer plus the set's
per-slot overhead — and a clip of ordinary prose produces well over a hundred
trigrams. Postings, not the stored text, were the bulk of the index. Documents
now occupy dense `u32` slots and postings are sorted `Vec<u32>`. That is four
bytes per entry with no per-entry overhead, and it turns intersection into a
linear merge instead of a hash lookup per candidate, which is where the latency
improvement comes from. Removing a document frees its slot for reuse so slots
stay dense.

**A preview the content already contains is no longer stored.** `text_preview`
is a truncation of the clip's own text, and both `contains()` and `trigrams()`
take the union of the fields — the union with a subset is the set. Image clips,
whose content is empty and whose preview is the only text they have, still keep
theirs, as does any preview that is not a clean substring.

Measuring after each change was worth it: the preview fix alone moved 5.2 KiB
to 5.0 KiB. That is what identified postings as the real cost rather than the
stored text, which is where I would have guessed.

## Correctness

This is the path that decides whether a user can find a clip, so the main test
asserts the index returns **exactly** what a brute-force scan returns, over a
corpus including Unicode, an emoji, and an empty document, for thirteen queries
including sub-trigram and whitespace-only ones. Trigram filtering is an
optimisation over "check every document", so any disagreement is a bug.

Plus targeted tests for the new invariants:
- a reused slot does not inherit the removed clip's matches (the failure mode a dense-slot scheme invites)
- postings are fully emptied when documents go away, so a long session of captures and deletions does not grow the index monotonically
- postings stay sorted and deduplicated across re-inserts of an existing id
- the sorted intersection itself, including empty and disjoint inputs

## Budget

`search_index_bytes_per_clip` drops from 8 KiB to 2 KiB. At 998 B observed, an
8 KiB limit would no longer catch anything, and the point of the budget is that
the old representation cannot come back unnoticed.

## Verification
- `cargo test --locked --all-targets`: 179 passed, 2 ignored
- `cargo test --locked --features dev-harness --all-targets`: 192 passed
- `cargo clippy -D warnings` in both configurations, `cargo fmt --check`
- `scripts/measure-perf-budgets.ps1`: all four in-process budgets within limits
- `pnpm run test`: 74 passed; `pnpm run release:check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced search index memory usage to approximately 998 bytes per clip.
  * Improved first-search response times to approximately 2–5 ms.
  * Increased scalability, with an estimated footprint of about 95 MiB for 100,000 clips.
* **Bug Fixes**
  * Improved search consistency and matching accuracy.
  * Prevented duplicate preview content from unnecessarily increasing index size.
  * Improved cleanup and reuse of search data as clips are added or removed.
* **Documentation**
  * Updated performance guidance with current measurements, scaling estimates, and memory-budget information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->