### PR TITLE
Keep hidden search blank and finish folder and duplicate cleanup

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { useSystemAccent } from './hooks/useSystemAccent';
 import { useUpdater } from './hooks/useUpdater';
 import { useRevealedClips } from './hooks/useRevealedClips';
 import { isImeKey, shouldCaptureTypeToSearch } from './utils/flyoutSearch';
+import { folderSelectionAfterReload } from './utils/folderSelection';
 import { useTranslation } from 'react-i18next';
 import { Toaster, toast } from 'sonner';
 import { generateDemoClips } from './debug/demoData';
@@ -444,6 +445,11 @@ function App() {
       const data = await invoke<FolderItem[]>('get_folders');
 
       setFolders(data);
+      const next = folderSelectionAfterReload(selectedFolderRef.current, data);
+      if (next !== selectedFolderRef.current) {
+        selectedFolderRef.current = next;
+        setSelectedFolder(next);
+      }
     } catch (error) {
       console.error('Failed to load folders:', error);
     }
@@ -524,9 +530,16 @@ function App() {
 
   useEffect(() => {
     const unlistenClipboard = listen('clipboard-change', () => {
-      refreshCurrentFolder();
-      loadFolders(); // Refresh folders to get updated counts
-      refreshTotalCount(); // Refresh total count
+      void (async () => {
+        const previous = selectedFolderRef.current;
+        await loadFolders();
+        // A deleted folder is reset to All inside loadFolders. That change
+        // reloads the unfiltered list; do not refetch the gone folder first.
+        if (selectedFolderRef.current === previous) {
+          refreshCurrentFolder();
+        }
+        refreshTotalCount();
+      })();
     });
 
     // When a screenshot finishes OCR in the background, surface its "paste text"

--- a/frontend/src/utils/folderSelection.test.ts
+++ b/frontend/src/utils/folderSelection.test.ts
@@ -3,9 +3,9 @@ import { folderSelectionAfterReload } from './folderSelection';
 
 describe('folderSelectionAfterReload', () => {
   it('keeps the selected folder when it is still in the list', () => {
-    expect(
-      folderSelectionAfterReload('receipts', [{ id: 'receipts' }, { id: 'work' }])
-    ).toBe('receipts');
+    expect(folderSelectionAfterReload('receipts', [{ id: 'receipts' }, { id: 'work' }])).toBe(
+      'receipts'
+    );
   });
 
   it('resets to All when the selected folder was deleted', () => {

--- a/frontend/src/utils/folderSelection.test.ts
+++ b/frontend/src/utils/folderSelection.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { folderSelectionAfterReload } from './folderSelection';
+
+describe('folderSelectionAfterReload', () => {
+  it('keeps the selected folder when it is still in the list', () => {
+    expect(
+      folderSelectionAfterReload('receipts', [{ id: 'receipts' }, { id: 'work' }])
+    ).toBe('receipts');
+  });
+
+  it('resets to All when the selected folder was deleted', () => {
+    expect(folderSelectionAfterReload('receipts', [{ id: 'work' }])).toBe(null);
+  });
+
+  it('leaves All selected', () => {
+    expect(folderSelectionAfterReload(null, [{ id: 'work' }])).toBe(null);
+  });
+});

--- a/frontend/src/utils/folderSelection.ts
+++ b/frontend/src/utils/folderSelection.ts
@@ -1,0 +1,10 @@
+/** Keep the current folder if it still exists; otherwise fall back to All. */
+export function folderSelectionAfterReload(
+  selectedFolder: string | null,
+  folders: { id: string }[]
+): string | null {
+  if (selectedFolder && !folders.some((folder) => folder.id === selectedFolder)) {
+    return null;
+  }
+  return selectedFolder;
+}

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -13,6 +13,7 @@ import { useLanguage } from '../hooks/useLanguage';
 import { useSystemAccent } from '../hooks/useSystemAccent';
 import { useRevealedClips } from '../hooks/useRevealedClips';
 import { customRange, DATE_PRESET_LABELS, DatePreset, presetRange } from '../utils/dateRange';
+import { folderSelectionAfterReload } from '../utils/folderSelection';
 import {
   applySelectionClick,
   EMPTY_SELECTION,
@@ -85,6 +86,8 @@ export function HistoryWindow() {
 
   const clipsRef = useRef<ClipboardItem[]>(clips);
   clipsRef.current = clips;
+  const selectedFolderRef = useRef(selectedFolder);
+  selectedFolderRef.current = selectedFolder;
   // Guards against an older load landing after a newer one and restoring stale
   // results — the same discipline the flyout uses.
   const loadIdRef = useRef(0);
@@ -157,7 +160,13 @@ export function HistoryWindow() {
 
   const loadFolders = useCallback(async () => {
     try {
-      setFolders(await invoke<FolderItem[]>('get_folders'));
+      const data = await invoke<FolderItem[]>('get_folders');
+      setFolders(data);
+      const next = folderSelectionAfterReload(selectedFolderRef.current, data);
+      if (next !== selectedFolderRef.current) {
+        selectedFolderRef.current = next;
+        setSelectedFolder(next);
+      }
     } catch (error) {
       console.error('Failed to load folders:', error);
     }
@@ -201,11 +210,16 @@ export function HistoryWindow() {
   // anywhere shows up here without a manual refresh.
   useEffect(() => {
     const unlistenClipboard = listen('clipboard-change', () => {
-      loadClips(false);
-      loadFolders();
-      refreshTotalCount();
-      // A new clip can introduce an app, or move one up the list.
-      loadSourceApps();
+      void (async () => {
+        const previous = selectedFolderRef.current;
+        await loadFolders();
+        if (selectedFolderRef.current === previous) {
+          loadClips(false);
+        }
+        refreshTotalCount();
+        // A new clip can introduce an app, or move one up the list.
+        loadSourceApps();
+      })();
     });
     const unlistenOcr = listen<string>('ocr-completed', (event) => {
       setClips((previous) =>
@@ -217,12 +231,17 @@ export function HistoryWindow() {
     // the next action against one. Refreshing when the window is focused again
     // catches every such change without a new cross-window event contract.
     const refreshOnFocus = () => {
-      loadClips(false);
-      loadFolders();
-      refreshTotalCount();
-      // Deleting elsewhere can empty out an app, changing its count or dropping
-      // it from the filter list entirely.
-      loadSourceApps();
+      void (async () => {
+        const previous = selectedFolderRef.current;
+        await loadFolders();
+        if (selectedFolderRef.current === previous) {
+          loadClips(false);
+        }
+        refreshTotalCount();
+        // Deleting elsewhere can empty out an app, changing its count or dropping
+        // it from the filter list entirely.
+        loadSourceApps();
+      })();
     };
     window.addEventListener('focus', refreshOnFocus);
 

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -1988,12 +1988,29 @@ async fn process_clipboard_snapshot(
     {
         log::error!("CLIPBOARD: Failed to persist auxiliary formats: {}", error);
         if inserted_new {
-            let image_path: Option<String> =
-                sqlx::query_scalar("SELECT file_path FROM clip_images WHERE clip_uuid = ?")
-                    .bind(&emitted_id)
-                    .fetch_optional(pool)
-                    .await
-                    .unwrap_or(None);
+            let image_path: Option<String> = match sqlx::query_scalar(
+                "SELECT file_path FROM clip_images WHERE clip_uuid = ?",
+            )
+            .bind(&emitted_id)
+            .fetch_optional(pool)
+            .await
+            {
+                Ok(path) => path,
+                Err(error) => {
+                    // A failed lookup is not "no row". Cascading the clip
+                    // delete would drop the path before we could collect it,
+                    // so fall back to the managed `{uuid}.cubby` name.
+                    log::warn!(
+                            "CLIPBOARD: Failed to look up image path while rolling back {emitted_id}: {error}"
+                        );
+                    Some(
+                        db.image_dir
+                            .join(format!("{emitted_id}.cubby"))
+                            .to_string_lossy()
+                            .to_string(),
+                    )
+                }
+            };
             match sqlx::query("DELETE FROM clips WHERE uuid = ?")
                 .bind(&emitted_id)
                 .execute(pool)
@@ -2196,11 +2213,25 @@ async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u3
     };
 
     let file_path: Option<String> =
-        sqlx::query_scalar(r#"SELECT file_path FROM clip_images WHERE clip_uuid = ?"#)
+        match sqlx::query_scalar(r#"SELECT file_path FROM clip_images WHERE clip_uuid = ?"#)
             .bind(&recent.uuid)
             .fetch_optional(&mut *transaction)
             .await
-            .unwrap_or(None);
+        {
+            Ok(path) => path,
+            Err(error) => {
+                log::warn!(
+                    "CLIPBOARD: Failed to look up image path while forgetting {}: {error}",
+                    recent.uuid
+                );
+                Some(
+                    db.image_dir
+                        .join(format!("{}.cubby", recent.uuid))
+                        .to_string_lossy()
+                        .to_string(),
+                )
+            }
+        };
 
     // Guarded delete: re-check is_pinned in the same statement so a pin that
     // lands between the earlier SELECT and this DELETE cannot leave orphan

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -331,6 +331,11 @@ fn build_ocr_match(ocr_text: &str, query: &str) -> Option<OcrMatch> {
 
 fn clip_to_search_item(clip: &Clip, query: &str) -> ClipboardItem {
     let mut item = clip_to_list_item(clip);
+    // Hidden list rows already blank content, notes, and OCR snippets.
+    // Search must not write those fields back from the decrypted image OCR.
+    if clip.is_hidden {
+        return item;
+    }
     if clip.clip_type == "image" {
         item.ocr_match = clip
             .ocr_text
@@ -1704,16 +1709,30 @@ pub async fn delete_folder(
     db: tauri::State<'_, Arc<Database>>,
     window: tauri::WebviewWindow,
 ) -> Result<(), String> {
-    let pool = &db.pool;
-
     let folder_id: i64 = id.parse().map_err(|_| "Invalid folder ID")?;
-    sqlx::query(r#"DELETE FROM folders WHERE id = ?"#)
+    delete_folder_in_pool(&db.pool, folder_id).await?;
+    let _ = window.emit("clipboard-change", ());
+    Ok(())
+}
+
+/// Unfile every member, then drop the folder, in one transaction.
+///
+/// `clips.folder_id` references `folders(id)` with no ON DELETE action, and the
+/// pool has foreign keys on. Deleting the folder row first fails for any folder
+/// that still has clips.
+async fn delete_folder_in_pool(pool: &SqlitePool, folder_id: i64) -> Result<(), String> {
+    let mut transaction = pool.begin().await.map_err(|e| e.to_string())?;
+    sqlx::query(r#"UPDATE clips SET folder_id = NULL WHERE folder_id = ?"#)
         .bind(folder_id)
-        .execute(pool)
+        .execute(&mut *transaction)
         .await
         .map_err(|e| e.to_string())?;
-
-    let _ = window.emit("clipboard-change", ());
+    sqlx::query(r#"DELETE FROM folders WHERE id = ?"#)
+        .bind(folder_id)
+        .execute(&mut *transaction)
+        .await
+        .map_err(|e| e.to_string())?;
+    transaction.commit().await.map_err(|e| e.to_string())?;
     Ok(())
 }
 
@@ -2346,35 +2365,57 @@ pub async fn clear_all_clips(db: tauri::State<'_, Arc<Database>>) -> Result<(), 
 
 #[tauri::command]
 pub async fn remove_duplicate_clips(db: tauri::State<'_, Arc<Database>>) -> Result<i64, String> {
-    let pool = &db.pool;
+    remove_duplicate_clips_in_database(&db).await
+}
 
-    // Keepers are the oldest *visible* copy per hash: a soft-deleted survivor
-    // would make the content vanish from the UI entirely. Pinned rows are never
-    // deleted, matching retention and clear-all.
-    let result = sqlx::query(
-        r#"
-        DELETE FROM clips
-        WHERE is_pinned = 0
+/// Hard-delete unpinned clips that are not the oldest visible copy of their
+/// hash. After `idx_clips_hash_unique` that is mostly unpinned soft-deletes.
+///
+/// `clip_images` cascades with the clip row, so the file paths have to be
+/// collected first — the same order retention and hard-delete already use.
+async fn remove_duplicate_clips_in_database(db: &Database) -> Result<i64, String> {
+    let pool = &db.pool;
+    let duplicate_filter = r#"
+        is_pinned = 0
           AND id NOT IN (
             SELECT MIN(id)
             FROM clips
             WHERE is_deleted = 0
             GROUP BY content_hash
-        )
-    "#,
-    )
-    .execute(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+          )
+    "#;
+    let select_paths = format!(
+        "SELECT file_path FROM clip_images WHERE clip_uuid IN (SELECT uuid FROM clips WHERE {duplicate_filter})"
+    );
+    let delete_clips = format!("DELETE FROM clips WHERE {duplicate_filter}");
 
-    cleanup_orphan_clip_image_files(pool, &db.image_dir).await?;
+    let mut transaction = pool.begin().await.map_err(|e| e.to_string())?;
+    let image_paths: Vec<Option<String>> = sqlx::query_scalar(&select_paths)
+        .fetch_all(&mut *transaction)
+        .await
+        .map_err(|e| e.to_string())?;
+    let deleted = sqlx::query(&delete_clips)
+        .execute(&mut *transaction)
+        .await
+        .map_err(|e| e.to_string())?
+        .rows_affected();
+    transaction.commit().await.map_err(|e| e.to_string())?;
 
-    if result.rows_affected() > 0 {
+    remove_clip_image_files(
+        &db.image_dir,
+        image_paths
+            .into_iter()
+            .flatten()
+            .filter(|path| !path.is_empty())
+            .collect(),
+    );
+
+    if deleted > 0 {
         crate::clipboard::reset_capture_dedup();
         db.search_index.invalidate();
     }
 
-    Ok(result.rows_affected() as i64)
+    Ok(deleted as i64)
 }
 
 #[tauri::command]
@@ -2762,9 +2803,10 @@ pub async fn import_from_ditto(
 mod tests {
     use super::{
         build_ocr_highlights, build_ocr_match, clear_clips_in_pool, clipboard_contents_for_restore,
-        directory_size_bytes, enforce_retention_in_pool, get_clip_details_in_database,
-        get_clips_in_database, load_recognized_text, migrate_clip_format_model,
-        migrate_encrypted_storage, ocr_text_layout, remove_clip_image_files, restore_hash_material,
+        delete_folder_in_pool, directory_size_bytes, enforce_retention_in_pool,
+        get_clip_details_in_database, get_clips_in_database, load_recognized_text,
+        migrate_clip_format_model, migrate_encrypted_storage, ocr_text_layout,
+        remove_clip_image_files, remove_duplicate_clips_in_database, restore_hash_material,
         search_clips_in_database, set_clip_notes_in_database, set_clip_ocr_text_in_database,
         toggle_clip_hidden_in_pool, toggle_clip_pin_in_pool, update_clip_text_in_database,
         ClipboardContent, NOTE_CHAR_LIMIT, OCR_SNIPPET_CHAR_LIMIT,
@@ -3351,6 +3393,167 @@ mod tests {
                 .unwrap();
         assert_eq!(items[0].content, "swordfish token 8821");
         assert!(!items[0].is_hidden);
+    }
+
+    #[tokio::test]
+    async fn hidden_image_search_does_not_leak_ocr_snippets() {
+        let database = test_database().await;
+        insert_search_clip(
+            &database,
+            SearchFixture {
+                id: "shot",
+                clip_type: "image",
+                content: "",
+                preview: "Screenshot",
+                ocr: Some("recovery code 8821 on the screenshot"),
+                folder_id: None,
+                pinned: false,
+                created_at: "2026-05-02 09:00:00",
+                source_app: None,
+            },
+        )
+        .await;
+
+        let visible = search_clips_in_database(
+            "8821".into(),
+            None,
+            10,
+            0,
+            None,
+            None,
+            None,
+            None,
+            &database,
+        )
+        .await
+        .unwrap();
+        assert_eq!(visible.len(), 1);
+        assert!(
+            visible[0].ocr_match.is_some(),
+            "a visible image search should still show the OCR snippet"
+        );
+
+        assert!(toggle_clip_hidden_in_pool(&database.pool, "shot")
+            .await
+            .expect("toggle should hide"));
+
+        let found = search_clips_in_database(
+            "8821".into(),
+            None,
+            10,
+            0,
+            None,
+            None,
+            None,
+            None,
+            &database,
+        )
+        .await
+        .unwrap();
+        assert_eq!(found.len(), 1, "a hidden image is still searchable");
+        assert!(found[0].is_hidden);
+        assert!(found[0].content.is_empty());
+        assert!(
+            found[0].ocr_match.is_none(),
+            "the OCR snippet is the hidden text"
+        );
+        assert!(
+            found[0].ocr_highlights.is_none(),
+            "highlight boxes are made of the same OCR words"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_folder_unfiles_member_clips() {
+        let database = test_database().await;
+        let folder_id = sqlx::query("INSERT INTO folders (name) VALUES ('Receipts')")
+            .execute(&database.pool)
+            .await
+            .unwrap()
+            .last_insert_rowid();
+        insert_search_clip(
+            &database,
+            SearchFixture {
+                id: "filed",
+                clip_type: "text",
+                content: "invoice 42",
+                preview: "invoice 42",
+                ocr: None,
+                folder_id: Some(folder_id),
+                pinned: false,
+                created_at: "2026-05-03 09:00:00",
+                source_app: None,
+            },
+        )
+        .await;
+
+        delete_folder_in_pool(&database.pool, folder_id)
+            .await
+            .expect("a folder with clips should delete");
+
+        let remaining_folders: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM folders")
+            .fetch_one(&database.pool)
+            .await
+            .unwrap();
+        assert_eq!(remaining_folders, 0);
+
+        let remaining_folder_id: Option<i64> =
+            sqlx::query_scalar("SELECT folder_id FROM clips WHERE uuid = 'filed'")
+                .fetch_one(&database.pool)
+                .await
+                .unwrap();
+        assert_eq!(remaining_folder_id, None, "members should be unfiled");
+    }
+
+    #[tokio::test]
+    async fn remove_duplicates_deletes_soft_deleted_image_files() {
+        let database = test_database().await;
+        std::fs::create_dir_all(&database.image_dir).unwrap();
+
+        insert_search_clip(
+            &database,
+            SearchFixture::text("keeper", "visible copy", "2026-05-04 09:00:00"),
+        )
+        .await;
+
+        sqlx::query(
+            r#"
+            INSERT INTO clips
+                (uuid, clip_type, content, text_preview, content_hash, is_deleted)
+            VALUES ('gone', 'image', X'', 'Screenshot', 'hash-gone', 1)
+            "#,
+        )
+        .execute(&database.pool)
+        .await
+        .unwrap();
+
+        let gone_path = database.image_dir.join("gone.cubby");
+        std::fs::write(&gone_path, b"full-resolution-bytes").unwrap();
+        sqlx::query(
+            r#"
+            INSERT INTO clip_images (clip_uuid, full_content, file_path, file_size, storage_kind)
+            VALUES ('gone', X'', ?, 21, 'file')
+            "#,
+        )
+        .bind(gone_path.to_string_lossy().as_ref())
+        .execute(&database.pool)
+        .await
+        .unwrap();
+
+        let deleted = remove_duplicate_clips_in_database(&database)
+            .await
+            .expect("duplicate cleanup should succeed");
+        assert_eq!(deleted, 1);
+
+        let remaining: Vec<String> = sqlx::query_scalar("SELECT uuid FROM clips ORDER BY uuid")
+            .fetch_all(&database.pool)
+            .await
+            .unwrap();
+        assert_eq!(remaining, vec!["keeper"]);
+        assert!(
+            !gone_path.exists(),
+            "the full-resolution file must not outlive the clip row"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

Three High bugs from the Aug 13 Cubby audit, all in the command/storage path.

- **[SBS-795](https://linear.app/southboundsoftware/issue/SBS-795):** Hiding a clip blanks list payloads, but search then wrote OCR snippets back from the decrypted image fields. Hidden image search now keeps those fields empty. The clip still matches (hide is a display flag, not a lock).
- **[SBS-798](https://linear.app/southboundsoftware/issue/SBS-798):** `delete_folder` only deleted the folder row. `clips.folder_id` has no `ON DELETE` action, so any folder with clips failed the foreign key. Members are now unfiled in the same transaction, then the folder is dropped.
- **[SBS-799](https://linear.app/southboundsoftware/issue/SBS-799):** `remove_duplicate_clips` deleted clip rows first, so `clip_images` cascaded away before the file paths could be collected. Paths are collected first. Capture rollback and clear-forget also stop treating a failed `file_path` lookup as "no file".

Window/flyout High bugs (SBS-800, SBS-801, SBS-802) are not in this PR.

## Verification

- [x] I kept this pull request focused.
- [ ] I tested the change on Windows 11.
- [x] I added or updated tests where practical.
- [x] I updated documentation for changed behavior.
- [x] I did not include clipboard contents, credentials, signing material, or other secrets.

New unit tests:

- `hidden_image_search_does_not_leak_ocr_snippets`
- `delete_folder_unfiles_member_clips`
- `remove_duplicates_deletes_soft_deleted_image_files`

`cargo test` for this crate needs Windows. This Linux session could not run them (no mingw). CI will.

## Test plan

- [ ] Hide a screenshot that has OCR. Search for a word on it. The row stays hidden and shows no snippet.
- [ ] Search the same word before hiding. The snippet still appears.
- [ ] Delete a folder that still has clips. The folder is gone and the clips are unfiled.
- [ ] Soft-delete an unpinned image, then Settings → Remove Duplicates. The `.cubby` file is gone.
- [ ] A pinned or visible clip is not removed by Remove Duplicates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch clip deletion, folder membership, search payloads for hidden clips, and on-disk image cleanup; mistakes could leak hidden OCR or leave orphan files, but scope is narrow and covered by new tests.
> 
> **Overview**
> Addresses three **High** audit items in the backend plus flyout/history behavior when a folder disappears.
> 
> **Hidden search (SBS-795):** Search used `clip_to_search_item` to attach OCR snippets after `clip_to_list_item` had already blanked hidden rows. An early return when `is_hidden` keeps search hits findable without leaking OCR match/highlights.
> 
> **Folder delete (SBS-798):** `delete_folder` now runs `delete_folder_in_pool`: null `folder_id` on member clips, then delete the folder row, in one transaction (FK-safe). The flyout and **History** window reload folders first on `clipboard-change` / focus; if the selected folder was removed, selection falls back to **All** via `folderSelectionAfterReload` and skips a stale folder clip fetch.
> 
> **Duplicate cleanup (SBS-799):** `remove_duplicate_clips_in_database` selects image paths before deleting duplicate clip rows, then removes files after commit. Clipboard rollback and clear-forget no longer treat a failed `file_path` lookup as “no file”—they fall back to `{uuid}.cubby` so files can still be collected.
> 
> Unit tests cover hidden OCR search, folder unfile-on-delete, and soft-deleted duplicate image file removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e46bd687a39d30ab89d5d616cb86879557bcdf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix hidden search results, folder deletion, and duplicate image cleanup
> - Hidden clipboard items no longer leak OCR snippet or highlight data in search results; `clip_to_search_item` in [commands.rs](https://github.com/tsouth89/cubby-clipboard/pull/195/files#diff-59f7096c7cd88d5d187e749ca400716cd225f951e78eac3d0081ec6c28ce5dcc) returns early when `is_hidden` is true.
> - Deleting a folder now atomically unfiles all member clips (sets `folder_id = NULL`) before deleting the folder row, preventing foreign key violations.
> - Duplicate clip removal now also deletes associated full-resolution image files and reports the correct deleted count.
> - Image file cleanup during clip rollback and forget operations now falls back to a constructed path when the DB query fails, reducing orphaned files.
> - In [App.tsx](https://github.com/tsouth89/cubby-clipboard/pull/195/files#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1eb) and [HistoryWindow.tsx](https://github.com/tsouth89/cubby-clipboard/pull/195/files#diff-66e4a504891e766358388fbcc59de24cd17efafbabffdf4380b98891366560f2), deleting the currently selected folder resets selection to All and skips reloading clips for a folder that no longer exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e46bd6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->