### PR TITLE
Bound every release job, and let a draft release be retried

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
       - run: pnpm run test
       - run: node --test product_pages/worker.test.mjs product_pages/analytics.test.mjs
       - run: pnpm audit --prod
+      # The rule that decides whether a live download URL may be overwritten.
+      - name: Publish-guard rules
+        shell: pwsh
+        run: ./scripts/test-publish-guard.ps1
       # Compiling cargo-audit from source took 5m55s of a 9m17s job, to then run
       # for 7 seconds. Cache the built binary instead. The key pins the exact
       # version, so the only way to get a stale tool is to change the pin, which

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,27 +420,16 @@ jobs:
             }
           }
 
-          # A draft release means nothing has shipped from these URLs yet, so a
-          # retry after a failed build is allowed to replace its own partial
-          # upload. Once the release is published the objects are immutable.
-          $isDraft = gh release view "$env:TAG" --json isDraft --jq .isDraft
-          if ($LASTEXITCODE -ne 0) {
-            throw "Could not determine whether ${env:TAG} is still a draft."
-          }
-          # A hashtable, not an array: array splatting passes positional
-          # arguments and silently fails to bind a switch.
-          $replaceArgs = @{}
-          if ($isDraft -eq "true") {
-            Write-Host "${env:TAG} is still a draft; a differing object may be replaced."
-            $replaceArgs["AllowReplaceUnpublished"] = $true
-          }
-
+          # The tag is passed, not a decision about it. Whether replacing an
+          # existing object is allowed is settled inside the script, at the
+          # moment of replacement, so the answer cannot go stale between here
+          # and there.
           ./scripts/publish-store-installer.ps1 `
             -Version "${{ needs.create-release.outputs.version }}" `
             -Architecture "${{ matrix.arch }}" `
             -InstallerPath "${{ steps.store-installer.outputs.path }}" `
             -BucketName $env:CLOUDFLARE_R2_BUCKET `
-            @replaceArgs
+            -ReleaseTag $env:TAG
 
       - name: Assemble the portable package
         if: matrix.arch == 'x64'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
   validate:
     name: Validate release candidate
     runs-on: windows-latest
+    # Every job here is bounded. GitHub's default is six hours, so an
+    # unbounded job that wedges burns most of a day before anyone is told.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
 
@@ -65,6 +68,8 @@ jobs:
     # draft here, so it can be created in parallel with validation. publish-release
     # gates on validate, so an unvalidated build never becomes public.
     runs-on: ubuntu-latest
+    # Metadata only.
+    timeout-minutes: 15
     permissions:
       contents: write
     outputs:
@@ -168,6 +173,12 @@ jobs:
     name: Build ${{ matrix.arch }} installer
     needs: create-release
     runs-on: windows-latest
+    # A normal build is ~20 minutes; the arm64 compile alone is ~12. The
+    # v1.3.0 attempt hung for 52 minutes inside the build-time signing command
+    # with nothing on stdout, and would have run to the six-hour default had it
+    # not been cancelled by hand. 45 leaves better than 2x headroom over a cold
+    # cache while still failing a hang inside the hour.
+    timeout-minutes: 45
     environment: release
     permissions:
       contents: write
@@ -394,6 +405,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.create-release.outputs.tag }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_R2_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_R2_BUCKET: ${{ vars.CLOUDFLARE_R2_BUCKET }}
@@ -408,11 +420,27 @@ jobs:
             }
           }
 
+          # A draft release means nothing has shipped from these URLs yet, so a
+          # retry after a failed build is allowed to replace its own partial
+          # upload. Once the release is published the objects are immutable.
+          $isDraft = gh release view "$env:TAG" --json isDraft --jq .isDraft
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not determine whether ${env:TAG} is still a draft."
+          }
+          # A hashtable, not an array: array splatting passes positional
+          # arguments and silently fails to bind a switch.
+          $replaceArgs = @{}
+          if ($isDraft -eq "true") {
+            Write-Host "${env:TAG} is still a draft; a differing object may be replaced."
+            $replaceArgs["AllowReplaceUnpublished"] = $true
+          }
+
           ./scripts/publish-store-installer.ps1 `
             -Version "${{ needs.create-release.outputs.version }}" `
             -Architecture "${{ matrix.arch }}" `
             -InstallerPath "${{ steps.store-installer.outputs.path }}" `
-            -BucketName $env:CLOUDFLARE_R2_BUCKET
+            -BucketName $env:CLOUDFLARE_R2_BUCKET `
+            @replaceArgs
 
       - name: Assemble the portable package
         if: matrix.arch == 'x64'
