### PR TITLE
Let the flyout follow the theme and type-to-search IME

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { useLanguage } from './hooks/useLanguage';
 import { useSystemAccent } from './hooks/useSystemAccent';
 import { useUpdater } from './hooks/useUpdater';
 import { useRevealedClips } from './hooks/useRevealedClips';
+import { isImeKey, shouldCaptureTypeToSearch } from './utils/flyoutSearch';
 import { useTranslation } from 'react-i18next';
 import { Toaster, toast } from 'sonner';
 import { generateDemoClips } from './debug/demoData';
@@ -85,9 +86,11 @@ function App() {
       : settings?.mica_effect === 'mica_alt' || settings?.mica_effect === 'auto'
         ? 'acrylic'
         : settings?.mica_effect || 'solid';
+  // Solid follows the theme token the same way Settings and History do.
+  // A hardcoded dark fill made light-theme text (near-black) unreadable.
   const windowSurface =
     windowEffect === 'solid'
-      ? 'bg-[#171719]'
+      ? 'bg-background'
       : windowEffect === 'acrylic'
         ? 'bg-background/[0.58]'
         : 'bg-background/[0.08]';
@@ -96,7 +99,7 @@ function App() {
       ? 'border-white/[0.14]'
       : windowEffect === 'mica'
         ? 'border-white/[0.10]'
-        : 'border-white/[0.09]';
+        : 'border-border';
   const windowGeometry = hasRoundedCorners ? 'p-2' : 'p-0';
   const windowShape = hasRoundedCorners
     ? 'rounded-[10px] shadow-[0_24px_80px_rgba(0,0,0,0.48),0_6px_24px_rgba(0,0,0,0.32)]'
@@ -317,14 +320,17 @@ function App() {
         setLoadError(false);
 
         const currentOffset = append ? clips.length : 0;
+        // The index lowercases but does not trim, so a leading space matches
+        // nothing. History already sends the trimmed form.
+        const query = searchQuery.trim();
 
         let data: AppClipboardItem[];
 
         if (assetCaptureEnabled) {
-          const query = searchQuery.trim().toLocaleLowerCase();
+          const demoQuery = query.toLocaleLowerCase();
           data = generateDemoClips()
             .filter((clip) => {
-              if (!query) return true;
+              if (!demoQuery) return true;
               const searchable = [
                 clip.content,
                 clip.preview,
@@ -335,16 +341,16 @@ function App() {
                 .filter(Boolean)
                 .join(' ')
                 .toLocaleLowerCase();
-              return searchable.includes(query);
+              return searchable.includes(demoQuery);
             })
-            .map((clip) => ({ ...clip, ocr_match: query ? clip.ocr_match : null }))
+            .map((clip) => ({ ...clip, ocr_match: demoQuery ? clip.ocr_match : null }))
             .filter((clip) => matchesContentFilter(clip, filter));
           invokeStart = performance.now();
           invokeEnd = invokeStart;
-        } else if (searchQuery.trim()) {
+        } else if (query) {
           if (perfLogEnabled) invokeStart = performance.now();
           data = await invoke<AppClipboardItem[]>('search_clips', {
-            query: searchQuery,
+            query,
             filterId: folderId,
             limit: 20,
             offset: currentOffset,
@@ -747,12 +753,20 @@ function App() {
       const target = event.target as HTMLElement | null;
       const isEditing =
         target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || target?.isContentEditable;
-      if (isEditing || event.ctrlKey || event.altKey || event.metaKey || event.key.length !== 1) {
-        return;
-      }
+      if (isEditing) return;
 
       const input = document.querySelector<HTMLInputElement>('[data-el="search-input"]');
       if (!input) return;
+
+      // IME: focus the box and let composition start there. preventDefault plus
+      // appending event.key as Latin stops WebView2 composition (ja/zh).
+      if (isImeKey(event)) {
+        input.focus();
+        return;
+      }
+
+      if (!shouldCaptureTypeToSearch(event)) return;
+
       event.preventDefault();
       input.focus();
       setSearchQuery((query) => `${query}${event.key}`);

--- a/frontend/src/utils/flyoutSearch.test.ts
+++ b/frontend/src/utils/flyoutSearch.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { isImeKey, shouldCaptureTypeToSearch } from './flyoutSearch';
+
+function key(
+  partial: Partial<{
+    isComposing: boolean;
+    key: string;
+    keyCode: number;
+    ctrlKey: boolean;
+    altKey: boolean;
+    metaKey: boolean;
+  }>
+) {
+  return {
+    isComposing: false,
+    key: 'a',
+    ctrlKey: false,
+    altKey: false,
+    metaKey: false,
+    ...partial,
+  };
+}
+
+describe('isImeKey', () => {
+  it('treats composing, Process, and keyCode 229 as IME', () => {
+    expect(isImeKey(key({ isComposing: true }))).toBe(true);
+    expect(isImeKey(key({ key: 'Process' }))).toBe(true);
+    expect(isImeKey(key({ keyCode: 229 }))).toBe(true);
+    expect(isImeKey(key({ key: 'a' }))).toBe(false);
+  });
+});
+
+describe('shouldCaptureTypeToSearch', () => {
+  it('captures a bare printable character', () => {
+    expect(shouldCaptureTypeToSearch(key({ key: 'a' }))).toBe(true);
+    expect(shouldCaptureTypeToSearch(key({ key: 'あ' }))).toBe(true);
+  });
+
+  it('ignores IME so composition is not preventDefaulted into Latin', () => {
+    expect(shouldCaptureTypeToSearch(key({ isComposing: true, key: 'a' }))).toBe(false);
+    expect(shouldCaptureTypeToSearch(key({ key: 'Process' }))).toBe(false);
+    expect(shouldCaptureTypeToSearch(key({ key: 'a', keyCode: 229 }))).toBe(false);
+  });
+
+  it('ignores modifiers and non-character keys', () => {
+    expect(shouldCaptureTypeToSearch(key({ ctrlKey: true }))).toBe(false);
+    expect(shouldCaptureTypeToSearch(key({ altKey: true }))).toBe(false);
+    expect(shouldCaptureTypeToSearch(key({ metaKey: true }))).toBe(false);
+    expect(shouldCaptureTypeToSearch(key({ key: 'Enter' }))).toBe(false);
+    expect(shouldCaptureTypeToSearch(key({ key: 'Escape' }))).toBe(false);
+  });
+});

--- a/frontend/src/utils/flyoutSearch.ts
+++ b/frontend/src/utils/flyoutSearch.ts
@@ -1,0 +1,22 @@
+/**
+ * Keys that belong to an IME candidate window, not to type-to-search.
+ * Chromium reports the first composing keydown with keyCode 229 before
+ * `isComposing` is true; `Process` is the same signal on some layouts.
+ */
+export function isImeKey(event: { isComposing: boolean; key: string; keyCode?: number }): boolean {
+  return event.isComposing || event.key === 'Process' || event.keyCode === 229;
+}
+
+/** Printable keys that should steal focus into the flyout search box. */
+export function shouldCaptureTypeToSearch(event: {
+  isComposing: boolean;
+  key: string;
+  keyCode?: number;
+  ctrlKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+}): boolean {
+  if (isImeKey(event)) return false;
+  if (event.ctrlKey || event.altKey || event.metaKey) return false;
+  return event.key.length === 1;
+}


### PR DESCRIPTION
## Summary
- Solid flyout chrome uses `bg-background` / `border-border` instead of a hardcoded dark fill, so light theme is readable ([SBS-797](https://linear.app/southboundsoftware/issue/SBS-797)). Mica and Acrylic stay translucent.
- Flyout search sends the trimmed query, matching History ([SBS-804](https://linear.app/southboundsoftware/issue/SBS-804)).
- Type-to-search skips IME keys (`isComposing`, `Process`, keyCode 229) and focuses the box so composition can start there instead of appending Latin.

## Test plan
- [ ] Settings: theme Light, window effect Solid — flyout background is light and text is readable
- [ ] Settings: theme Dark, window effect Solid — flyout still looks solid/dark
- [ ] Settings: Mica / Acrylic still look translucent
- [ ] Flyout: type a leading space then a real term — results match (not empty)
- [ ] Japanese or Chinese IME: with search unfocused, type to search — composition starts in the search box, not a Latin letter
- [ ] Latin type-to-search still focuses search and inserts the character

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flyout type-to-search to support IME input and follow theme tokens
> - Adds `isImeKey` and `shouldCaptureTypeToSearch` helpers in [`flyoutSearch.ts`](https://github.com/tsouth89/cubby-clipboard/pull/194/files#diff-445788fd2b28b63b016dfcf5e3a354815648befff721efbccbb8439c6e037e13) to distinguish IME composition keys from printable characters.
> - IME keys (composing, `'Process'`, keyCode 229) now focus the search input without injecting Latin characters; bare printable keys append to the search query as before.
> - Window styling for the `'solid'` effect switches from hardcoded colors to theme tokens (`bg-background`, `border-border`).
> - The search query is trimmed before sending to `search_clips`; demo mode lowercases a separate `demoQuery` for in-memory filtering.
> - Behavioral Change: trimming may change results for queries with leading/trailing whitespace; demo OCR match visibility now depends on the lowercased query.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72fa9fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->