### PR TITLE
Release as v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable Cubby Clipboard changes are documented here. PastePaw entries below Cubby's first beta are retained as upstream history and attribution.
 
-## v1.3.0
+## v1.3.1
 
 ### Added
 - A dedicated History window, separate from the Win+V flyout, with a larger image preview you can read and select text from

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cubby-clipboard",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A native-feeling clipboard history replacement for Windows 11",
   "license": "GPL-3.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "cubby"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubby"
-version = "1.3.0"
+version = "1.3.1"
 description = "A native-feeling clipboard history replacement for Windows 11"
 authors = ["SouthForge AI", "PastePaw contributors"]
 license = "GPL-3.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "Cubby Clipboard",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "identifier": "ai.southforge.cubbyclipboard",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version-only change: 1.3.0 → 1.3.1 across `package.json`, `Cargo.toml`, `tauri.conf.json`, `Cargo.lock`, and the CHANGELOG heading. Same release content.

## Why the version is being burned

v1.3.0 was tagged and its build failed twice.

**Run 1** hung for **52 minutes** inside the build-time signing command on arm64:

```
23:23:46  Built application at: ...aarch64-pc-windows-msvc\release\cubby.exe
23:23:46  Signing ...cubby.exe with a custom signing command
          ← 52 minutes, no output →
00:15:48  cancelled
```

Orphaned at cleanup: `signtool` and **two `msedge` processes** — a browser starting on a headless runner, which is what `DefaultAzureCredential` does when it falls through to interactive login. It blocks forever rather than failing. The arm64 compile itself took ~12 minutes, right in line with history, so this was never a slow build.

**Run 2** then hit the deeper problem. Code signing is not deterministic, and R2 objects under `releases/<tag>/` are immutable, so the rebuild produced different bytes for a key run 1 had already claimed:

```
Refusing to overwrite immutable release object with different bytes:
releases/v1.3.0/Cubby.Clipboard_1.3.0_x64-Store-setup.exe
```

That guard was right. But it means **the first run of a tag permanently claims it** — a release build cannot be re-run, ever.

By then v1.3.0's artifacts were split across two builds (x64 installer from run 2, x64 portable from run 1, R2 Store object from run 1), so it was no longer coherent. Nothing had been published — still a draft, never seen by a user — so the number is free. The v1.3.0 draft and tag are deleted.

## Two real pipeline bugs this exposed

Not fixed here, to keep this a clean version bump:

1. **The build jobs have no `timeout-minutes`.** `submit-store` has one (30); the builds don't, so a hang burns toward GitHub's 6-hour cap in silence. A 30–45 minute cap would have failed run 1 in a fraction of the time.
2. **A re-run can never succeed after a partial release.** Non-deterministic signing plus immutable storage means recovery always costs a version number. The guard should probably allow replacing objects for a tag whose GitHub release is still a draft.

## Verification
- `pnpm run release:check`: v1.3.1 consistent across all four files
- `cargo test --locked --all-targets`: 188 passed, 2 ignored
- `cargo clippy --locked --all-targets -- -D warnings`