### PR TITLE
Report what the startup migrations did

### DIFF
--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -93,6 +93,10 @@ impl Database {
     /// has to collapse the group to exactly one row for the constraint to hold
     /// -- so the pin is moved rather than honoured in place.
     ///
+    /// Returns the number of duplicate rows removed so the caller can report
+    /// it. Deliberately does not log: this runs before the log plugin is
+    /// installed, so anything written here is discarded.
+    ///
     /// Returns the number of duplicate rows removed. On failure the whole
     /// reconciliation rolls back and the old non-unique index is left in place:
     /// an unconstrained database that works beats a half-migrated one.
@@ -247,7 +251,6 @@ impl Database {
             // for the same reason. At startup the index has not been built yet
             // and this is a no-op; it matters for any later caller.
             self.search_index.invalidate();
-            log::info!("STORAGE: Removed {removed} duplicate clips before enforcing unique hashes");
         }
         Ok(removed)
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,16 +81,24 @@ pub fn run_app() {
         .block_on(async { Database::new(&db_path_str).await })
         .unwrap_or_else(|error| panic!("Cubby storage initialization failed: {error}"));
 
-    // Carried into `setup`: the migration below runs before the log plugin is
-    // installed, so its failure message has nowhere to go until then.
-    let mut dedup_error: Option<String> = None;
+    // Anything logged in this function is thrown away.
+    //
+    // `tauri_plugin_log` is not installed until the builder runs, far below, so
+    // a `log::info!` or `log::error!` up here goes nowhere -- which silently
+    // cost the record of a migration that modified a real user's history. These
+    // messages are collected instead and flushed in `setup`, once the logger
+    // exists. Add to this rather than logging directly.
+    let mut startup_log: Vec<(log::Level, String)> = Vec::new();
     rt.block_on(async {
         db.migrate().await.expect("Cubby database migration failed");
         let migrated = commands::migrate_encrypted_storage(&db)
             .await
             .unwrap_or_else(|error| panic!("Cubby encrypted storage migration failed: {error}"));
         if migrated > 0 {
-            log::info!("STORAGE: Encrypted {} existing clipboard items", migrated);
+            startup_log.push((
+                log::Level::Info,
+                format!("STORAGE: Encrypted {migrated} existing clipboard items"),
+            ));
         }
         commands::migrate_clip_format_model(&db)
             .await
@@ -102,12 +110,22 @@ pub fn run_app() {
         // version, which still works, and refusing to start over a hardening
         // step would be a worse outcome than running unconstrained.
         //
-        // The message is carried out to `setup` rather than logged here. This
-        // runs before the log plugin is installed, so a `log::error!` at this
-        // point goes nowhere -- which would have made "report the failure" a
-        // promise the code did not keep.
-        if let Err(error) = db.enforce_content_hash_uniqueness().await {
-            dedup_error = Some(error);
+        // Both outcomes are recorded. Removing duplicates edits history the
+        // user cannot get back, so a run that changed something has to say so;
+        // the first release of this migration merged five clips on a real
+        // machine and left nothing in the log to show for it.
+        match db.enforce_content_hash_uniqueness().await {
+            Ok(0) => {}
+            Ok(removed) => startup_log.push((
+                log::Level::Info,
+                format!(
+                    "STORAGE: Merged {removed} duplicate clips while making clip hashes unique"
+                ),
+            )),
+            Err(error) => startup_log.push((
+                log::Level::Error,
+                format!("STORAGE: Could not enforce unique clip hashes: {error}"),
+            )),
         }
     });
 
@@ -257,11 +275,9 @@ pub fn run_app() {
         .setup(move |app| {
             log::info!("Cubby starting...");
 
-            // Deferred from before the log plugin existed, so a failed
-            // uniqueness migration is actually visible rather than silently
-            // dropped on the floor.
-            if let Some(error) = dedup_error.take() {
-                log::error!("STORAGE: Could not enforce unique clip hashes: {error}");
+            // Everything that happened before the logger existed.
+            for (level, message) in startup_log.drain(..) {
+                log::log!(level, "{message}");
             }
 
             // Initialize Settings Manager

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -273,12 +273,15 @@ pub fn run_app() {
             }
         })
         .setup(move |app| {
-            log::info!("Cubby starting...");
-
-            // Everything that happened before the logger existed.
+            // Flushed before anything else is logged: these describe work that
+            // finished before the logger existed, so they belong above the
+            // first line of this run rather than interleaved after it. Their
+            // timestamps are necessarily the flush time, not the event time.
             for (level, message) in startup_log.drain(..) {
                 log::log!(level, "{message}");
             }
+
+            log::info!("Cubby starting...");
 
             // Initialize Settings Manager
             let db_for_settings = db_arc.clone();


### PR DESCRIPTION
The v1.3.1 uniqueness migration **merged five clips in a real history and logged nothing**. Verified against the live database afterwards:

```
hash indexes : ['idx_clips_hash_unique']
clip rows    : 3735   (visible: 3735)
dupe groups  : 0      (was 5)
```

It worked — nothing was lost — but removing rows edits history the user cannot get back, and a run that changes something has to say so.

## The cause is general

`tauri_plugin_log` is not installed until the builder runs, so **every** `log::` call earlier in `run_app` is discarded. This was not unique to my message: the encrypted-storage migration's `"Encrypted N existing clipboard items"` count was being thrown away the same way.

Worse, an earlier fix deferred the uniqueness migration's *error* to `setup` but left its *success* message behind — so the one case that stayed silent was the case where the migration actually did something.

## The fix

Messages produced before the logger exists are collected and flushed in `setup`:

```rust
// Anything logged in this function is thrown away.
// ... These messages are collected instead and flushed in `setup`, once the
// logger exists. Add to this rather than logging directly.
let mut startup_log: Vec<(log::Level, String)> = Vec::new();
```

`enforce_content_hash_uniqueness` no longer logs at all — it returns the count and the caller reports it. That puts the rule in one visible place instead of leaving it to be rediscovered at each call site, which is how this was missed the first time.

Both outcomes are now reported:

- `STORAGE: Merged N duplicate clips while making clip hashes unique`
- `STORAGE: Could not enforce unique clip hashes: <error>`

## Not covered

The `SEARCH: Could not build the in-memory index` error sits in an `rt.spawn` task, which almost certainly runs after the logger is installed but is not ordered against it. Left alone rather than restructured on a guess.

## Verification
- `cargo test --locked --all-targets`: 188 passed, 2 ignored
- `cargo clippy --locked --all-targets -- -D warnings`, `cargo fmt --all`