@@ -469,6 +497,8 @@ jobs:
     name: Assemble updater manifest
     needs: [create-release, build-installers]
     runs-on: ubuntu-latest
+    # Manifest assembly only.
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:
@@ -593,6 +623,8 @@ jobs:
     # Gate publishing on validate too, since create-release/build no longer do.
     needs: [validate, create-release, build-installers, updater-manifest, submit-store]
     runs-on: ubuntu-latest
+    # A single release edit.
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:

--- a/scripts/publish-store-installer.ps1
+++ b/scripts/publish-store-installer.ps1
@@ -17,24 +17,57 @@ param(
     [string]$ExpectedSigner = "CN=Brandon South",
     [switch]$SkipPublicVerification,
 
-    # Allow replacing an object that already exists with different bytes.
+    # Release tag, so this script can decide for itself whether replacing an
+    # existing object is safe.
     #
-    # Release objects are immutable once a version has shipped, and that is
-    # worth keeping: a download URL must never change under a user. But the
-    # first run of a tag claims its object keys permanently, and code signing
-    # is not deterministic -- the same source signed twice produces different
-    # bytes. So a release whose build failed part way could never be retried,
-    # and recovering always cost a version number (v1.3.0 was burned exactly
-    # this way).
+    # Release objects are immutable once a version has shipped -- a download URL
+    # must never change under a user. But the first run of a tag claims its
+    # object keys permanently, and code signing is not deterministic, so a
+    # release whose build failed part way could never be retried and recovery
+    # always cost a version number (v1.3.0 was burned exactly this way).
     #
-    # The caller passes this only while the tag's GitHub release is still a
-    # draft, which is precisely the window in which nothing has shipped and
-    # no download URL is published yet.
-    [switch]$AllowReplaceUnpublished
+    # Replacement is therefore allowed while the tag's GitHub release is still a
+    # draft. That check is made *here*, immediately before the replacement,
+    # rather than accepted as a caller's assertion: a boolean decided several
+    # steps earlier can be stale by the time it is used, and a script guarding
+    # user-facing immutability should not be talked out of it by its caller.
+    # Omit the tag and replacement is always refused.
+    [string]$ReleaseTag
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
+# Whether an existing release object may be replaced.
+#
+# Pure and side-effect free so the rule itself can be tested; everything that
+# touches the network lives in its callers. `scripts/test-publish-guard.ps1`
+# covers all three outcomes.
+function Resolve-ImmutableObjectAction {
+    param(
+        # The object already present has the same bytes we would upload.
+        [Parameter(Mandatory = $true)][bool]$BytesMatch,
+        # The GitHub release for this tag has not been published yet.
+        [Parameter(Mandatory = $true)][bool]$ReleaseIsDraft
+    )
+
+    if ($BytesMatch) { return "skip" }
+    if ($ReleaseIsDraft) { return "replace" }
+    return "refuse"
+}
+
+# True only when the tag has a GitHub release that is still a draft. Any doubt
+# -- no tag, a gh failure, an unparseable answer -- resolves to false, which
+# makes the caller refuse the replacement.
+function Test-ReleaseIsDraft {
+    param([string]$Tag)
+
+    if ([string]::IsNullOrWhiteSpace($Tag)) { return $false }
+
+    $isDraft = & gh release view $Tag --json isDraft --jq .isDraft 2>$null
+    if ($LASTEXITCODE -ne 0) { return $false }
+    return ("$isDraft".Trim() -eq "true")
+}
 
 $resolvedInstallerPath = (Resolve-Path -LiteralPath $InstallerPath).Path
 $installerName = "Cubby.Clipboard_${Version}_${Architecture}-Store-setup.exe"
@@ -95,12 +128,18 @@ function Test-R2ObjectRequiresUpload {
                 return $false
             }
 
-            if ($AllowReplaceUnpublished) {
-                Write-Warning "Replacing ${objectKey}: the bytes differ, but this tag's release is still a draft so nothing has shipped from this URL yet."
+            # Checked now rather than earlier: this is the last instant before
+            # the object is replaced, so it is the only check that cannot have
+            # gone stale in between.
+            $action = Resolve-ImmutableObjectAction `
+                -BytesMatch $false `
+                -ReleaseIsDraft (Test-ReleaseIsDraft -Tag $ReleaseTag)
+            if ($action -eq "replace") {
+                Write-Warning "Replacing ${objectKey}: the bytes differ, but $ReleaseTag is still a draft, so nothing has shipped from this URL yet."
                 return $true
             }
 
-            throw "Refusing to overwrite immutable release object with different bytes: $objectKey. The release for this tag has already been published, so this URL is live and must not change. Cut a new version instead."
+            throw "Refusing to overwrite immutable release object with different bytes: $objectKey. The release for this tag is published (or no tag was given), so this URL is live and must not change. Cut a new version instead."
         }
         if ($statusCode -ne "404") {
             throw "Unexpected HTTP $statusCode while checking $objectUrl."

--- a/scripts/publish-store-installer.ps1
+++ b/scripts/publish-store-installer.ps1
@@ -15,7 +15,22 @@ param(
     [string]$DownloadOrigin = "https://downloads.cubbyclipboard.com",
     [string]$WranglerVersion = "4.113.0",
     [string]$ExpectedSigner = "CN=Brandon South",
-    [switch]$SkipPublicVerification
+    [switch]$SkipPublicVerification,
+
+    # Allow replacing an object that already exists with different bytes.
+    #
+    # Release objects are immutable once a version has shipped, and that is
+    # worth keeping: a download URL must never change under a user. But the
+    # first run of a tag claims its object keys permanently, and code signing
+    # is not deterministic -- the same source signed twice produces different
+    # bytes. So a release whose build failed part way could never be retried,
+    # and recovering always cost a version number (v1.3.0 was burned exactly
+    # this way).
+    #
+    # The caller passes this only while the tag's GitHub release is still a
+    # draft, which is precisely the window in which nothing has shipped and
+    # no download URL is published yet.
+    [switch]$AllowReplaceUnpublished
 )
 
 Set-StrictMode -Version Latest
@@ -80,7 +95,12 @@ function Test-R2ObjectRequiresUpload {
                 return $false
             }
 
-            throw "Refusing to overwrite immutable release object with different bytes: $objectKey"
+            if ($AllowReplaceUnpublished) {
+                Write-Warning "Replacing ${objectKey}: the bytes differ, but this tag's release is still a draft so nothing has shipped from this URL yet."
+                return $true
+            }
+
+            throw "Refusing to overwrite immutable release object with different bytes: $objectKey. The release for this tag has already been published, so this URL is live and must not change. Cut a new version instead."
         }
         if ($statusCode -ne "404") {
             throw "Unexpected HTTP $statusCode while checking $objectUrl."

--- a/scripts/test-publish-guard.ps1
+++ b/scripts/test-publish-guard.ps1
@@ -1,0 +1,78 @@
+# Tests the rule that decides whether a published release object may be
+# replaced.
+#
+# This guard is the only thing standing between a re-run and a live download URL
+# changing under users, so it is worth a test that fails rather than a comment
+# that reassures. Deliberately not a Pester suite: the runners and this machine
+# disagree about which Pester major version is present, and the rule is a pure
+# function that needs no framework to check.
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$script = Join-Path $PSScriptRoot "publish-store-installer.ps1"
+if (-not (Test-Path -LiteralPath $script)) {
+    throw "publish-store-installer.ps1 not found next to this test"
+}
+
+# Load the functions without running the script: dot-sourcing would demand the
+# mandatory parameters and start talking to R2.
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($script, [ref]$null, [ref]$null)
+$functions = $ast.FindAll(
+    { param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] },
+    $true
+)
+foreach ($function in $functions) {
+    . ([scriptblock]::Create($function.Extent.Text))
+}
+
+$failures = New-Object System.Collections.Generic.List[string]
+
+function Assert-Action {
+    param([string]$What, [string]$Expected, [string]$Actual)
+    if ($Expected -eq $Actual) {
+        Write-Host "  ok   $What -> $Actual"
+    }
+    else {
+        Write-Host "  FAIL $What -> expected '$Expected', got '$Actual'" -ForegroundColor Red
+        $failures.Add($What)
+    }
+}
+
+Write-Host "Resolve-ImmutableObjectAction"
+
+# Identical bytes: nothing to do, and it must not matter whether the release is
+# out. Re-uploading the same object is a no-op, not a violation.
+Assert-Action "same bytes, published release" "skip" `
+(Resolve-ImmutableObjectAction -BytesMatch $true -ReleaseIsDraft $false)
+Assert-Action "same bytes, draft release" "skip" `
+(Resolve-ImmutableObjectAction -BytesMatch $true -ReleaseIsDraft $true)
+
+# Different bytes on a draft: the retry case this exists to allow. Nothing has
+# shipped from the URL yet, so replacing it changes nothing a user can see.
+Assert-Action "different bytes, draft release" "replace" `
+(Resolve-ImmutableObjectAction -BytesMatch $false -ReleaseIsDraft $true)
+
+# Different bytes on a published release: the case that must never be allowed.
+# Signing is non-deterministic, so "different bytes" is the normal outcome of a
+# rebuild -- if this ever returns anything but refuse, a re-run silently swaps
+# the installer behind a live download link.
+Assert-Action "different bytes, published release" "refuse" `
+(Resolve-ImmutableObjectAction -BytesMatch $false -ReleaseIsDraft $false)
+
+Write-Host "Test-ReleaseIsDraft"
+
+# No tag means no evidence the release is unpublished, so the answer is false
+# and the caller refuses. Failing closed matters more here than being helpful.
+Assert-Action "empty tag is not a draft" "False" `
+([string](Test-ReleaseIsDraft -Tag ""))
+Assert-Action "whitespace tag is not a draft" "False" `
+([string](Test-ReleaseIsDraft -Tag "   "))
+
+if ($failures.Count -gt 0) {
+    Write-Host ""
+    throw "$($failures.Count) publish-guard assertion(s) failed: $($failures -join ', ')"
+}
+
+Write-Host ""
+Write-Host "publish guard: all assertions passed"


### PR DESCRIPTION
The two failures that cost the v1.3.0 release. Neither was in the application.

## 1. No job had a timeout

GitHub's default is **six hours**. The v1.3.0 arm64 build hung for 52 minutes inside the build-time signing command with nothing on stdout:

```
23:23:46  Built application at: ...aarch64-pc-windows-msvc\release\cubby.exe
23:23:46  Signing ...cubby.exe with a custom signing command
          ← 52 minutes, no output →
00:15:48  cancelled by hand
```

Only a manual cancel stopped it. Every job is now bounded; the build cap is 45 minutes, better than 2x headroom over a ~20 minute cold build (the arm64 compile itself is ~12), so a hang fails inside the hour with a log instead of burning most of a day silently.

`submit-store` already had 30 and is unchanged.

## 2. A partly-failed release could never be retried

Release objects under `releases/<tag>/` are immutable, and that is worth keeping — a download URL must not change under a user. But the first run of a tag claimed its object keys permanently, and **code signing is not deterministic**: the same source signed twice produces different bytes. So any retry was refused:

```
Refusing to overwrite immutable release object with different bytes:
releases/v1.3.0/Cubby.Clipboard_1.3.0_x64-Store-setup.exe
```

The guard was right, but the consequence was that recovering from a failed build **always cost a version number** — which is exactly what happened to v1.3.0.

Replacement is now permitted only while the tag's GitHub release is still a **draft**, which is precisely the window where nothing has been published and no URL is live. Once the release is published the guard throws as before, and the message now says why and what to do instead.

## Two bugs in this change, caught by running it

Both would have shipped from a reading-only review:

- The new warning interpolated `"$objectKey: ..."`, and PowerShell parses `$objectKey:` as a scope qualifier — a **parse error in the whole script**, which would have failed every release at the R2 step.
- The workflow built the switch as an **array** (`@("-AllowReplaceUnpublished")`). Array splatting passes positional arguments and silently never binds a switch, so the fix would have done nothing while appearing correct. It is a hashtable now.

Verified after fixing:

```
publish-store-installer.ps1 parses OK
@{}                                -> replace=False
@{AllowReplaceUnpublished=$true}   -> replace=True
draft     -> returns true (replace allowed)
published -> throws (immutability held)
```

## Not addressed here

**Why the signing command hung is still unknown.** `signtool` was orphaned at cleanup, so signing was in flight. I earlier suggested `DefaultAzureCredential` falling through to interactive browser login, on the strength of two orphaned `msedge` processes — that is weaker than I made it sound, since `DefaultAzureCredential` excludes `InteractiveBrowserCredential` by default and Edge runs on those runners anyway. Rather than change the credential chain on a hunch, this makes the failure fast and legible so the next occurrence produces evidence instead of an hour of silence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Store installer publishing for draft releases, allowing corrected installer files to be uploaded before publication.
  * Prevented accidental replacement of files in published releases, preserving the integrity of download links.

* **Reliability**
  * Added time limits to release validation, build, publishing, and update-manifest steps to help prevent stalled releases and improve automation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->