### PR TITLE
Fix history scroll reset to include source and date filters

### DIFF
--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -189,7 +189,7 @@ export function HistoryWindow() {
   const [listResetToken, setListResetToken] = useState(0);
   useEffect(() => {
     setListResetToken((token) => token + 1);
-  }, [contentFilter, searchQuery, selectedFolder]);
+  }, [contentFilter, searchQuery, selectedFolder, sourceApp, dateFrom, dateTo]);
 
   useEffect(() => {
     loadFolders();


### PR DESCRIPTION
Adds sourceApp, dateFrom, and dateTo to the dependency array of the effect that resets the history list scroll position, so changing the source app or date range filters now resets the scroll position like the other filters. Fixes #181.

## What changed

The effect that bumps listResetToken (used to reset the History list scroll position) only depended on contentFilter, searchQuery, and selectedFolder. Changing the source app filter or the date range did not reset the scroll position, leaving the user scrolled into stale results. This adds sourceApp, dateFrom, and dateTo to that dependency array.

## Verification

I reviewed the full file to confirm this is the only effect controlling listResetToken and that no other logic depends on the old dependency list. I was not able to run the app or its test suite in this environment, so this has not been manually verified on Windows 11.
- [x ] I kept this pull request focused.
- [ ] I tested the change on Windows 11.
- [ ] I added or updated tests where practical.
- [ ] I updated documentation for changed behavior.
- [x ] I did not include clipboard contents, credentials, signing material, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * History results now reset correctly when the source app or date-range filters change, ensuring displayed entries stay synchronized with the selected filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->