### PR TITLE
Keep clip edits, history files, and captures from mixing or vanishing

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -788,7 +788,7 @@ fn capture_one_bound_sequence(
     Ok(CaptureAttempt::Handled)
 }
 
-/// True when the clipboard advertises a format `materialize_clipboard_content`
+/// True when the clipboard advertises a format `materialize_clipboard_content_once`
 /// can read (text or an image). Used to tell "unsupported payload"
 /// (mark handled) apart from "supported but contended" (defer and retry).
 #[cfg(target_os = "windows")]
@@ -1128,19 +1128,6 @@ fn run_native_listener(event_tx: tokio::sync::mpsc::UnboundedSender<ClipboardLis
 fn run_native_listener(_event_tx: tokio::sync::mpsc::UnboundedSender<ClipboardListenerEvent>) {
     set_capture_state(CAPTURE_STATE_STOPPED);
     record_capture_error("clipboard capture requires Windows");
-}
-
-fn materialize_clipboard_content() -> Option<(CapturedContent, Vec<CapturedFormat>)> {
-    const ATTEMPTS: u32 = 10;
-    for attempt in 0..ATTEMPTS {
-        if let Some(content) = materialize_clipboard_content_once(attempt) {
-            return Some(content);
-        }
-        if attempt + 1 < ATTEMPTS {
-            std::thread::sleep(clipboard_retry_delay(attempt));
-        }
-    }
-    None
 }
 
 /// One materialize attempt. `attempt` is 0-based so the last try can do a

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -435,6 +435,134 @@ enum CaptureAttempt {
     Deferred,
 }
 
+/// How many times one capture may restart after the clipboard sequence moves
+/// mid-read. Each restart re-collects metadata and payload together.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+const MAX_SEQUENCE_BIND_ATTEMPTS: u32 = 3;
+
+/// The clipboard advanced while this capture was still reading. Metadata from
+/// the old sequence must not be paired with the new payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SequenceBindError {
+    Changed { from: u32, to: u32 },
+}
+
+/// Source/sensitivity collected before the payload is materialized.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(not(test), allow(dead_code))]
+struct CapturePrivacyMetadata {
+    sensitive: bool,
+}
+
+/// One capture whose metadata and payload were read under the same sequence.
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(not(test), allow(dead_code))]
+enum SequenceBoundCapture<T> {
+    Bound {
+        sequence: u32,
+        metadata: CapturePrivacyMetadata,
+        payload: T,
+    },
+    Changed {
+        from: u32,
+        to: u32,
+    },
+}
+
+/// Collect metadata, then payload, and keep the pair only if the clipboard
+/// sequence never moved. This is the test seam for SBS-767.
+#[cfg_attr(not(test), allow(dead_code))]
+fn bind_capture_to_sequence<S, M, P, T>(
+    read_sequence: S,
+    collect_metadata: M,
+    collect_payload: P,
+) -> SequenceBoundCapture<T>
+where
+    S: Fn() -> u32,
+    M: FnOnce() -> CapturePrivacyMetadata,
+    P: FnOnce() -> T,
+{
+    let start = read_sequence();
+    let metadata = collect_metadata();
+    let after_metadata = read_sequence();
+    if after_metadata != start {
+        return SequenceBoundCapture::Changed {
+            from: start,
+            to: after_metadata,
+        };
+    }
+    let payload = collect_payload();
+    let after_payload = read_sequence();
+    if after_payload != start {
+        return SequenceBoundCapture::Changed {
+            from: start,
+            to: after_payload,
+        };
+    }
+    SequenceBoundCapture::Bound {
+        sequence: start,
+        metadata,
+        payload,
+    }
+}
+
+/// Persist only when the sequence is still the one we bound. A later copy must
+/// not inherit this snapshot's privacy flags.
+fn persist_if_sequence_holds<T>(
+    expected: u32,
+    current: u32,
+    snapshot: T,
+) -> Result<T, SequenceBindError> {
+    if current == expected {
+        Ok(snapshot)
+    } else {
+        Err(SequenceBindError::Changed {
+            from: expected,
+            to: current,
+        })
+    }
+}
+
+/// Retry a delayed materialize, but abort as soon as the sequence moves so a
+/// later (possibly sensitive) payload is never kept with earlier metadata.
+fn materialize_with_sequence_guard<F, T>(
+    expected: u32,
+    read_sequence: impl Fn() -> u32,
+    mut attempt: F,
+    max_attempts: u32,
+) -> Result<Option<T>, SequenceBindError>
+where
+    F: FnMut(u32) -> Option<T>,
+{
+    for index in 0..max_attempts {
+        let current = read_sequence();
+        if current != expected {
+            return Err(SequenceBindError::Changed {
+                from: expected,
+                to: current,
+            });
+        }
+        if let Some(value) = attempt(index) {
+            let current = read_sequence();
+            if current != expected {
+                return Err(SequenceBindError::Changed {
+                    from: expected,
+                    to: current,
+                });
+            }
+            return Ok(Some(value));
+        }
+    }
+    let current = read_sequence();
+    if current != expected {
+        return Err(SequenceBindError::Changed {
+            from: expected,
+            to: current,
+        });
+    }
+    Ok(None)
+}
+
 /// Try to materialize and queue the clipboard content behind `sequence`.
 ///
 /// The sequence is marked handled only after a successful materialize (or a
