### PR TITLE
Route owner PR reviews through Grok

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -38,7 +38,7 @@ jobs:
     # and CodeRev treats its contents only as review evidence.
     if: >-
       github.event.pull_request.user.login == 'tsouth89' &&
-      github.actor != 'dependabot[bot]' &&
+      github.actor == 'tsouth89' &&
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
@@ -51,10 +51,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      # Tracks main during the shadow phase so reviewer fixes land without a
-      # release step. Pin to a tag once the shadow comparison earns it.
+      # Pin the reviewed action commit: mutable refs must not execute on a
+      # persistent self-hosted machine with repository secrets.
       - name: Review
-        uses: tsouth89/coderev@main
+        uses: tsouth89/coderev@4343c19eb746310259e13abfe5e3381c708385cf
         with:
           provider: exec
           model: grok-subscription

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -37,8 +37,8 @@ jobs:
     # and runs the BASE repo's workflow; the checkout below pins the PR head
     # and CodeRev treats its contents only as review evidence.
     if: >-
-      github.event.pull_request.user.login == 'tsouth89' &&
-      github.actor == 'tsouth89' &&
+      github.event.pull_request.user.login == github.repository_owner &&
+      github.actor == github.repository_owner &&
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
@@ -58,8 +58,8 @@ jobs:
         with:
           provider: exec
           model: grok-subscription
-          # Uses CodeRev's trusted action-owned wrapper, not PR-controlled code.
-          exec-command: grok
+          # Absolute path prevents the PR checkout from shadowing the CLI.
+          exec-command: 'C:\Users\tsout\.grok\bin\grok.exe'
           # Muse keeps the measured two-model recall diversity.
           find2-provider: meta
           find2-model: muse-spark-1.2-contributor

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,11 +1,9 @@
 # CodeRev shadow review.
 #
-# Runs alongside CodeRabbit rather than replacing it. CodeRev's benchmark
-# (four runs over ten recorded toolport-studio PRs; logs in the coderev repo)
-# proved cost (~$0.05/PR) and latency (~3 min) but not precision: that is
-# judged during this shadow phase by comparing its comments against
-# CodeRabbit's on real pull requests. Do not cancel CodeRabbit on the
-# strength of this file existing.
+# The Grok subscription canary changes generation only. DeepSeek keeps judging
+# the panel so generator quality can be measured independently before the
+# riskier panel swap. Keep rates and wall time come from run logs; do not scale
+# this workflow until they hold at 30-50% and under roughly five minutes.
 #
 # Advisory (continue-on-error): a red X on a model's opinion trains people to
 # ignore the check.
@@ -30,22 +28,19 @@ permissions:
 jobs:
   review:
     name: CodeRev (advisory)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, windows, cubby-clipboard, grok]
     continue-on-error: true
     timeout-minutes: 20
-    # Reviews run for: same-repo branches, established contributors (GitHub
-    # flips author_association to CONTRIBUTOR when a first PR merges, so
-    # merging someone's first PR is what adds them to the known list), or any
-    # PR a maintainer explicitly labels 'coderev' (the first-timer approval
-    # act). pull_request_target supplies secrets and runs the BASE repo's
-    # workflow, so PR authors cannot tamper with this file; the checkout below
-    # pins the PR head and nothing in the pipeline executes workspace code.
+    # Public-repo boundary: only the owner's own same-repository branches may
+    # schedule a job on the local Grok runner. Forks, contributors, and labels
+    # never grant access to this machine. pull_request_target supplies secrets
+    # and runs the BASE repo's workflow; the checkout below pins the PR head
+    # and CodeRev treats its contents only as review evidence.
     if: >-
+      github.event.pull_request.user.login == 'tsouth89' &&
       github.actor != 'dependabot[bot]' &&
       github.event.pull_request.draft == false &&
-      (github.event.pull_request.head.repo.full_name == github.repository ||
-       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association) ||
-       contains(github.event.pull_request.labels.*.name, 'coderev'))
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -61,9 +56,15 @@ jobs:
       - name: Review
         uses: tsouth89/coderev@main
         with:
-          api-key: ${{ secrets.REVIEW_API_KEY }}
-          # Dual-generator: second model hunts alongside the first; one panel judges.
+          provider: exec
+          model: grok-subscription
+          # Uses CodeRev's trusted action-owned wrapper, not PR-controlled code.
+          exec-command: grok
+          # Muse keeps the measured two-model recall diversity.
           find2-provider: meta
           find2-model: muse-spark-1.2-contributor
           find2-api-key: ${{ secrets.REVIEW_FIND2_API_KEY }}
+          # Phase one isolates Grok generation quality; DeepSeek remains the panel.
+          refute-provider: deepseek
+          refute-api-key: ${{ secrets.REVIEW_API_KEY }}
           conventions: AGENTS.md


### PR DESCRIPTION
## Summary
- route owner-authored same-repository PR reviews to the repo-scoped Cubby Clipboard Grok runner
- use the Grok subscription CLI as primary generator while retaining Muse as generator two
- retain DeepSeek as the panel during the isolated Grok generation canary
- prevent forks, contributors, and labels from scheduling work on the local PC

## Verification
- workflow diff passes `git diff --check`
- `cubby-clipboard-grok` is online with `self-hosted`, `windows`, `cubby-clipboard`, and `grok` labels
- required DeepSeek and Muse secret names are present
- runner is launched windowlessly at user logon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated pull request review workflows to improve review generation and validation.
  * Reviews now run only for eligible, non-draft changes submitted from approved repository branches.
  * Refined the review process to use separate generation and verification stages for more consistent feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->