### PR TITLE
Say plainly that copied files are not kept, and unblock the Settings links

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Copy a screenshot and Cubby reads the text inside it using the built-in Windows 
 | Built for everyday use | Private by design |
 | --- | --- |
 | Search your history by text, including words inside copied screenshots (offline OCR) | No account, cloud sync, ads, or desktop analytics |
-| Text, HTML, RTF, images, and file lists | AES-256-GCM encryption for stored clipboard payloads |
+| Text, HTML, RTF, and images | AES-256-GCM encryption for stored clipboard payloads |
 | Pinning, folders, filters, and per-app context | Encryption key protected for the current Windows user |
 | Keyboard-first navigation and paste | Ignored-app and sensitive-content controls |
 | Windows 11 flyout, tray, themes, and startup options | Open-source GPL-3.0 code |
@@ -63,6 +63,8 @@ The app checks for signed updates at startup and every 30 minutes while it is ru
 ## Privacy
 
 Clipboard data stays on your PC. Cubby encrypts stored clipboard payloads and image data with AES-256-GCM, with the key protected by Windows for your user account. The desktop app contains no analytics or usage telemetry.
+
+Copying files is not recorded. A copied file is a path, not content, so a saved entry for it would break as soon as the file moves. Cubby ignores file payloads instead of storing paths you copied. Screenshots are unaffected: a tool that copies a real image alongside a file reference is kept as the image.
 
 The app contacts GitHub to check for signed updates and opens links you request. The website uses limited, cookie-free first-party analytics; it does not receive clipboard content. Read the full [privacy policy](https://cubbyclipboard.com/privacy.html).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ Third-party actions in privileged release, Store, and signing workflows must be 
 In addition to AES-256-GCM at rest, Cubby skips:
 
 - Clipboard items tagged with Windows `ExcludeClipboardContentFromMonitorProcessing` (default on).
-- Text that matches high-confidence secret heuristics such as private keys, cloud API tokens, and grouped payment-card numbers (default on; category logged, never content).
+- Text that matches high-confidence secret heuristics such as private keys, cloud API tokens, and grouped payment-card numbers (off by default, enable in Settings; category logged, never content). This one is opt-in because a wrong guess silently drops a clip the user wanted to keep.
 - A one-time seeded ignore list of major password-manager executables, editable in Settings.
 
 ## Clipboard history at rest
@@ -36,4 +36,6 @@ Cubby encrypts clipboard payloads, previews, source attribution, metadata, and i
 
 Existing plaintext history is migrated before the clipboard listener starts. Cubby fails closed if the key cannot be unlocked or migration cannot complete, preventing new history from being mixed into an unreadable or partially encrypted store.
 
-Core Windows clipboard representations are retained together: Unicode text, HTML, RTF, file-drop lists, and images. Auxiliary formats are encrypted in the same authenticated store. Cubby intentionally does not persist arbitrary private application formats because some contain process-specific handles or unsafe opaque data that cannot be replayed reliably.
+Core Windows clipboard representations are retained together: Unicode text, HTML, RTF, and images. Auxiliary formats are encrypted in the same authenticated store. Cubby intentionally does not persist arbitrary private application formats because some contain process-specific handles or unsafe opaque data that cannot be replayed reliably.
+
+Copying files is intentionally not recorded. A file payload is a reference to a path, not durable content, so a history entry for it can silently stop working after a move, a disconnect, or a target-app mismatch. Cubby ignores both physical (`CF_HDROP`) and virtual file payloads before reading any text they advertise, and a migration removes file rows written by earlier versions. The one exception is a screenshot tool that publishes a real bitmap alongside a file reference: Cubby keeps that as an image, never as a path.

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -451,6 +451,16 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
     }
   };
 
