### PR TITLE
Keep History preview details in sync after save and reveal

### DIFF
--- a/frontend/src/components/ClipCard.tsx
+++ b/frontend/src/components/ClipCard.tsx
@@ -76,8 +76,11 @@ export const ClipCard = memo(function ClipCard({
   // real payload is fetched separately, so render that in its place — but only
   // the payload. The revealed copy is a snapshot taken when the fetch returned,
   // so taking metadata from it too would freeze the pin state and the timestamp
-  // at that moment until the reveal was dropped.
-  const clip = revealed ? { ...row, content: revealed.content, preview: revealed.preview } : row;
+  // at that moment until the reveal was dropped. Notes are the exception: the
+  // hidden row blanks them, so they have to come from the reveal copy too.
+  const clip = revealed
+    ? { ...row, content: revealed.content, preview: revealed.preview, notes: revealed.notes }
+    : row;
   const isHidden = (row.is_hidden ?? false) && !revealed;
 
   const imageSrc = useMemo(

--- a/frontend/src/components/ClipPreview.tsx
+++ b/frontend/src/components/ClipPreview.tsx
@@ -133,6 +133,12 @@ export function ClipPreview({
   // "Loading…" and re-transfer the whole blob for no visual gain.
   const previousClipId = useRef<string | null>(null);
 
+  // The save handlers are async, so a save that resolves after the selection
+  // moved must not apply its result to the new clip. This mirrors the live id
+  // for the handlers to compare against their captured target.
+  const activeClipIdRef = useRef(clipId);
+  activeClipIdRef.current = clipId;
+
   useEffect(() => {
     if (previousClipId.current !== clipId) {
       previousClipId.current = clipId;
@@ -312,9 +318,11 @@ export function ClipPreview({
                   className={actionClass}
                   disabled={scanBusy || scanDraft === (details?.ocr_text ?? '')}
                   onClick={async () => {
+                    const targetId = clip.id;
                     setScanBusy(true);
                     try {
-                      await onSaveOcrText(clip.id, scanDraft);
+                      await onSaveOcrText(targetId, scanDraft);
+                      if (activeClipIdRef.current !== targetId) return;
                       setDetails((current) => withSavedOcrText(current, scanDraft));
                       setScanDraft(null);
                     } finally {
@@ -453,9 +461,11 @@ export function ClipPreview({
               className={actionClass}
               disabled={saving}
               onClick={async () => {
+                const targetId = clip.id;
                 setSaving(true);
                 try {
-                  await onSaveText(clip.id, draft);
+                  await onSaveText(targetId, draft);
+                  if (activeClipIdRef.current !== targetId) return;
                   setDetails((current) =>
                     withSavedText(current, draft, revealed?.notes ?? clip.notes ?? null)
                   );
@@ -486,11 +496,9 @@ export function ClipPreview({
               // preview would silently chop the clip on save. A reveal already
               // fetched that payload; waiting on details would disable Edit forever.
               onClick={() => setDraft(fullTextForEdit(details, revealed?.content, clip.content))}
-              disabled={!isEditReady(details, detailsError, revealed?.content)}
+              disabled={!isEditReady(details, revealed?.content)}
               title={
-                !isEditReady(details, detailsError, revealed?.content)
-                  ? 'Loading the full text…'
-                  : undefined
+                !isEditReady(details, revealed?.content) ? 'Loading the full text…' : undefined
               }
             >
               <Pencil size={13} />

--- a/frontend/src/components/ClipPreview.tsx
+++ b/frontend/src/components/ClipPreview.tsx
@@ -19,7 +19,6 @@ import {
 import { ClipboardItem } from '../types';
 import { NOTE_CHAR_LIMIT } from '../constants';
 import { ImageTextViewer } from './ImageTextViewer';
-import { OcrLayout } from '../utils/ocrSelection';
 import {
   contentKind,
   formatBytes,
@@ -28,14 +27,15 @@ import {
   parseImageMetadata,
   sourceLabel,
 } from '../utils/clipDisplay';
+import {
+  ClipDetails,
+  fullTextForEdit,
+  isEditReady,
+  withSavedOcrText,
+  withSavedText,
+} from '../utils/clipPreviewState';
 
-/** Payload of the `get_clip_details` command. */
-export interface ClipDetails {
-  content: string;
-  ocr_text: string | null;
-  image_expired: boolean;
-  ocr_layout: OcrLayout | null;
-}
+export type { ClipDetails };
 
 const actionClass =
   'inline-flex items-center gap-1.5 rounded-md border border-white/[0.09] bg-white/[0.05] px-2.5 py-1.5 text-[11px] font-medium text-foreground transition-colors hover:bg-white/[0.1] disabled:opacity-40';
@@ -175,11 +175,12 @@ export function ClipPreview({
     setScanDraft(null);
   }, [clipId]);
   // Follow the selection rather than the keystrokes, so switching clips shows
-  // the new clip's note instead of carrying the previous one across.
+  // the new clip's note instead of carrying the previous one across. Hidden
+  // rows withhold notes; a reveal puts them back on the session copy.
   useEffect(() => {
     noteCancelled.current = false;
-    setNoteDraft(clip?.notes ?? '');
-  }, [clipId, clip?.notes]);
+    setNoteDraft(revealed?.notes ?? clip?.notes ?? '');
+  }, [clipId, clip?.notes, revealed?.notes]);
 
   const imageMetadata = useMemo(() => parseImageMetadata(clip?.metadata), [clip?.metadata]);
   // Wait for the full payload rather than showing the row's thumbnail first.
@@ -314,6 +315,7 @@ export function ClipPreview({
                     setScanBusy(true);
                     try {
                       await onSaveOcrText(clip.id, scanDraft);
+                      setDetails((current) => withSavedOcrText(current, scanDraft));
                       setScanDraft(null);
                     } finally {
                       setScanBusy(false);
@@ -408,11 +410,11 @@ export function ClipPreview({
               // and noteDraft still holds the text the user asked to discard.
               if (noteCancelled.current) {
                 noteCancelled.current = false;
-                setNoteDraft(clip.notes ?? '');
+                setNoteDraft(revealed?.notes ?? clip.notes ?? '');
                 return;
               }
               const next = noteDraft.trim();
-              if (next !== (clip.notes ?? '')) void onSaveNotes(clip.id, next);
+              if (next !== (revealed?.notes ?? clip.notes ?? '')) void onSaveNotes(clip.id, next);
             }}
             onKeyDown={(event) => {
               // While an IME is composing, Enter and Escape belong to the
@@ -454,6 +456,9 @@ export function ClipPreview({
                 setSaving(true);
                 try {
                   await onSaveText(clip.id, draft);
+                  setDetails((current) =>
+                    withSavedText(current, draft, revealed?.notes ?? clip.notes ?? null)
+                  );
                   setDraft(null);
                 } finally {
                   setSaving(false);
@@ -478,10 +483,15 @@ export function ClipPreview({
               type="button"
               className={actionClass}
               // The full text, not the row's truncated preview — editing from a
-              // preview would silently chop the clip on save.
-              onClick={() => setDraft(details?.content ?? clip.content ?? '')}
-              disabled={!details && !detailsError}
-              title={!details && !detailsError ? 'Loading the full text…' : undefined}
+              // preview would silently chop the clip on save. A reveal already
+              // fetched that payload; waiting on details would disable Edit forever.
+              onClick={() => setDraft(fullTextForEdit(details, revealed?.content, clip.content))}
+              disabled={!isEditReady(details, detailsError, revealed?.content)}
+              title={
+                !isEditReady(details, detailsError, revealed?.content)
+                  ? 'Loading the full text…'
+                  : undefined
+              }
             >
               <Pencil size={13} />
               Edit

--- a/frontend/src/components/ClipPreview.tsx
+++ b/frontend/src/components/ClipPreview.tsx
@@ -139,6 +139,10 @@ export function ClipPreview({
   const activeClipIdRef = useRef(clipId);
   activeClipIdRef.current = clipId;
 
+  // A fetch started before a save can land after it and undo the saved text, so
+  // every successful save bumps this generation and stale responses are dropped.
+  const saveGenerationRef = useRef(0);
+
   useEffect(() => {
     if (previousClipId.current !== clipId) {
       previousClipId.current = clipId;
@@ -147,10 +151,11 @@ export function ClipPreview({
     }
     if (!clipId || !shouldFetch) return;
 
+    const generation = saveGenerationRef.current;
     let active = true;
     invoke<ClipDetails>('get_clip_details', { id: clipId })
       .then((loaded) => {
-        if (!active) return;
+        if (!active || saveGenerationRef.current !== generation) return;
         setDetails(loaded);
         // Each attempt owns the outcome. A refetch that succeeds after a failed
         // first load must retire the error, or the pane shows the loaded image
@@ -159,7 +164,7 @@ export function ClipPreview({
       })
       .catch((error) => {
         console.error('Failed to load clip details:', error);
-        if (active) setDetailsError(String(error));
+        if (active && saveGenerationRef.current === generation) setDetailsError(String(error));
       });
 
     return () => {
@@ -323,6 +328,7 @@ export function ClipPreview({
                     try {
                       await onSaveOcrText(targetId, scanDraft);
                       if (activeClipIdRef.current !== targetId) return;
+                      saveGenerationRef.current += 1;
                       setDetails((current) => withSavedOcrText(current, scanDraft));
                       setScanDraft(null);
                     } finally {
@@ -466,6 +472,7 @@ export function ClipPreview({
                 try {
                   await onSaveText(targetId, draft);
                   if (activeClipIdRef.current !== targetId) return;
+                  saveGenerationRef.current += 1;
                   setDetails((current) =>
                     withSavedText(current, draft, revealed?.notes ?? clip.notes ?? null)
                   );

--- a/frontend/src/hooks/useRevealedClips.ts
+++ b/frontend/src/hooks/useRevealedClips.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { toast } from 'sonner';
 import { ClipboardItem } from '../types';
+import { ClipDetails } from '../utils/clipPreviewState';
 
 /**
  * Session-scoped reveal for hidden clips (SOU-586).
@@ -41,13 +42,20 @@ export function useRevealedClips() {
 
     pending.current.add(clip.id);
     try {
-      const details = await invoke<{ content: string }>('get_clip_details', { id: clip.id });
+      const details = await invoke<ClipDetails>('get_clip_details', { id: clip.id });
       // Cancelled while the fetch was out.
       if (!pending.current.has(clip.id)) return;
       setRevealed((current) => {
         const next = new Map(current);
-        // Keep the row's own metadata; only the payload was withheld.
-        next.set(clip.id, { ...clip, content: details.content, preview: details.content });
+        // Keep the row's own metadata; only the payload was withheld. Notes
+        // were blanked with the content (a note like "AWS root password" would
+        // otherwise put the secret back on the row), so they come back here.
+        next.set(clip.id, {
+          ...clip,
+          content: details.content,
+          preview: details.content,
+          notes: details.notes,
+        });
         return next;
       });
     } catch (error) {
@@ -78,11 +86,25 @@ export function useRevealedClips() {
     });
   }, []);
 
+  /**
+   * Patch one already-revealed copy. Used after an edit or note save so leaving
+   * the clip and coming back does not show the pre-save payload from this map.
+   */
+  const updateRevealed = useCallback((clipId: string, patch: Partial<ClipboardItem>) => {
+    setRevealed((current) => {
+      const existing = current.get(clipId);
+      if (!existing) return current;
+      const next = new Map(current);
+      next.set(clipId, { ...existing, ...patch });
+      return next;
+    });
+  }, []);
+
   /** Forget every reveal — used when the surface closes or the list reloads. */
   const clearRevealed = useCallback(() => {
     pending.current.clear();
     setRevealed(new Map());
   }, []);
 
-  return { revealed, toggleReveal, forgetRevealed, clearRevealed };
+  return { revealed, toggleReveal, forgetRevealed, updateRevealed, clearRevealed };
 }

--- a/frontend/src/utils/clipPreviewState.test.ts
+++ b/frontend/src/utils/clipPreviewState.test.ts
@@ -31,16 +31,19 @@ describe('fullTextForEdit', () => {
 
 describe('isEditReady', () => {
   it('stays disabled until the full text is in hand', () => {
-    expect(isEditReady(null, null, undefined)).toBe(false);
+    expect(isEditReady(null, undefined)).toBe(false);
   });
 
   it('enables Edit from a reveal even when details were skipped', () => {
-    expect(isEditReady(null, null, 'swordfish')).toBe(true);
+    expect(isEditReady(null, 'swordfish')).toBe(true);
   });
 
-  it('enables Edit after details load or fail', () => {
-    expect(isEditReady(details, null, undefined)).toBe(true);
-    expect(isEditReady(null, 'failed', undefined)).toBe(true);
+  it('enables Edit after details load', () => {
+    expect(isEditReady(details, undefined)).toBe(true);
+  });
+
+  it('keeps Edit disabled when details fail without a reveal', () => {
+    expect(isEditReady(null, undefined)).toBe(false);
   });
 });
 
@@ -64,6 +67,10 @@ describe('withSavedText', () => {
 describe('withSavedOcrText', () => {
   it('replaces ocr_text so Scan text does not reopen the pre-correction reading', () => {
     expect(withSavedOcrText(details, 'fixed scan')?.ocr_text).toBe('fixed scan');
+  });
+
+  it('trims whitespace so Scan does not reopen an unsaved padded reading', () => {
+    expect(withSavedOcrText(details, '  fixed scan  ')?.ocr_text).toBe('fixed scan');
   });
 
   it('clears recognized text when the correction is empty', () => {

--- a/frontend/src/utils/clipPreviewState.test.ts
+++ b/frontend/src/utils/clipPreviewState.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ClipDetails,
+  fullTextForEdit,
+  isEditReady,
+  withSavedOcrText,
+  withSavedText,
+} from './clipPreviewState';
+
+const details: ClipDetails = {
+  content: 'old body',
+  ocr_text: 'old scan',
+  image_expired: false,
+  ocr_layout: null,
+  notes: 'keep me',
+};
+
+describe('fullTextForEdit', () => {
+  it('prefers loaded details over the reveal copy and the list row', () => {
+    expect(fullTextForEdit(details, 'revealed', 'row')).toBe('old body');
+  });
+
+  it('uses the reveal payload when details were never fetched', () => {
+    expect(fullTextForEdit(null, 'revealed body', '')).toBe('revealed body');
+  });
+
+  it('falls back to the list row only when nothing else is loaded', () => {
+    expect(fullTextForEdit(null, undefined, 'row body')).toBe('row body');
+  });
+});
+
+describe('isEditReady', () => {
+  it('stays disabled until the full text is in hand', () => {
+    expect(isEditReady(null, null, undefined)).toBe(false);
+  });
+
+  it('enables Edit from a reveal even when details were skipped', () => {
+    expect(isEditReady(null, null, 'swordfish')).toBe(true);
+  });
+
+  it('enables Edit after details load or fail', () => {
+    expect(isEditReady(details, null, undefined)).toBe(true);
+    expect(isEditReady(null, 'failed', undefined)).toBe(true);
+  });
+});
+
+describe('withSavedText', () => {
+  it('replaces details.content so a later Edit does not reopen the old string', () => {
+    expect(withSavedText(details, 'new body', 'keep me').content).toBe('new body');
+    expect(withSavedText(details, 'new body', 'keep me').notes).toBe('keep me');
+  });
+
+  it('synthesizes details after saving a revealed clip that never fetched them', () => {
+    expect(withSavedText(null, 'new body', 'a note')).toEqual({
+      content: 'new body',
+      ocr_text: null,
+      image_expired: false,
+      ocr_layout: null,
+      notes: 'a note',
+    });
+  });
+});
+
+describe('withSavedOcrText', () => {
+  it('replaces ocr_text so Scan text does not reopen the pre-correction reading', () => {
+    expect(withSavedOcrText(details, 'fixed scan')?.ocr_text).toBe('fixed scan');
+  });
+
+  it('clears recognized text when the correction is empty', () => {
+    expect(withSavedOcrText(details, '   ')?.ocr_text).toBeNull();
+  });
+});

--- a/frontend/src/utils/clipPreviewState.ts
+++ b/frontend/src/utils/clipPreviewState.ts
@@ -21,14 +21,15 @@ export function fullTextForEdit(
 /**
  * Edit needs the full payload. A reveal already fetched it, so waiting on
  * `details` would leave the button disabled forever — that fetch is skipped
- * for revealed text so the pane does not go blank.
+ * for revealed text so the pane does not go blank. A failed details load is
+ * explicitly *not* ready: the only fallback left is the list row's truncated
+ * preview, and editing from it would silently chop the clip on save.
  */
 export function isEditReady(
   details: ClipDetails | null,
-  detailsError: string | null,
   revealedContent: string | undefined
 ): boolean {
-  return details !== null || detailsError !== null || Boolean(revealedContent);
+  return details !== null || revealedContent !== undefined;
 }
 
 /** Keep the pane in sync after Save without waiting for a clipId change. */
@@ -51,5 +52,6 @@ export function withSavedText(
 /** Keep Scan text in sync after Save correction; `has_ocr_text` often does not change. */
 export function withSavedOcrText(details: ClipDetails | null, text: string): ClipDetails | null {
   if (!details) return null;
-  return { ...details, ocr_text: text.trim().length > 0 ? text : null };
+  const normalized = text.trim();
+  return { ...details, ocr_text: normalized || null };
 }

--- a/frontend/src/utils/clipPreviewState.ts
+++ b/frontend/src/utils/clipPreviewState.ts
@@ -1,0 +1,55 @@
+import { OcrLayout } from './ocrSelection';
+
+/** Payload of the `get_clip_details` command. */
+export interface ClipDetails {
+  content: string;
+  ocr_text: string | null;
+  image_expired: boolean;
+  ocr_layout: OcrLayout | null;
+  notes: string | null;
+}
+
+/** Full text for the editor: details first, then a reveal payload, never the row preview. */
+export function fullTextForEdit(
+  details: ClipDetails | null,
+  revealedContent: string | undefined,
+  clipContent: string | undefined
+): string {
+  return details?.content ?? revealedContent ?? clipContent ?? '';
+}
+
+/**
+ * Edit needs the full payload. A reveal already fetched it, so waiting on
+ * `details` would leave the button disabled forever — that fetch is skipped
+ * for revealed text so the pane does not go blank.
+ */
+export function isEditReady(
+  details: ClipDetails | null,
+  detailsError: string | null,
+  revealedContent: string | undefined
+): boolean {
+  return details !== null || detailsError !== null || Boolean(revealedContent);
+}
+
+/** Keep the pane in sync after Save without waiting for a clipId change. */
+export function withSavedText(
+  details: ClipDetails | null,
+  text: string,
+  notes: string | null
+): ClipDetails {
+  return details
+    ? { ...details, content: text }
+    : {
+        content: text,
+        ocr_text: null,
+        image_expired: false,
+        ocr_layout: null,
+        notes,
+      };
+}
+
+/** Keep Scan text in sync after Save correction; `has_ocr_text` often does not change. */
+export function withSavedOcrText(details: ClipDetails | null, text: string): ClipDetails | null {
+  if (!details) return null;
+  return { ...details, ocr_text: text.trim().length > 0 ? text : null };
+}

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -81,7 +81,7 @@ export function HistoryWindow() {
   useSystemAccent();
   const density = settings?.density ?? 'comfortable';
 
-  const { revealed, toggleReveal, forgetRevealed } = useRevealedClips();
+  const { revealed, toggleReveal, forgetRevealed, updateRevealed } = useRevealedClips();
 
   const clipsRef = useRef<ClipboardItem[]>(clips);
   clipsRef.current = clips;
@@ -429,6 +429,9 @@ export function HistoryWindow() {
     async (clipId: string, text: string) => {
       try {
         await invoke('update_clip_text', { id: clipId, text });
+        // Hidden rows still ship empty content after reload; keep the session
+        // reveal in sync so leaving this clip and coming back does not revert.
+        updateRevealed(clipId, { content: text, preview: text });
         // The row still holds the pre-edit preview, and the edit may have
         // changed which clips a filter or search matches.
         await loadClips(false);
@@ -436,23 +439,29 @@ export function HistoryWindow() {
       } catch (error) {
         console.error('Failed to update the clip:', error);
         toast.error('Failed to update the clip');
+        throw error;
       }
     },
-    [loadClips]
+    [loadClips, updateRevealed]
   );
-  const handleSaveNotes = useCallback(async (clipId: string, notes: string) => {
-    try {
-      await invoke('set_clip_notes', { id: clipId, notes });
-      // Cheap local update so the row's note appears immediately; a note also
-      // changes what search matches, but not the current result set.
-      setClips((current) =>
-        current.map((clip) => (clip.id === clipId ? { ...clip, notes: notes || null } : clip))
-      );
-    } catch (error) {
-      console.error('Failed to save the note:', error);
-      toast.error('Failed to save the note');
-    }
-  }, []);
+  const handleSaveNotes = useCallback(
+    async (clipId: string, notes: string) => {
+      try {
+        await invoke('set_clip_notes', { id: clipId, notes });
+        // Cheap local update so the row's note appears immediately; a note also
+        // changes what search matches, but not the current result set.
+        setClips((current) =>
+          current.map((clip) => (clip.id === clipId ? { ...clip, notes: notes || null } : clip))
+        );
+        // Hidden rows withhold notes; the reveal copy is what the pane reads.
+        updateRevealed(clipId, { notes: notes || null });
+      } catch (error) {
+        console.error('Failed to save the note:', error);
+        toast.error('Failed to save the note');
+      }
+    },
+    [updateRevealed]
+  );
 
   const handleSaveOcrText = useCallback(async (clipId: string, text: string) => {
     try {
@@ -468,6 +477,7 @@ export function HistoryWindow() {
     } catch (error) {
       console.error('Failed to save the recognized text:', error);
       toast.error('Failed to save the recognized text');
+      throw error;
     }
   }, []);
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2502,6 +2502,9 @@ pub struct ClipDetails {
     /// clips, and for images captured before word layouts were recorded — those
     /// still offer the whole recognized block via `ocr_text`.
     pub ocr_layout: Option<crate::models::OcrTextLayout>,
+    /// The clip's note. Hidden list rows withhold this (a note can name the
+    /// secret); reveal and the preview pane read it here with the payload.
+    pub notes: Option<String>,
 }
 
 #[tauri::command]
@@ -2545,6 +2548,7 @@ async fn get_clip_details_in_database(db: &Database, id: &str) -> Result<ClipDet
         ocr_text: clip.ocr_text.filter(|text| !text.trim().is_empty()),
         image_expired,
         ocr_layout,
+        notes: clip.notes.filter(|text| !text.trim().is_empty()),
     })
 }
 
@@ -3279,6 +3283,9 @@ mod tests {
                 .with_app("code.exe"),
         )
         .await;
+        set_clip_notes_in_database(&database, "secret", "AWS root password")
+            .await
+            .unwrap();
 
         assert_eq!(
             listed_ids(&database, None, None, None).await,
@@ -3300,6 +3307,10 @@ mod tests {
         // it cannot be read off the row or out of the renderer's memory.
         assert!(items[0].content.is_empty());
         assert!(items[0].preview.is_empty());
+        assert!(
+            items[0].notes.is_none(),
+            "a note naming the secret must not ship on the hidden row"
+        );
 
         // Still searchable, and the match snippet does not leak it either.
         let found = search_clips_in_database(
@@ -3329,6 +3340,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(details.content, "swordfish token 8821");
+        assert_eq!(details.notes.as_deref(), Some("AWS root password"));
 
         assert!(!toggle_clip_hidden_in_pool(&database.pool, "secret")
             .await


### PR DESCRIPTION
## Summary
- After a History text or OCR save, update the preview details immediately so a later Edit or Scan does not reopen (and rewrite) the pre-save string ([SBS-796](https://linear.app/southboundsoftware/issue/SBS-796)).
- Return notes from `get_clip_details`, copy them onto a session reveal, and enable Edit from that payload so revealed hidden clips are no longer stuck on "Loading the full text…" with a blank note ([SBS-806](https://linear.app/southboundsoftware/issue/SBS-806)).
- Failed saves rethrow so the draft stays open instead of looking saved.

## Test plan
- [ ] History: edit a text clip, Save, Edit again — the draft is the new text; Save does not revert it
- [ ] History: correct recognized text, Save correction, Scan text again — shows the correction
- [ ] Hide a text clip that has a note, Reveal — the note is visible and Edit is enabled with the full text
- [ ] A failed save (toast error) leaves the editor open with the draft intact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Revealed clip details now include notes, while hidden history entries keep notes private.
  * Editing revealed clip text and notes keeps previews synchronized.
  * OCR corrections can be saved or cleared.
  * Preview editing uses all available revealed content for more complete drafts.

* **Bug Fixes**
  * Improved consistency when canceling, saving, or restoring clip previews and edits.
  * Prevented outdated loading and save results from overwriting newer clip changes.
  * Improved session-state synchronization after revealed clip updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep History preview details in sync after save and reveal for hidden clips
> - Adds a `notes` field to the `get_clip_details` command response so revealed hidden clips can display their notes, which are intentionally omitted from list rows.
> - Introduces utility functions (`fullTextForEdit`, `isEditReady`, `withSavedText`, `withSavedOcrText`) in [`clipPreviewState.ts`](https://github.com/tsouth89/cubby-clipboard/pull/193/files#diff-ab056bed56736e59c5fd4847796085d47499c5dc070194a4b2e438e8960801d4) to manage preview state transitions after saves.
> - After a text, notes, or OCR save in [`HistoryWindow.tsx`](https://github.com/tsouth89/cubby-clipboard/pull/193/files#diff-66e4a504891e766358388fbcc59de24cd17efafbabffdf4380b98891366560f2), revealed clip copies are patched in place so revisiting a clip reflects saved content without a refetch.
> - Stale `get_clip_details` responses that arrive after a save are discarded using a generation counter, and mid-save selection changes no longer apply results to the wrong clip.
> - Edit is enabled as soon as details or a reveal payload is available, using the full text rather than the truncated list preview.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1184e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->