### PR TITLE
chore: pin fixed Grok review action

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -54,7 +54,7 @@ jobs:
       # Pin the reviewed action commit: mutable refs must not execute on a
       # persistent self-hosted machine with repository secrets.
       - name: Review
-        uses: tsouth89/coderev@8e991699725889f99b02f4f940e521de12144da5
+        uses: tsouth89/coderev@b86b8a2e2f647b4cabc8370fffd2413014e08b48
         with:
           provider: exec
           model: grok-subscription


### PR DESCRIPTION
Pins CodeRev to signed, immutable merge commit b86b8a2e2f647b4cabc8370fffd2413014e08b48, produced by the reviewed and CI-verified upstream change https://github.com/tsouth89/coderev/pull/3. The delta removes only the conflicting Grok prompt-file turn cap and adds its regression test while retaining the runner safety restrictions.