+  // A URL missing from the opener allowlist rejects at the Tauri boundary with
+  // no visible effect, so a swallowed console.error looked exactly like a dead
+  // button. Say so instead: the user can still reach the page in a browser.
+  const handleOpenUrl = (url: string) => {
+    openUrl(url).catch((error) => {
+      console.error(`Could not open ${url}:`, error);
+      toast.error(t('settings.linkFailed', { url }));
+    });
+  };
+
   const handleCheckUpdates = async () => {
     setCheckingUpdate(true);
     try {
@@ -1691,7 +1701,7 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
                         )}
                       </div>
                       <button
-                        onClick={() => openUrl(GITHUB_URL).catch(console.error)}
+                        onClick={() => handleOpenUrl(GITHUB_URL)}
                         className="flex w-full items-center gap-3 px-4 py-3 text-sm transition-colors hover:bg-accent/40"
                       >
                         <Github size={16} className="text-muted-foreground" />
@@ -1699,7 +1709,7 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
                         <ExternalLink size={14} className="text-muted-foreground" />
                       </button>
                       <button
-                        onClick={() => openUrl(WEBSITE_URL).catch(console.error)}
+                        onClick={() => handleOpenUrl(WEBSITE_URL)}
                         className="flex w-full items-center gap-3 px-4 py-3 text-sm transition-colors hover:bg-accent/40"
                       >
                         <Globe size={16} className="text-muted-foreground" />
@@ -1707,7 +1717,7 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
                         <ExternalLink size={14} className="text-muted-foreground" />
                       </button>
                       <button
-                        onClick={() => openUrl(PRIVACY_URL).catch(console.error)}
+                        onClick={() => handleOpenUrl(PRIVACY_URL)}
                         className="flex w-full items-center gap-3 px-4 py-3 text-sm transition-colors hover:bg-accent/40"
                       >
                         <ShieldCheck size={16} className="text-muted-foreground" />

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -84,7 +84,8 @@
     "removeDuplicates": "Duplikate entfernen",
     "removeDuplicatesSuccess": "{{count}} doppelte Einträge entfernt",
     "newFolderPlaceholder": "Neuer Ordnername",
