### PR TITLE
Prepare the v1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,26 @@
 
 All notable Cubby Clipboard changes are documented here. PastePaw entries below Cubby's first beta are retained as upstream history and attribution.
 
-## v1.2.6
+## v1.3.0
+
+### Added
+- A dedicated History window, separate from the Win+V flyout, with a larger image preview you can read and select text from
+- Multi-select in the History window, with copy, paste, delete, and move applied to everything selected
+- Filter history by source application and by date range, with per-app counts and quick date presets
+- Edit the text of a stored clip in place
+- Notes on a clip, searchable alongside its content and its recognized text
+- On-demand Scan Text on an image clip, with an editable box for correcting the recognized text before you use it
+- Encrypted local backup export and import, protected by a passphrase so a bundle can be restored on another machine
+- A per-clip visibility toggle for keeping sensitive content hidden in the list
+
+### Fixed
+- Stop a failed duplicate check from storing a second copy of a clip. The database now enforces uniqueness itself, and duplicates already in your history are merged on first launch, keeping pins, folders, notes, and hidden state
+- Keep history ordering total, so scrolling can no longer repeat or skip a clip
+- Four capture and paste failure paths, alongside signing the shipped binaries so Windows stops flagging them
+- Accessibility problems found by a static audit, including missing names for icon-only buttons
 
 ### Changed
+- Search uses roughly a fifth of the memory it used to per clip, and returns results faster on a large history
 - Refreshed the interface icon set. The filter, settings, shield, play, pause, file, and flask icons are redrawn with the same meanings and slightly different shapes
 
 ## v1.2.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cubby-clipboard",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "A native-feeling clipboard history replacement for Windows 11",
   "license": "GPL-3.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "cubby"
-version = "1.2.6"
+version = "1.3.0"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubby"
-version = "1.2.6"
+version = "1.3.0"
 description = "A native-feeling clipboard history replacement for Windows 11"
 authors = ["SouthForge AI", "PastePaw contributors"]
 license = "GPL-3.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "Cubby Clipboard",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "identifier": "ai.southforge.cubbyclipboard",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
Prepares the **v1.3.0** release. No behaviour changes — CHANGELOG, version files, and lockfile only.

## Why 1.3.0 and not 1.2.6

The last tag is **`v1.2.5`**. The version files already said 1.2.6, but it was never tagged, so roughly **thirty commits are sitting unreleased** — and 1.2.6's CHANGELOG entry covered only the icon refresh, a fraction of what is actually unshipped.

1.2.6 is folded into 1.3.0 rather than kept as its own section: it never reached anyone, and a minor bump is the honest version for a release that adds a dedicated History window, multi-select and bulk actions, editable clips, notes, on-demand Scan Text, encrypted backup export/import, and per-clip visibility.

## The changelog entry

Written from the full commit list since `v1.2.5`, per the release procedure in `AGENTS.md`, and limited to user-visible behaviour.

Test and CI work from the same range is **deliberately absent** — the application-compatibility matrix, the performance budgets, the clipboard fixtures, the CodeRev workflow, the React 19 and TypeScript 6 upgrades. None of it changes what the app does, and release notes are for users.

One line is called out under Fixed on purpose:

> Stop a failed duplicate check from storing a second copy of a clip. The database now enforces uniqueness itself, and duplicates already in your history are merged on first launch, keeping pins, folders, notes, and hidden state

That migration **modifies existing history on first launch**, so it belongs in the notes rather than being filed as an invisible internal fix.

## Migration rehearsal

Before this release, #171's migration was rehearsed against a **copy** of a real 3,725-clip history (the live database was never opened):

| | Before | After |
| --- | ---: | ---: |
| Total rows | 3,725 | 3,720 |
| Distinct visible content | 3,720 | **3,720** |
| Pinned content | 3 | **3** |
| Duplicate groups | 5 | **0** |

Five real duplicate groups existed and collapsed cleanly with nothing lost. All five were pairs of visible, unpinned rows — so the soft-delete data-loss case that review caught does not occur in that history, though it remains reachable on any future run.

## What this PR does not do

**It does not tag or publish anything.** Pushing `v1.3.0` triggers the signed release workflow and puts a build in front of users, which is yours to do:

```bash
git tag v1.3.0
git push origin v1.3.0
```

## Verification
- `pnpm run release:check`: v1.3.0 metadata consistent across `package.json`, `Cargo.toml`, `tauri.conf.json`, and the CHANGELOG heading
- `Cargo.lock` regenerated (CI builds with `--locked`, so a stale lock would fail)
- `cargo test --locked --all-targets`: 188 passed, 2 ignored
- `cargo clippy --locked --all-targets -- -D warnings`
- `pnpm run test`: 74 passed