@@ -473,10 +601,63 @@ fn deferral_decision(
 /// `Err(())` means the snapshot consumer is gone (process teardown).
 #[cfg(target_os = "windows")]
 fn capture_clipboard_update(
-    sequence: u32,
+    mut sequence: u32,
     event_tx: &tokio::sync::mpsc::UnboundedSender<ClipboardListenerEvent>,
 ) -> Result<CaptureAttempt, ()> {
+    let read_sequence =
+        || unsafe { windows::Win32::System::DataExchange::GetClipboardSequenceNumber() };
+
+    for bind_attempt in 0..MAX_SEQUENCE_BIND_ATTEMPTS {
+        match capture_one_bound_sequence(sequence, &read_sequence, event_tx) {
+            Ok(attempt) => return Ok(attempt),
+            Err(BoundCaptureFailure::ConsumerGone) => return Err(()),
+            Err(BoundCaptureFailure::Sequence(SequenceBindError::Changed { from, to })) => {
+                log::debug!(
+                    "CLIPBOARD: Sequence changed {from} -> {to} during capture (bind attempt {}); retrying from metadata",
+                    bind_attempt + 1
+                );
+                // The clipboard now belongs to a newer copy. Bind the next
+                // attempt to that sequence rather than the stale event number.
+                sequence = to;
+            }
+        }
+    }
+
+    let current = read_sequence();
+    note_clipboard_event(current);
+    log::warn!(
+        "CLIPBOARD: Discarded capture because sequence {} kept changing during read",
+        current
+    );
+    Ok(CaptureAttempt::Handled)
+}
+
+#[cfg(target_os = "windows")]
+enum BoundCaptureFailure {
+    Sequence(SequenceBindError),
+    ConsumerGone,
+}
+
+#[cfg(target_os = "windows")]
+impl From<SequenceBindError> for BoundCaptureFailure {
+    fn from(error: SequenceBindError) -> Self {
+        Self::Sequence(error)
+    }
+}
+
+/// One metadata-then-payload read, kept only if the sequence stays put.
+#[cfg(target_os = "windows")]
+fn capture_one_bound_sequence(
+    mut sequence: u32,
+    read_sequence: &impl Fn() -> u32,
+    event_tx: &tokio::sync::mpsc::UnboundedSender<ClipboardListenerEvent>,
+) -> Result<CaptureAttempt, BoundCaptureFailure> {
     let started = Instant::now();
+    let live = read_sequence();
+    if live != sequence {
+        // The event sequence is already stale. Capture whatever is current.
+        sequence = live;
+    }
 
     // File clipboard payloads are references to external paths, not durable
     // clipboard content. Recording them as history creates entries that can
@@ -487,6 +668,17 @@ fn capture_clipboard_update(
     // as an image rather than as an unreliable file reference.
     let has_file_payload = clipboard_has_file_payload_format();
     let has_image_payload = clipboard_has_image_format();
+    let source_app_identity = get_clipboard_owner_identity();
+    let sensitive = clipboard_marked_sensitive();
+    let after_metadata = read_sequence();
+    if after_metadata != sequence {
+        return Err(SequenceBindError::Changed {
+            from: sequence,
+            to: after_metadata,
+        }
+        .into());
+    }
+
     if crate::clipboard_policy::classify_file_payload(has_file_payload, has_image_payload)
         == crate::clipboard_policy::FilePayloadPolicy::IgnoreFilePayload
     {
@@ -498,10 +690,22 @@ fn capture_clipboard_update(
         return Ok(CaptureAttempt::Handled);
     }
 
-    let source_app_identity = get_clipboard_owner_identity();
-    let sensitive = clipboard_marked_sensitive();
+    let materialized = materialize_with_sequence_guard(
+        sequence,
+        read_sequence,
+        |attempt| {
+            let content = materialize_clipboard_content_once(attempt);
+            if content.is_none() && attempt + 1 < 10 {
+                std::thread::sleep(clipboard_retry_delay(attempt));
+            }
+            content
+        },
+        10,
+    )?;
 
-    if let Some((content, formats)) = materialize_clipboard_content() {
+    persist_if_sequence_holds(sequence, read_sequence(), ())?;
+
+    if let Some((content, formats)) = materialized {
         note_clipboard_event(sequence);
         let snapshot = ClipboardSnapshot {
             sequence,
@@ -514,7 +718,7 @@ fn capture_clipboard_update(
         return event_tx
             .send(ClipboardListenerEvent::Content(snapshot))
             .map(|_| CaptureAttempt::Handled)
-            .map_err(|_| ());
+            .map_err(|_| BoundCaptureFailure::ConsumerGone);
     }
 
     if has_file_payload && has_image_payload {
@@ -530,6 +734,7 @@ fn capture_clipboard_update(
     }
 
     if clipboard_is_cleared() {
+        persist_if_sequence_holds(sequence, read_sequence(), ())?;
         // Empty clipboard (or empty text with no image/files). This is
         // the password-manager auto-clear signal; never treat a new
         // non-empty copy as a clear.
@@ -537,10 +742,11 @@ fn capture_clipboard_update(
         return event_tx
             .send(ClipboardListenerEvent::Cleared { sequence })
             .map(|_| CaptureAttempt::Handled)
-            .map_err(|_| ());
+            .map_err(|_| BoundCaptureFailure::ConsumerGone);
     }
 
     if clipboard_has_supported_format() {
+        persist_if_sequence_holds(sequence, read_sequence(), ())?;
         let (attempts, decision) = deferral_decision(
             DEFERRED_SEQUENCE.load(Ordering::SeqCst),
             DEFERRED_ATTEMPTS.load(Ordering::SeqCst),
@@ -571,6 +777,7 @@ fn capture_clipboard_update(
         return Ok(CaptureAttempt::Handled);
     }
 
+    persist_if_sequence_holds(sequence, read_sequence(), ())?;
     // Nothing we support (custom/private formats only). Mark handled so the
     // watchdog does not treat an ignored format as a dead listener.
     note_clipboard_event(sequence);
@@ -925,58 +1132,67 @@ fn run_native_listener(_event_tx: tokio::sync::mpsc::UnboundedSender<ClipboardLi
 
 fn materialize_clipboard_content() -> Option<(CapturedContent, Vec<CapturedFormat>)> {
     const ATTEMPTS: u32 = 10;
-
     for attempt in 0..ATTEMPTS {
-        // Screenshot tools commonly expose both a bitmap and CF_HDROP for the
-        // saved image. Treat that as an image in Cubby. If the advertised image
-        // is still being rendered, do not let the easier file read mask it
-        // immediately; retry the image for the complete bounded window.
-        if clipboard_has_image_format() && clipboard_has_file_payload_format() {
-            if let Ok(image) = read_clipboard_image_fast(attempt + 1 == ATTEMPTS) {
-                return Some((captured_image(image), Vec::new()));
-            }
-
-            if attempt + 1 < ATTEMPTS {
-                std::thread::sleep(clipboard_retry_delay(attempt));
-                continue;
-            }
-            // The caller records this hybrid update as handled. Do not fall
-            // through to text, where the path could be captured as a text clip.
-            return None;
+        if let Some(content) = materialize_clipboard_content_once(attempt) {
+            return Some(content);
         }
-
-        if let Ok(ctx) = ClipboardContext::new() {
-            if let Ok(text) = ctx.get_text() {
-                if let Some(content) = capture_text(text) {
-                    let mut formats = Vec::new();
-                    if let Ok(html) = ctx.get_html() {
-                        if !html.is_empty() {
-                            formats.push(CapturedFormat {
-                                name: "html",
-                                content: html.into_bytes(),
-                            });
-                        }
-                    }
-                    if let Ok(rtf) = ctx.get_rich_text() {
-                        if !rtf.is_empty() {
-                            formats.push(CapturedFormat {
-                                name: "rtf",
-                                content: rtf.into_bytes(),
-                            });
-                        }
-                    }
-                    return Some((content, formats));
-                }
-            }
-        }
-
-        if let Ok(image) = read_clipboard_image_fast(attempt + 1 == ATTEMPTS) {
-            return Some((captured_image(image), Vec::new()));
-        }
-
         if attempt + 1 < ATTEMPTS {
             std::thread::sleep(clipboard_retry_delay(attempt));
         }
+    }
+    None
+}
+
+/// One materialize attempt. `attempt` is 0-based so the last try can do a
+/// slower image decode. The sequence-bound capture path checks the clipboard
+/// sequence around each call instead of sleeping across a sequence change.
+fn materialize_clipboard_content_once(
+    attempt: u32,
+) -> Option<(CapturedContent, Vec<CapturedFormat>)> {
+    const ATTEMPTS: u32 = 10;
+    let last_attempt = attempt + 1 == ATTEMPTS;
+
+    // Screenshot tools commonly expose both a bitmap and CF_HDROP for the
+    // saved image. Treat that as an image in Cubby. If the advertised image
+    // is still being rendered, do not let the easier file read mask it
+    // immediately; retry the image for the complete bounded window.
+    if clipboard_has_image_format() && clipboard_has_file_payload_format() {
+        if let Ok(image) = read_clipboard_image_fast(last_attempt) {
+            return Some((captured_image(image), Vec::new()));
+        }
+        // The caller records this hybrid update as handled on the last miss.
+        // Do not fall through to text, where the path could be captured as a
+        // text clip.
+        return None;
+    }
+
+    if let Ok(ctx) = ClipboardContext::new() {
+        if let Ok(text) = ctx.get_text() {
+            if let Some(content) = capture_text(text) {
+                let mut formats = Vec::new();
+                if let Ok(html) = ctx.get_html() {
+                    if !html.is_empty() {
+                        formats.push(CapturedFormat {
+                            name: "html",
+                            content: html.into_bytes(),
+                        });
+                    }
+                }
+                if let Ok(rtf) = ctx.get_rich_text() {
+                    if !rtf.is_empty() {
+                        formats.push(CapturedFormat {
+                            name: "rtf",
+                            content: rtf.into_bytes(),
+                        });
+                    }
+                }
+                return Some((content, formats));
+            }
+        }
+    }
+
+    if let Ok(image) = read_clipboard_image_fast(last_attempt) {
+        return Some((captured_image(image), Vec::new()));
     }
 
     None
@@ -2841,6 +3057,99 @@ mod tests {
             is_remote_client_owner(Some("ncplayer.exe"), true),
             false
         ));
+    }
+
+    mod sequence_bind {
+        use super::super::{
+            bind_capture_to_sequence, materialize_with_sequence_guard, persist_if_sequence_holds,
+            CapturePrivacyMetadata, SequenceBindError, SequenceBoundCapture,
+        };
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        const PASSWORD: &str = "hunter2-from-the-next-copy";
+
+        #[test]
+        fn a_sequence_change_after_metadata_does_not_persist_sensitive_content() {
+            let sequence = AtomicU32::new(10);
+            let persisted = std::cell::RefCell::new(None);
+            let bound = bind_capture_to_sequence(
+                || sequence.load(Ordering::SeqCst),
+                || {
+                    let metadata = CapturePrivacyMetadata { sensitive: false };
+                    sequence.store(11, Ordering::SeqCst);
+                    metadata
+                },
+                || PASSWORD,
+            );
+            if let SequenceBoundCapture::Bound { payload, .. } = bound {
+                *persisted.borrow_mut() = Some(payload);
+            }
+            assert!(matches!(
+                bound,
+                SequenceBoundCapture::Changed { from: 10, to: 11 }
+            ));
+            assert!(
+                persisted.borrow().is_none(),
+                "sensitive content from the next sequence must not be persisted"
+            );
+        }
+
+        #[test]
+        fn a_sequence_change_during_delayed_materialize_does_not_persist_sensitive_content() {
+            let sequence = AtomicU32::new(20);
+            let attempts = AtomicU32::new(0);
+            let result = materialize_with_sequence_guard(
+                20,
+                || sequence.load(Ordering::SeqCst),
+                |_| {
+                    let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                    if attempt == 0 {
+                        sequence.store(21, Ordering::SeqCst);
+                        None
+                    } else {
+                        Some(PASSWORD)
+                    }
+                },
+                4,
+            );
+            assert!(matches!(
+                result,
+                Err(SequenceBindError::Changed { from: 20, to: 21 })
+            ));
+            assert_ne!(result.ok().flatten(), Some(PASSWORD));
+        }
+
+        #[test]
+        fn persist_is_rejected_when_the_sequence_moves_before_write() {
+            assert_eq!(
+                persist_if_sequence_holds(3, 4, PASSWORD),
+                Err(SequenceBindError::Changed { from: 3, to: 4 })
+            );
+            assert_eq!(persist_if_sequence_holds(3, 3, "safe"), Ok("safe"));
+        }
+
+        #[test]
+        fn a_stable_sequence_keeps_metadata_and_payload_together() {
+            let bound = bind_capture_to_sequence(
+                || 7,
+                || CapturePrivacyMetadata { sensitive: true },
+                || "tagged-secret",
+            );
+            match bound {
+                SequenceBoundCapture::Bound {
+                    sequence,
+                    metadata,
+                    payload,
+                } => {
+                    assert_eq!(sequence, 7);
+                    assert!(metadata.sensitive);
+                    assert_eq!(payload, "tagged-secret");
+                }
+                SequenceBoundCapture::Changed { from, to } => {
+                    panic!("stable sequence changed {from} -> {to}")
+                }
+            }
+        }
     }
 
     #[cfg(target_os = "windows")]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3,7 +3,6 @@ use crate::models::{Clip, ClipboardItem, Folder, FolderItem, OcrHighlights, OcrM
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use clipboard_rs::common::RustImage;
 use clipboard_rs::{Clipboard, ClipboardContent, ClipboardContext, RustImageData};
-use sqlx::error::DatabaseError;
 use sqlx::SqlitePool;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -1591,9 +1590,8 @@ async fn update_clip_text_in_database(db: &Database, id: &str, text: &str) -> Re
 fn is_unique_constraint_error(error: &sqlx::Error) -> bool {
     match error {
         sqlx::Error::Database(database_error) => {
-            database_error.is_unique_violation()
-                || database_error
-                    .message()
+            sqlx::error::DatabaseError::is_unique_violation(database_error.as_ref())
+                || sqlx::error::DatabaseError::message(database_error.as_ref())
                     .to_ascii_lowercase()
                     .contains("unique")
         }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3,6 +3,7 @@ use crate::models::{Clip, ClipboardItem, Folder, FolderItem, OcrHighlights, OcrM
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use clipboard_rs::common::RustImage;
 use clipboard_rs::{Clipboard, ClipboardContent, ClipboardContext, RustImageData};
+use sqlx::error::DatabaseError;
 use sqlx::SqlitePool;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -1517,6 +1518,34 @@ async fn update_clip_text_in_database(db: &Database, id: &str, text: &str) -> Re
         return Err("Image clips cannot be edited".to_string());
     }
 
+    let hash_material = crate::clipboard::build_clip_hash_material(
+        "text",
+        text.as_bytes(),
+        std::iter::empty::<(&str, &[u8])>(),
+    );
+    // Dedup treats an edited clip exactly like any other clip: the hash follows
+    // the content, so re-copying this text later matches this row instead of
+    // adding a third. A collision with a *different* clip is rejected with no
+    // mutation: deleting HTML/RTF first and then failing the unique hash left
+    // a half-edited row (SBS-768).
+    let content_hash = db.crypto.keyed_hash(&hash_material);
+    let preview = truncate_preview(text);
+    let encrypted_content = db.crypto.encrypt(text.as_bytes())?;
+    let encrypted_preview = db.crypto.encrypt_text(&preview)?;
+
+    let mut transaction = db.pool.begin().await.map_err(|e| e.to_string())?;
+
+    let existing_uuid: Option<String> =
+        sqlx::query_scalar("SELECT uuid FROM clips WHERE content_hash = ? AND uuid != ?")
+            .bind(&content_hash)
+            .bind(id)
+            .fetch_optional(&mut *transaction)
+            .await
+            .map_err(|e| e.to_string())?;
+    if existing_uuid.is_some() {
+        return Err("Another clip already has this text".to_string());
+    }
+
     // The edited text is now the whole clip. Any html/rtf captured alongside it
     // described the *old* text, so keeping them would paste the pre-edit version
     // into anything that prefers a rich format — the edit would look like it had
@@ -1525,33 +1554,29 @@ async fn update_clip_text_in_database(db: &Database, id: &str, text: &str) -> Re
     // formats: it has to describe what the clip now is.
     sqlx::query("DELETE FROM clip_formats WHERE clip_uuid = ?")
         .bind(id)
-        .execute(&db.pool)
+        .execute(&mut *transaction)
         .await
         .map_err(|e| e.to_string())?;
 
-    let hash_material = crate::clipboard::build_clip_hash_material(
-        "text",
-        text.as_bytes(),
-        std::iter::empty::<(&str, &[u8])>(),
-    );
-    // Dedup treats an edited clip exactly like any other clip: the hash follows
-    // the content, so re-copying this text later matches this row instead of
-    // adding a third. A collision with an existing clip is allowed rather than
-    // rejected — refusing an edit because some unrelated row happens to hold the
-    // same text would be the more surprising behavior.
-    let content_hash = db.crypto.keyed_hash(&hash_material);
-    let preview = truncate_preview(text);
-
-    sqlx::query(
+    let update = sqlx::query(
         "UPDATE clips SET clip_type = 'text', content = ?, text_preview = ?, content_hash = ? WHERE uuid = ?",
     )
-    .bind(db.crypto.encrypt(text.as_bytes())?)
-    .bind(db.crypto.encrypt_text(&preview)?)
+    .bind(encrypted_content)
+    .bind(encrypted_preview)
     .bind(&content_hash)
     .bind(id)
-    .execute(&db.pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    .execute(&mut *transaction)
+    .await;
+
+    match update {
+        Ok(_) => {}
+        Err(error) if is_unique_constraint_error(&error) => {
+            return Err("Another clip already has this text".to_string());
+        }
+        Err(error) => return Err(error.to_string()),
+    }
+
+    transaction.commit().await.map_err(|e| e.to_string())?;
 
     // The index holds the pre-edit text until it is told otherwise, so search
     // would keep matching words the clip no longer contains.
@@ -1561,6 +1586,19 @@ async fn update_clip_text_in_database(db: &Database, id: &str, text: &str) -> Re
     // what this row used to hold.
     crate::clipboard::reset_capture_dedup();
     Ok(())
+}
+
+fn is_unique_constraint_error(error: &sqlx::Error) -> bool {
+    match error {
+        sqlx::Error::Database(database_error) => {
+            database_error.is_unique_violation()
+                || database_error
+                    .message()
+                    .to_ascii_lowercase()
+                    .contains("unique")
+        }
+        _ => error.to_string().to_ascii_lowercase().contains("unique"),
+    }
 }
 
 /// Preview text stored on the row, bounded so a huge clip does not bloat every
@@ -3150,6 +3188,97 @@ mod tests {
         assert!(update_clip_text_in_database(&database, "missing", "nope")
             .await
             .is_err());
+    }
+
+    #[tokio::test]
+    async fn editing_a_rich_clip_to_an_existing_hash_is_rejected_without_mutation() {
+        let database = test_database().await;
+        insert_search_clip(
+            &database,
+            SearchFixture::text("editable", "original wording", "2026-06-01 09:00:00"),
+        )
+        .await;
+        insert_search_clip(
+            &database,
+            SearchFixture::text("existing", "already stored", "2026-06-01 10:00:00"),
+        )
+        .await;
+
+        let original_html = database.crypto.encrypt(b"<b>original wording</b>").unwrap();
+        let original_rtf = database.crypto.encrypt(b"{\\rtf original}").unwrap();
+        sqlx::query(
+            "INSERT INTO clip_formats (clip_uuid, format, content) VALUES ('editable', 'html', ?), ('editable', 'rtf', ?)",
+        )
+        .bind(&original_html)
+        .bind(&original_rtf)
+        .execute(&database.pool)
+        .await
+        .unwrap();
+
+        let existing_hash =
+            database
+                .crypto
+                .keyed_hash(&crate::clipboard::build_clip_hash_material(
+                    "text",
+                    b"already stored",
+                    std::iter::empty::<(&str, &[u8])>(),
+                ));
+        sqlx::query("UPDATE clips SET content_hash = ? WHERE uuid = 'existing'")
+            .bind(&existing_hash)
+            .execute(&database.pool)
+            .await
+            .unwrap();
+
+        let before_text = get_clip_details_in_database(&database, "editable")
+            .await
+            .unwrap()
+            .content;
+        let before_hash: String =
+            sqlx::query_scalar("SELECT content_hash FROM clips WHERE uuid = 'editable'")
+                .fetch_one(&database.pool)
+                .await
+                .unwrap();
+
+        let error = update_clip_text_in_database(&database, "editable", "already stored")
+            .await
+            .expect_err("a duplicate-hash edit must be rejected");
+        assert!(
+            error.to_lowercase().contains("already"),
+            "expected a duplicate-target error, got: {error}"
+        );
+
+        let after = get_clip_details_in_database(&database, "editable")
+            .await
+            .unwrap();
+        assert_eq!(after.content, before_text);
+        assert_eq!(after.content, "original wording");
+        let after_hash: String =
+            sqlx::query_scalar("SELECT content_hash FROM clips WHERE uuid = 'editable'")
+                .fetch_one(&database.pool)
+                .await
+                .unwrap();
+        assert_eq!(after_hash, before_hash);
+
+        let format_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM clip_formats WHERE clip_uuid = 'editable'")
+                .fetch_one(&database.pool)
+                .await
+                .unwrap();
+        assert_eq!(format_count, 2);
+        let html: Vec<u8> = sqlx::query_scalar(
+            "SELECT content FROM clip_formats WHERE clip_uuid = 'editable' AND format = 'html'",
+        )
+        .fetch_one(&database.pool)
+        .await
+        .unwrap();
+        let rtf: Vec<u8> = sqlx::query_scalar(
+            "SELECT content FROM clip_formats WHERE clip_uuid = 'editable' AND format = 'rtf'",
+        )
+        .fetch_one(&database.pool)
+        .await
+        .unwrap();
+        assert_eq!(html, original_html);
+        assert_eq!(rtf, original_rtf);
     }
 
     #[tokio::test]

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -1,4 +1,3 @@
-use sqlx::error::DatabaseError;
 use sqlx::SqlitePool;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -656,6 +655,7 @@ async fn assess_database_file_once(db_path: &Path) -> DatabaseHealth {
 }
 
 /// Kept for tests that only need "usable or not".
+#[cfg(test)]
 async fn verify_database_quick_check(db_path: &Path) -> Result<(), String> {
     match assess_database_file(db_path).await {
         DatabaseHealth::Healthy => Ok(()),
@@ -666,7 +666,7 @@ async fn verify_database_quick_check(db_path: &Path) -> Result<(), String> {
 fn classify_health_check_error(error: &sqlx::Error, stage: &str) -> DatabaseHealth {
     match error {
         sqlx::Error::Database(database_error) => classify_sqlite_health_failure(
-            database_error.code().as_deref(),
+            sqlx::error::DatabaseError::code(database_error.as_ref()).as_deref(),
             &format!("{stage} failed: {database_error}"),
         ),
         sqlx::Error::Io(io_error) => DatabaseHealth::Unassessable {

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -1,3 +1,4 @@
+use sqlx::error::DatabaseError;
 use sqlx::SqlitePool;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -490,24 +491,28 @@ impl Database {
 
 /// Ensure `db_path` is either absent (will be created) or a healthy SQLite file.
 ///
-/// On open/integrity failure the existing `cubby.db` (+ WAL/SHM) is renamed to a
-/// timestamped quarantine name and startup continues with a fresh file. The
-/// DPAPI-protected `storage.key` and image blobs are left alone so a future
-/// manual recovery from the quarantine file can still decrypt.
+/// Quarantine runs only when an integrity check itself reports corruption, or
+/// when SQLite proves the file is not a database. Transient open/query errors
+/// (BUSY, LOCKED, I/O, permissions) leave the original file untouched and
+/// surface a startup error instead (SBS-770).
 async fn prepare_database_file(db_path: &Path) -> Result<(), String> {
     if !db_path.exists() {
         return Ok(());
     }
 
-    match verify_database_quick_check(db_path).await {
-        Ok(()) => {
+    apply_database_health(db_path, assess_database_file(db_path).await).await
+}
+
+async fn apply_database_health(db_path: &Path, health: DatabaseHealth) -> Result<(), String> {
+    match health {
+        DatabaseHealth::Healthy => {
             if let Err(error) = refresh_rolling_backup(db_path).await {
                 // Backup is best-effort; a full disk must not block capture.
                 log::warn!("STORAGE: Could not refresh history backup: {error}");
             }
             Ok(())
         }
-        Err(reason) => {
+        DatabaseHealth::Corrupt { reason } => {
             // Structural diagnostics only: never log row contents.
             log::error!(
                 "STORAGE: Clipboard history database is unusable ({}); quarantining",
@@ -520,6 +525,10 @@ async fn prepare_database_file(db_path: &Path) -> Result<(), String> {
             restore_from_rolling_backup(db_path).await;
             Ok(())
         }
+        DatabaseHealth::Unassessable { reason } => Err(format!(
+            "could not assess clipboard history ({}); the existing database was left untouched",
+            sanitize_storage_diagnostic(&reason)
+        )),
     }
 }
 
@@ -534,12 +543,15 @@ async fn restore_from_rolling_backup(db_path: &Path) {
         return;
     }
 
-    if let Err(error) = verify_database_quick_check(&backup).await {
-        log::error!(
-            "STORAGE: Rolling backup failed verification ({}); starting with an empty history",
-            sanitize_storage_diagnostic(&error)
-        );
-        return;
+    match assess_database_file(&backup).await {
+        DatabaseHealth::Healthy => {}
+        DatabaseHealth::Corrupt { reason } | DatabaseHealth::Unassessable { reason } => {
+            log::error!(
+                "STORAGE: Rolling backup failed verification ({}); starting with an empty history",
+                sanitize_storage_diagnostic(&reason)
+            );
+            return;
+        }
     }
 
     let source = backup.clone();
@@ -558,19 +570,62 @@ async fn restore_from_rolling_backup(db_path: &Path) {
     }
 }
 
-async fn verify_database_quick_check(db_path: &Path) -> Result<(), String> {
+/// How many times a recoverable health-check error is retried before startup
+/// fails without touching the file.
+const HEALTH_CHECK_ATTEMPTS: u32 = 5;
+const HEALTH_CHECK_BUSY_TIMEOUT: Duration = Duration::from_millis(50);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DatabaseHealth {
+    Healthy,
+    /// Integrity check ran and reported damage, or SQLite proved this is not a
+    /// database. The only case that may quarantine.
+    Corrupt {
+        reason: String,
+    },
+    /// Operational error: lock, I/O, permissions. Do not quarantine.
+    Unassessable {
+        reason: String,
+    },
+}
+
+async fn assess_database_file(db_path: &Path) -> DatabaseHealth {
+    let mut last_unassessable = None;
+    for attempt in 0..HEALTH_CHECK_ATTEMPTS {
+        match assess_database_file_once(db_path).await {
+            DatabaseHealth::Healthy => return DatabaseHealth::Healthy,
+            DatabaseHealth::Corrupt { reason } => {
+                return DatabaseHealth::Corrupt { reason };
+            }
+            DatabaseHealth::Unassessable { reason } => {
+                last_unassessable = Some(reason);
+                if attempt + 1 < HEALTH_CHECK_ATTEMPTS {
+                    let delay_ms = 20u64 << attempt.min(4);
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                }
+            }
+        }
+    }
+    DatabaseHealth::Unassessable {
+        reason: last_unassessable.unwrap_or_else(|| "could not assess database".to_string()),
+    }
+}
+
+async fn assess_database_file_once(db_path: &Path) -> DatabaseHealth {
     use sqlx::Connection;
 
     let options = sqlx::sqlite::SqliteConnectOptions::new()
         .filename(db_path)
         .create_if_missing(false)
-        .foreign_keys(true);
+        .foreign_keys(true)
+        .busy_timeout(HEALTH_CHECK_BUSY_TIMEOUT);
 
     // One connection (not a pool) so Windows releases the file handle before
     // quarantine rename runs.
-    let mut conn = sqlx::SqliteConnection::connect_with(&options)
-        .await
-        .map_err(|e| format!("open failed: {e}"))?;
+    let mut conn = match sqlx::SqliteConnection::connect_with(&options).await {
+        Ok(conn) => conn,
+        Err(error) => return classify_health_check_error(&error, "open"),
+    };
 
     // quick_check catches most corruption at startup without a full page walk.
     let result: Result<String, sqlx::Error> = sqlx::query_scalar("PRAGMA quick_check")
@@ -578,6 +633,8 @@ async fn verify_database_quick_check(db_path: &Path) -> Result<(), String> {
         .await;
 
     // Checkpoint so a subsequent file copy of the main DB is consistent.
+    // A checkpoint error is not an integrity verdict: the file may still be
+    // healthy, and failing here must not quarantine or block startup.
     let _ = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
         .execute(&mut conn)
         .await;
@@ -590,10 +647,76 @@ async fn verify_database_quick_check(db_path: &Path) -> Result<(), String> {
     }
 
     match result {
-        Ok(text) if text.eq_ignore_ascii_case("ok") => Ok(()),
-        Ok(text) => Err(format!("quick_check: {text}")),
-        Err(e) => Err(format!("quick_check failed: {e}")),
+        Ok(text) if text.eq_ignore_ascii_case("ok") => DatabaseHealth::Healthy,
+        Ok(text) => DatabaseHealth::Corrupt {
+            reason: format!("quick_check: {text}"),
+        },
+        Err(error) => classify_health_check_error(&error, "quick_check"),
     }
+}
+
+/// Kept for tests that only need "usable or not".
+async fn verify_database_quick_check(db_path: &Path) -> Result<(), String> {
+    match assess_database_file(db_path).await {
+        DatabaseHealth::Healthy => Ok(()),
+        DatabaseHealth::Corrupt { reason } | DatabaseHealth::Unassessable { reason } => Err(reason),
+    }
+}
+
+fn classify_health_check_error(error: &sqlx::Error, stage: &str) -> DatabaseHealth {
+    match error {
+        sqlx::Error::Database(database_error) => classify_sqlite_health_failure(
+            database_error.code().as_deref(),
+            &format!("{stage} failed: {database_error}"),
+        ),
+        sqlx::Error::Io(io_error) => DatabaseHealth::Unassessable {
+            reason: format!("{stage} failed: {io_error}"),
+        },
+        sqlx::Error::PoolTimedOut => DatabaseHealth::Unassessable {
+            reason: format!("{stage} failed: timed out"),
+        },
+        other => classify_sqlite_health_failure(None, &format!("{stage} failed: {other}")),
+    }
+}
+
+fn classify_sqlite_health_failure(code: Option<&str>, reason: &str) -> DatabaseHealth {
+    if sqlite_failure_is_corruption(code, reason) {
+        DatabaseHealth::Corrupt {
+            reason: reason.to_string(),
+        }
+    } else {
+        DatabaseHealth::Unassessable {
+            reason: reason.to_string(),
+        }
+    }
+}
+
+fn sqlite_failure_is_corruption(code: Option<&str>, reason: &str) -> bool {
+    if let Some(primary) = sqlite_primary_result_code(code) {
+        // SQLITE_CORRUPT = 11, SQLITE_NOTADB = 26.
+        if primary == 11 || primary == 26 {
+            return true;
+        }
+        // Operational primary codes are never treated as corruption.
+        if matches!(primary, 3 | 5 | 6 | 8 | 10 | 13 | 14 | 15) {
+            return false;
+        }
+    }
+
+    let lower = reason.to_ascii_lowercase();
+    lower.contains("not a database")
+        || lower.contains("file is encrypted or is not a database")
+        || lower.contains("malformed")
+}
+
+fn sqlite_primary_result_code(code: Option<&str>) -> Option<i64> {
+    let code = code?;
+    let parsed = code
+        .strip_prefix("SQLITE_")
+        .unwrap_or(code)
+        .parse::<i64>()
+        .ok()?;
+    Some(parsed & 0xff)
 }
 
 async fn refresh_rolling_backup(db_path: &Path) -> Result<(), String> {
@@ -869,9 +992,10 @@ async fn add_column_if_missing(pool: &SqlitePool, sql: &str) -> Result<(), sqlx:
 #[cfg(test)]
 mod tests {
     use super::{
-        prepare_database_file, quarantine_database_files, replace_backup_atomically,
-        rolling_backup_path, sanitize_storage_diagnostic, should_skip_backup_refresh,
-        verify_database_quick_check, Database,
+        apply_database_health, classify_sqlite_health_failure, prepare_database_file,
+        quarantine_database_files, replace_backup_atomically, rolling_backup_path,
+        sanitize_storage_diagnostic, should_skip_backup_refresh, sqlite_failure_is_corruption,
+        verify_database_quick_check, Database, DatabaseHealth,
     };
     use crate::crypto::CryptoManager;
     use sqlx::sqlite::SqlitePoolOptions;
@@ -1599,6 +1723,82 @@ mod tests {
         assert!(!clean.contains('\n'));
         assert!(!clean.contains('\u{7}'));
         assert!(clean.chars().count() <= 183);
+    }
+
+    #[test]
+    fn busy_locked_and_io_errors_are_not_corruption() {
+        for (code, message) in [
+            (Some("5"), "open failed: database is locked"),
+            (Some("6"), "quick_check failed: database table is locked"),
+            (Some("10"), "open failed: disk I/O error"),
+            (Some("14"), "open failed: unable to open database file"),
+            (Some("261"), "open failed: database is locked"),
+            (None, "open failed: permission denied"),
+        ] {
+            assert!(
+                !sqlite_failure_is_corruption(code, message),
+                "{code:?} {message} must not quarantine"
+            );
+            assert!(matches!(
+                classify_sqlite_health_failure(code, message),
+                DatabaseHealth::Unassessable { .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn integrity_and_notadb_failures_are_corruption() {
+        assert!(matches!(
+            classify_sqlite_health_failure(Some("26"), "open failed: file is not a database"),
+            DatabaseHealth::Corrupt { .. }
+        ));
+        assert!(matches!(
+            classify_sqlite_health_failure(Some("11"), "quick_check failed: malformed"),
+            DatabaseHealth::Corrupt { .. }
+        ));
+        assert!(sqlite_failure_is_corruption(
+            None,
+            "open failed: file is not a database"
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_transient_health_error_leaves_the_database_untouched() {
+        let directory = temp_dir();
+        let database_path = directory.join("cubby.db");
+        let payload = b"keep-this-history-file";
+        std::fs::write(&database_path, payload).unwrap();
+
+        let result = apply_database_health(
+            &database_path,
+            DatabaseHealth::Unassessable {
+                reason: "database is locked".to_string(),
+            },
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "a transient failure must surface a startup error, got {result:?}"
+        );
+        let error = result.unwrap_err();
+        assert!(
+            error.contains("left untouched"),
+            "expected a non-destructive error, got: {error}"
+        );
+        assert!(database_path.exists(), "original path must remain");
+        assert_eq!(std::fs::read(&database_path).unwrap(), payload);
+        let quarantined: Vec<_> = std::fs::read_dir(&directory)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains("corrupt-"))
+            .collect();
+        assert!(
+            quarantined.is_empty(),
+            "transient errors must not quarantine, got {quarantined:?}"
+        );
+        let _ = std::fs::remove_dir_all(directory);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

Three Urgent bugs from the Aug 13 Cubby audit, all in the data path.

- **[SBS-768](https://linear.app/southboundsoftware/issue/SBS-768):**
Editing a rich-text clip deleted HTML/RTF, then updated the unique
hash. If that hash already existed, the update failed and the formats
were already gone. The delete and hash update now run in one
transaction. A duplicate target is rejected with no mutation.

- **[SBS-770](https://linear.app/southboundsoftware/issue/SBS-770):**
Startup treated every open/query failure as corruption and quarantined
the history file. A lock, I/O, or permission error now retries, then
fails startup with a clear message. The original `cubby.db` path and
bytes stay put. Quarantine runs only when `quick_check` reports damage
or SQLite proves the file is not a database.

- **[SBS-767](https://linear.app/southboundsoftware/issue/SBS-767):**
Source and sensitivity were read before the payload, with no sequence
check. A fast second copy could store a secret under the previous
non-sensitive flags. Capture now binds metadata and payload to one
`GetClipboardSequenceNumber` value, re-checks before persist, and
retries or discards if the sequence moved.

Internal Cubby work. No GitHub issues were created for these tickets.

## Verification

- [x] I kept this pull request focused.
- [ ] I tested the change on Windows 11.
- [x] I added or updated tests where practical.
- [x] I did not include clipboard contents, credentials, signing
material, or other secrets.

New unit tests:

- `editing_a_rich_clip_to_an_existing_hash_is_rejected_without_mutation`
- `busy_locked_and_io_errors_are_not_corruption`
- `a_transient_health_error_leaves_the_database_untouched`
- `a_sequence_change_after_metadata_does_not_persist_sensitive_content`
- `a_sequence_change_during_delayed_materialize_does_not_persist_sensitive_content`

`cargo test` for this crate needs Windows. This Linux session could not
run them (no mingw). CI will.

## Test plan

- [ ] Edit a rich-text clip to text that already exists as another clip.
The edit fails. The original text, hash, HTML, and RTF are still there.
- [ ] Edit a rich-text clip to new unique text. The edit applies and the
stale rich formats are gone.
- [ ] If a second Cubby instance hits a locked history file at startup,
the existing `cubby.db` is not renamed to `*.corrupt-*`.
- [ ] A garbage or structurally corrupt `cubby.db` is still quarantined
and startup continues.
- [ ] Copy a note, then immediately copy a password-manager secret. The
secret is not stored under the note's non-sensitive flags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch clipboard privacy binding, transactional clip edits, and startup quarantine logic—areas where incorrect behavior could leak sensitive flags or destroy history, though the PR adds targeted tests and narrows quarantine to proven corruption.
> 
> **Overview**
> Fixes three data-path bugs where captures could mix privacy flags, rich-text edits could half-mutate rows, and startup could quarantine a healthy locked `cubby.db`.
> 
> **Clipboard capture (SBS-767)** — Windows capture now ties sensitivity/source metadata and payload to a single `GetClipboardSequenceNumber`, re-checks the sequence after metadata, around each materialize attempt, and before persisting. Fast back-to-back copies retry up to three bind attempts; if the sequence keeps moving, the capture is discarded instead of storing a secret under the prior copy’s non-sensitive flags. Materialization is split into `materialize_clipboard_content_once` so sleeps happen between guarded attempts.
> 
> **Clip text edits (SBS-768)** — Editing clip text to content that already exists on another row is rejected inside one transaction: hash/preview/content are prepared first, duplicate `content_hash` is checked before deleting HTML/RTF, and a unique constraint failure still returns an error without leaving formats deleted.
> 
> **Database startup (SBS-770)** — Health assessment distinguishes **corrupt** (`quick_check` damage, NOTADB) from **unassessable** (busy, locked, I/O, permissions). Only corrupt files are quarantined and restored from backup; transient failures retry then fail startup with the original file untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f6005922a54af4156c263753c185c2de1343f1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent clipboard captures from mixing metadata and payloads across sequence changes
> - Clipboard captures in [clipboard.rs](https://github.com/tsouth89/cubby-clipboard/pull/197/files#diff-8b53e1d4014cd55d2bf889ca51d824e6f3c4f2e3775e5b8a5d2670c416a3b984) now bind metadata and payload reads to a stable clipboard sequence number; if the sequence changes mid-read, the capture aborts and rebinds to the new sequence, retrying up to 3 times before discarding.
> - Editing a clip to text that duplicates an existing clip is now rejected transactionally in [commands.rs](https://github.com/tsouth89/cubby-clipboard/pull/197/files#diff-59f7096c7cd88d5d187e749ca400716cd225f951e78eac3d0081ec6c28ce5dcc), leaving the original clip and its formats unchanged.
> - Database health checks in [database.rs](https://github.com/tsouth89/cubby-clipboard/pull/197/files#diff-6a8f2d03587850d3f942776b1cf06ca106b6ce46ca2e5eb3bd008d7b728c327f) now distinguish confirmed corruption from transient errors (busy, I/O); only confirmed corruption triggers quarantine, while transient failures surface a startup error and leave the file intact.
> - The rolling backup restore now validates the backup file's health before restoring, avoiding replacing a good DB with a corrupt backup.
> - Risk: transient SQLite errors at startup now fail the app instead of silently quarantining the database file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f60059.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->