-    "noFolders": "Keine benutzerdefinierten Ordner erstellt."
+    "noFolders": "Keine benutzerdefinierten Ordner erstellt.",
+    "linkFailed": "Could not open {{url}} in your browser."
   },
   "notifications": {
     "clipDeleted": "Eintrag gelöscht",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -165,6 +165,7 @@
     "upToDate": "You're on the latest version.",
     "sourceCode": "Source code on GitHub",
     "privacyPolicy": "Privacy policy",
+    "linkFailed": "Could not open {{url}} in your browser.",
     "openSourceTitle": "Free and open source.",
     "openSourceNote": "Cubby is GPL-3.0, a fork of PastePaw. © 2026 SouthForge AI.",
     "folderItemCount": "{{count}} items",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -84,7 +84,8 @@
     "removeDuplicates": "Supprimer les doublons",
     "removeDuplicatesSuccess": "{{count}} éléments en double supprimés",
     "newFolderPlaceholder": "Nom du nouveau dossier",
-    "noFolders": "Aucun dossier personnalisé créé."
+    "noFolders": "Aucun dossier personnalisé créé.",
+    "linkFailed": "Could not open {{url}} in your browser."
   },
   "notifications": {
     "clipDeleted": "Élément supprimé",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -84,7 +84,8 @@
     "removeDuplicates": "重複を削除",
     "removeDuplicatesSuccess": "{{count}} 件の重複クリップを削除しました",
     "newFolderPlaceholder": "新しいフォルダー名",
-    "noFolders": "カスタムフォルダーはまだ作成されていません。"
+    "noFolders": "カスタムフォルダーはまだ作成されていません。",
+    "linkFailed": "Could not open {{url}} in your browser."
   },
   "notifications": {
     "clipDeleted": "クリップを削除しました",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -84,7 +84,8 @@
     "removeDuplicates": "移除重复项",
     "removeDuplicatesSuccess": "已移除 {{count}} 个重复剪贴",
     "newFolderPlaceholder": "新文件夹名称",
-    "noFolders": "尚未创建自定义文件夹。"
+    "noFolders": "尚未创建自定义文件夹。",
+    "linkFailed": "Could not open {{url}} in your browser."
   },
   "notifications": {
     "clipDeleted": "剪贴已删除",

--- a/product_pages/privacy.html
+++ b/product_pages/privacy.html
@@ -47,7 +47,7 @@
       <div class="legal-callout"><p><strong>The short version:</strong> Cubby stores clipboard history locally on your Windows PC. The desktop app does not include analytics, advertising, cloud sync, or network-backed AI features. This website collects limited, privacy-preserving visit counts.</p></div>
 
       <h2>What Cubby stores</h2>
-      <p>To provide clipboard history, Cubby records supported content you copy while it is running. That currently includes plain text, HTML, RTF, images, and file lists, along with useful context such as the source application, content type, timestamps, and whether an item is pinned.</p>
+      <p>To provide clipboard history, Cubby records supported content you copy while it is running. That currently includes plain text, HTML, RTF, and images, along with useful context such as the source application, content type, timestamps, and whether an item is pinned. Copying files is not recorded: a copied file is a path, not content, so Cubby ignores file payloads instead of storing paths you copied.</p>
       <p>History is stored in Cubby’s local application-data directory. Clipboard payloads are kept in a local SQLite database, and image data is kept in local application files.</p>
 
       <h2>What Cubby does not collect</h2>

--- a/product_pages/support.html
+++ b/product_pages/support.html
@@ -90,7 +90,7 @@
       </ul>
 
       <h2>Early-release expectations</h2>
-      <p>Cubby is beta software and is not yet presented as a fully hardened general release. It supports plain text, HTML, RTF, images, and file lists, though clipboard compatibility can still vary between applications and custom formats. Check the latest release notes for current behavior.</p>
+      <p>Cubby is beta software and is not yet presented as a fully hardened general release. It supports plain text, HTML, RTF, and images, though clipboard compatibility can still vary between applications and custom formats; copying files is not recorded. Check the latest release notes for current behavior.</p>
     </article>
   </main>
   <footer class="site-footer"><div class="shell footer-grid"><div><a class="brand footer-brand" href="/"><img class="brand-mark" src="/brand-mark.svg" alt=""><span>cubby clipboard</span></a><p>A better place for what you copy.</p></div><nav aria-label="Footer navigation"><a href="/privacy">Privacy</a><a href="/terms">Terms</a><a href="/support">Support</a><a href="https://github.com/tsouth89/cubby-clipboard">GitHub</a></nav></div><div class="shell footer-bottom"><span>© 2026 SouthForge AI</span><span>Free and open source · GPL-3.0</span></div></footer>

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -24,6 +24,8 @@ const [
   secretsSource,
   modelsSource,
   securityDoc,
+  readmeDoc,
+  settingsPanelSource,
 ] = await Promise.all([
   read('package.json'),
   read('src-tauri/tauri.conf.json'),
@@ -40,6 +42,8 @@ const [
   read('src-tauri/src/secrets.rs'),
   read('src-tauri/src/models.rs'),
   read('SECURITY.md'),
+  read('README.md'),
+  read('frontend/src/components/SettingsPanel.tsx'),
 ]);
 
 const packageVersion = JSON.parse(packageText).version;
@@ -174,6 +178,40 @@ if (`${clipboardSource}\n${commandSource}`.includes('ClipboardContent::Files')) 
   throw new Error(
     'Release product code must not restore external file references as durable history'
   );
+}
+
+// The gates above encode that copied files are never stored. Public docs claimed
+// the opposite for months because nothing tied the two together. If file capture
+// is ever restored, delete these lines deliberately along with the design work.
+for (const [docName, doc] of [['README.md', readmeDoc], ['SECURITY.md', securityDoc]]) {
+  const fileClaim = doc.match(/^.*\bfile[- ](?:lists?|drop lists?)\b.*$/im)?.[0];
+  if (fileClaim) {
+    throw new Error(
+      `${docName} claims file-list clipboard history, which capture policy deliberately ignores: ${fileClaim.trim()}`
+    );
+  }
+}
+
+// A URL the frontend opens but the capability does not allow is rejected at the
+// Tauri boundary, which reads to the user as a button that does nothing.
+const openerScope = capability.permissions.find(
+  (permission) => permission?.identifier === 'opener:allow-open-url'
+);
+// No `$` anchor: these sources are CRLF, so a trailing `\r` would leave the
+// pattern matching nothing and the gate passing on an empty set.
+const allowedUrls = new Set((openerScope?.allow ?? []).map((entry) => entry.url));
+const openedUrls = [...settingsPanelSource.matchAll(/^const \w*URL = '([^']+)';/gm)].map(
+  ([, url]) => url
+);
+if (openedUrls.length === 0) {
+  throw new Error('Could not find the Settings link URL constants to check against the allowlist');
+}
+for (const openedUrl of openedUrls) {
+  if (!allowedUrls.has(openedUrl)) {
+    throw new Error(
+      `Settings opens ${openedUrl}, but src-tauri/capabilities/default.json does not allow it`
+    );
+  }
 }
 
 for (const sensitiveLogFragment of ['Detected self-paste for hash', 'full_path: {:?}', 'path match): {}']) {

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -25,6 +25,8 @@ const [
   modelsSource,
   securityDoc,
   readmeDoc,
+  privacyPageDoc,
+  supportPageDoc,
   settingsPanelSource,
 ] = await Promise.all([
   read('package.json'),
@@ -43,6 +45,8 @@ const [
   read('src-tauri/src/models.rs'),
   read('SECURITY.md'),
   read('README.md'),
+  read('product_pages/privacy.html'),
+  read('product_pages/support.html'),
   read('frontend/src/components/SettingsPanel.tsx'),
 ]);
 
@@ -183,11 +187,36 @@ if (`${clipboardSource}\n${commandSource}`.includes('ClipboardContent::Files')) 
 // The gates above encode that copied files are never stored. Public docs claimed
 // the opposite for months because nothing tied the two together. If file capture
 // is ever restored, delete these lines deliberately along with the design work.
-for (const [docName, doc] of [['README.md', readmeDoc], ['SECURITY.md', securityDoc]]) {
-  const fileClaim = doc.match(/^.*\bfile[- ](?:lists?|drop lists?)\b.*$/im)?.[0];
+//
+// A sentence only counts as a claim if it says files are retained or
+// supported (retained|stores|supports|includes|records) without also
+// negating that (not|never|ignore). This lets docs correctly say "Cubby does
+// not store file lists" while still catching restated lies like "Cubby
+// stores copied files" that don't use the literal phrase "file lists".
+// Checked per sentence rather than per line: a paragraph line can carry both
+// an accurate negated claim and a false unnegated one, and a negation later
+// in the same line must not paper over a false claim earlier in it.
+const fileMentionPattern = /\bfiles?\b/i;
+const retentionClaimPattern = /\b(?:retained|stores?|supports?|includes?|records?(?:ed)?)\b/i;
+const negationPattern = /\b(?:not|never|ignor\w*)\b/i;
+for (const [docName, doc] of [
+  ['README.md', readmeDoc],
+  ['SECURITY.md', securityDoc],
+  ['product_pages/privacy.html', privacyPageDoc],
+  ['product_pages/support.html', supportPageDoc],
+]) {
+  const fileClaim = doc
+    .replace(/\r?\n/g, ' ')
+    .split(/(?<=[.!?])\s+/)
+    .find(
+      (sentence) =>
+        fileMentionPattern.test(sentence) &&
+        retentionClaimPattern.test(sentence) &&
+        !negationPattern.test(sentence)
+    );
   if (fileClaim) {
     throw new Error(
-      `${docName} claims file-list clipboard history, which capture policy deliberately ignores: ${fileClaim.trim()}`
+      `${docName} claims file clipboard history is retained or supported, which capture policy deliberately ignores: ${fileClaim.trim()}`
     );
   }
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -24,6 +24,12 @@
       "allow": [
         {
           "url": "https://github.com/tsouth89/cubby-clipboard"
+        },
+        {
+          "url": "https://cubbyclipboard.com"
+        },
+        {
+          "url": "https://cubbyclipboard.com/privacy"
         }
       ]
     }


### PR DESCRIPTION
Batch 1 of the Cubby board cleanup. Three issues, all cases where a public claim or a visible button did not match the code.

## SBS-811 — secret heuristics are off, not on

`SECURITY.md` said high-confidence secret matching is "default on". `AppSettings::default` sets `skip_likely_secrets: false` on purpose: a wrong guess silently drops a clip the user wanted to keep. Corrected the doc and stated the reason. The default is unchanged, since flipping it is a product decision.

## SBS-780 — file-list history was never real

`README.md` and `SECURITY.md` both advertised file-list clipboard history. Capture ignores file payloads (`clipboard.rs:481-499`), a migration deletes legacy `file`/`files` rows, and `check-release.mjs` already blocked restoring them. So the docs promised a missing feature and implied Cubby records paths you copy, which is the opposite of the privacy story.

Both docs now describe the real behavior, including the screenshot-tool exception where a real bitmap arrives beside a `CF_HDROP` and is kept as an image.

## SBS-810 — two Settings buttons did nothing

The opener allowlist contained only the GitHub URL. `cubbyclipboard.com` and the privacy policy were rejected at the Tauri boundary, and `.catch(console.error)` swallowed it, so both buttons looked dead. Allowlisted both URLs and replaced the swallowed error with a toast.

## Regression gates

`check-release.mjs` gains two checks, per SBS-780's acceptance criteria:

1. The docs may not claim file-list history while the capture gates reject it.
2. Every `const *URL` Settings opens must appear in the opener allowlist.

The second omits a `$` anchor deliberately: these sources are CRLF, and a trailing `\r` left the first version matching nothing and passing on an empty set. It now also fails if it finds no URLs at all.

## Verification

- `node scripts/check-release.mjs` passes
- `pnpm run test` — 93 passed
- `tsc --noEmit` — clean
- Both new gates confirmed to **fail** on the pre-fix content, not just pass on the new content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify that copied files are not recorded and fix Settings link failures
> - Updates [README.md](https://github.com/tsouth89/cubby-clipboard/pull/198/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), [privacy.html](https://github.com/tsouth89/cubby-clipboard/pull/198/files#diff-c9d4b5077587a9c3753be84f19d211791e5993b7643fa2747aa2123ab4cb3726), [support.html](https://github.com/tsouth89/cubby-clipboard/pull/198/files#diff-515eddf8f3ed758f13c2d2c251a5e8d1405fa5b3ff95c53bf597642080e75392), and [SECURITY.md](https://github.com/tsouth89/cubby-clipboard/pull/198/files#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7) to explicitly state that file payloads (CF_HDROP and virtual files) are not recorded; screenshots carrying bitmaps are still retained as images.
> - Adds `https://cubbyclipboard.com` and `https://cubbyclipboard.com/privacy` to the Tauri opener capability allowlist in [default.json](https://github.com/tsouth89/cubby-clipboard/pull/198/files#diff-8fe2bbfebcddedcaa718510825d2a4bd04f59d2826a6848ea55fa086c5bb4213), so Settings links open successfully instead of being silently rejected.
> - Replaces silent `console.error` fallback in [SettingsPanel.tsx](https://github.com/tsouth89/cubby-clipboard/pull/198/files#diff-38408b3809281234112752cfa89d42e1cefb93ae401149b8094a60fa3cde3ea7) with a localized toast error (`settings.linkFailed`) when a Settings URL fails to open.
> - Extends [check-release.mjs](https://github.com/tsouth89/cubby-clipboard/pull/198/files#diff-14ac66f5d0a1f9e003460f1b27bce6e68f7665390d99e23d897038130d21cdca) to fail the release if public docs claim file capture is supported without negation, or if any Settings link URL is missing from the opener allowlist.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8c92c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->