### PR TITLE
Stop a failed paste and a failed reload from lying about history

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { useUpdater } from './hooks/useUpdater';
 import { useRevealedClips } from './hooks/useRevealedClips';
 import { isImeKey, shouldCaptureTypeToSearch } from './utils/flyoutSearch';
 import { folderSelectionAfterReload } from './utils/folderSelection';
+import { clipLoadFailure } from './utils/clipLoadFailure';
 import { useTranslation } from 'react-i18next';
 import { Toaster, toast } from 'sonner';
 import { generateDemoClips } from './debug/demoData';
@@ -428,6 +429,9 @@ function App() {
         console.error('Failed to load clips:', error);
         setLoadError(true);
         setHasMore(false);
+        const failure = clipLoadFailure(append);
+        if (failure.clearList) setClips([]);
+        if (failure.notify) toast.error(t('clipList.loadMoreFailed'));
         return false;
       } finally {
         if (perfId === loadPerfIdRef.current) setIsLoading(false);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -113,6 +113,10 @@ function App() {
   const selectedFolderRef = useRef(selectedFolder);
   selectedFolderRef.current = selectedFolder;
   const loadPerfIdRef = useRef(0);
+  // Which query the rows on screen answer. A failed replace only has to wipe
+  // them when this no longer matches the load that failed — a same-filter
+  // refresh (clipboard change, post-edit reload, retry) leaves a correct page.
+  const visibleFilterKeyRef = useRef<string | null>(null);
   const perfLogEnabled =
     typeof window !== 'undefined' &&
     (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
@@ -313,6 +317,7 @@ function App() {
       filter: ContentFilter = 'all'
     ) => {
       const perfId = ++loadPerfIdRef.current;
+      const filterKey = JSON.stringify([folderId, searchQuery.trim(), filter]);
       const loadStart = perfLogEnabled ? performance.now() : 0;
       let invokeStart = 0;
       let invokeEnd = 0;
@@ -395,6 +400,7 @@ function App() {
         } else {
           setClips(data);
         }
+        visibleFilterKeyRef.current = filterKey;
 
         // If we got fewer than limit, no more clips
         setHasMore(data.length === 20);
@@ -429,9 +435,24 @@ function App() {
         console.error('Failed to load clips:', error);
         setLoadError(true);
         setHasMore(false);
-        const failure = clipLoadFailure(append);
-        if (failure.clearList) setClips([]);
-        if (failure.notify) toast.error(t('clipList.loadMoreFailed'));
+        const failure = clipLoadFailure({
+          append,
+          visibleRowsStillApply: visibleFilterKeyRef.current === filterKey,
+          hasVisibleClips: clips.length > 0,
+        });
+        if (failure.clearList) {
+          setClips([]);
+          // The empty list now stands for this query, so retrying it is a
+          // same-filter refresh rather than another filter change.
+          visibleFilterKeyRef.current = filterKey;
+        }
+        if (failure.notify) {
+          toast.error(t(append ? 'clipList.loadMoreFailed' : 'clipList.refreshFailed'), {
+            // One id, so a backend that keeps failing on every clipboard change
+            // replaces its own message instead of stacking a wall of them.
+            id: 'clip-load-failed',
+          });
+        }
         return false;
       } finally {
         if (perfId === loadPerfIdRef.current) setIsLoading(false);
@@ -987,6 +1008,9 @@ function App() {
 
       setSelectedClipId(null);
       setClipListResetToken((token) => token + 1);
+      // The rows on screen are the clips that were just deleted, so a failed
+      // reload must not keep them up the way a plain refresh failure does.
+      visibleFilterKeyRef.current = null;
       await Promise.all([
         loadClips(selectedFolder, false, searchQuery, contentFilter),
         loadFolders(),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -113,6 +113,8 @@ function App() {
   const selectedFolderRef = useRef(selectedFolder);
   selectedFolderRef.current = selectedFolder;
   const loadPerfIdRef = useRef(0);
+  const clipsRef = useRef(clips);
+  clipsRef.current = clips;
   // Which query the rows on screen answer. A failed replace only has to wipe
   // them when this no longer matches the load that failed — a same-filter
   // refresh (clipboard change, post-edit reload, retry) leaves a correct page.
@@ -326,7 +328,7 @@ function App() {
         setIsLoading(true);
         setLoadError(false);
 
-        const currentOffset = append ? clips.length : 0;
+        const currentOffset = append ? clipsRef.current.length : 0;
         // The index lowercases but does not trim, so a leading space matches
         // nothing. History already sends the trimmed form.
         const query = searchQuery.trim();
@@ -438,7 +440,7 @@ function App() {
         const failure = clipLoadFailure({
           append,
           visibleRowsStillApply: visibleFilterKeyRef.current === filterKey,
-          hasVisibleClips: clips.length > 0,
+          hasVisibleClips: clipsRef.current.length > 0,
         });
         if (failure.clearList) {
           setClips([]);
@@ -458,7 +460,7 @@ function App() {
         if (perfId === loadPerfIdRef.current) setIsLoading(false);
       }
     },
-    [clips.length]
+    []
   );
 
   const loadFolders = useCallback(async () => {
@@ -1008,14 +1010,19 @@ function App() {
 
       setSelectedClipId(null);
       setClipListResetToken((token) => token + 1);
-      // The rows on screen are the clips that were just deleted, so a failed
-      // reload must not keep them up the way a plain refresh failure does.
-      visibleFilterKeyRef.current = null;
-      await Promise.all([
+      // Clear-all deletes every visible row. Clear-unpinned leaves pinned
+      // clips, so a failed reload must keep those rather than wiping them.
+      if (mode === 'all') {
+        visibleFilterKeyRef.current = null;
+      }
+      const [reloaded] = await Promise.all([
         loadClips(selectedFolder, false, searchQuery, contentFilter),
         loadFolders(),
         refreshTotalCount(),
       ]);
+      if (!reloaded) {
+        return;
+      }
       toast.success(
         mode === 'unpinned'
           ? t('notifications.clearUnpinnedSuccess', { count: deleted })

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -12,7 +12,9 @@
   },
   "clipList": {
     "empty": "Noch keine Einträge",
-    "emptyDesc": "Kopieren Sie etwas in Ihre Zwischenablage, dann erscheint es hier."
+    "emptyDesc": "Kopieren Sie etwas in Ihre Zwischenablage, dann erscheint es hier.",
+    "loadMoreFailed": "Couldn’t load more clips",
+    "refreshFailed": "Couldn’t refresh clipboard history"
   },
   "folders": {
     "all": "Alle Einträge",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -25,6 +25,7 @@
     "loadFailed": "Couldn’t load clipboard history",
     "loadFailedDesc": "Cubby kept your data. Try loading it again.",
     "loadMoreFailed": "Couldn’t load more clips",
+    "refreshFailed": "Couldn’t refresh clipboard history",
     "retry": "Try again"
   },
   "pasteContext": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -24,6 +24,7 @@
     "noTextDesc": "Copy some text or switch back to All.",
     "loadFailed": "Couldn’t load clipboard history",
     "loadFailedDesc": "Cubby kept your data. Try loading it again.",
+    "loadMoreFailed": "Couldn’t load more clips",
     "retry": "Try again"
   },
   "pasteContext": {

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -12,7 +12,9 @@
   },
   "clipList": {
     "empty": "Aucun élément pour le moment",
-    "emptyDesc": "Copiez quelque chose dans votre presse-papiers et cela apparaîtra ici."
+    "emptyDesc": "Copiez quelque chose dans votre presse-papiers et cela apparaîtra ici.",
+    "loadMoreFailed": "Couldn’t load more clips",
+    "refreshFailed": "Couldn’t refresh clipboard history"
   },
   "folders": {
     "all": "Tous les éléments",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -12,7 +12,9 @@
   },
   "clipList": {
     "empty": "まだクリップがありません",
-    "emptyDesc": "何かをクリップボードにコピーすると、ここに表示されます。"
+    "emptyDesc": "何かをクリップボードにコピーすると、ここに表示されます。",
+    "loadMoreFailed": "Couldn’t load more clips",
+    "refreshFailed": "Couldn’t refresh clipboard history"
   },
   "folders": {
     "all": "すべてのクリップ",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -12,7 +12,9 @@
   },
   "clipList": {
     "empty": "暂无剪贴",
-    "emptyDesc": "复制内容后将显示在这里"
+    "emptyDesc": "复制内容后将显示在这里",
+    "loadMoreFailed": "Couldn’t load more clips",
+    "refreshFailed": "Couldn’t refresh clipboard history"
   },
   "folders": {
     "all": "全部",

--- a/frontend/src/utils/clipLoadFailure.test.ts
+++ b/frontend/src/utils/clipLoadFailure.test.ts
@@ -2,24 +2,54 @@ import { describe, expect, it } from 'vitest';
 import { clipLoadFailure } from './clipLoadFailure';
 
 describe('clipLoadFailure', () => {
-  it('clears the list when a replace load fails', () => {
+  it('clears the list when a replace load for new filters fails', () => {
     // The rows on screen were fetched for a different search, folder, or type
-    // filter. Leaving them up showed stale results as if they still matched.
-    expect(clipLoadFailure(false)).toEqual({ clearList: true, notify: false });
+    // filter. Leaving them up shows stale results as if they still matched.
+    expect(
+      clipLoadFailure({ append: false, visibleRowsStillApply: false, hasVisibleClips: true })
+    ).toEqual({ clearList: true, notify: false });
+  });
+
+  it('keeps the list when a refresh with unchanged filters fails', () => {
+    // Clipboard-change, window focus, and post-edit reloads all replace the
+    // list with the same query. The rows are still correct, so a failed refresh
+    // must not swap a good first page for the empty error panel.
+    expect(
+      clipLoadFailure({ append: false, visibleRowsStillApply: true, hasVisibleClips: true })
+    ).toEqual({ clearList: false, notify: true });
   });
 
   it('keeps the list when an append load fails', () => {
     // Page one is still correct for the active filters. Only pagination broke.
-    expect(clipLoadFailure(true)).toEqual({ clearList: false, notify: true });
+    expect(
+      clipLoadFailure({ append: true, visibleRowsStillApply: true, hasVisibleClips: true })
+    ).toEqual({ clearList: false, notify: true });
+  });
+
+  it('stays quiet when nothing was on screen to keep', () => {
+    // A first load, or a retry after the list already emptied, leaves the error
+    // panel showing. A message on top of it would say the same thing twice.
+    expect(
+      clipLoadFailure({ append: false, visibleRowsStillApply: true, hasVisibleClips: false })
+    ).toEqual({ clearList: false, notify: false });
   });
 
   it('always tells the user exactly one way', () => {
     for (const append of [true, false]) {
-      const { clearList, notify } = clipLoadFailure(append);
-      // Clearing reveals ClipList's error panel and retry button, so a cleared
-      // list is already a message. Neither would fail silently; both would
-      // discard good rows and talk over the panel at the same time.
-      expect(clearList !== notify).toBe(true);
+      for (const visibleRowsStillApply of [true, false]) {
+        for (const hasVisibleClips of [true, false]) {
+          const { clearList, notify } = clipLoadFailure({
+            append,
+            visibleRowsStillApply,
+            hasVisibleClips,
+          });
+          // ClipList renders its error panel and retry button only on an empty
+          // list, so an empty list is already a message. Neither would fail
+          // silently; both would talk over the panel.
+          const listEmptyAfter = clearList || !hasVisibleClips;
+          expect(listEmptyAfter !== notify).toBe(true);
+        }
+      }
     }
   });
 });

--- a/frontend/src/utils/clipLoadFailure.test.ts
+++ b/frontend/src/utils/clipLoadFailure.test.ts
@@ -11,12 +11,21 @@ describe('clipLoadFailure', () => {
   });
 
   it('keeps the list when a refresh with unchanged filters fails', () => {
-    // Clipboard-change, window focus, and post-edit reloads all replace the
-    // list with the same query. The rows are still correct, so a failed refresh
-    // must not swap a good first page for the empty error panel.
+    // Clipboard-change, window focus, post-edit, and pin reloads all replace
+    // the list with the same query. The rows are still correct, so a failed
+    // refresh must not swap a good first page for the empty error panel.
     expect(
       clipLoadFailure({ append: false, visibleRowsStillApply: true, hasVisibleClips: true })
     ).toEqual({ clearList: false, notify: true });
+  });
+
+  it('does not clear the list when a pin reload fails', () => {
+    // Pinning does not remove rows from the current query. afterBulkChange
+    // leaves visibleRowsStillApply true so a failed replace keeps them.
+    expect(
+      clipLoadFailure({ append: false, visibleRowsStillApply: true, hasVisibleClips: true })
+        .clearList
+    ).toBe(false);
   });
 
   it('keeps the list when an append load fails', () => {

--- a/frontend/src/utils/clipLoadFailure.test.ts
+++ b/frontend/src/utils/clipLoadFailure.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { clipLoadFailure } from './clipLoadFailure';
+
+describe('clipLoadFailure', () => {
+  it('clears the list when a replace load fails', () => {
+    // The rows on screen were fetched for a different search, folder, or type
+    // filter. Leaving them up showed stale results as if they still matched.
+    expect(clipLoadFailure(false)).toEqual({ clearList: true, notify: false });
+  });
+
+  it('keeps the list when an append load fails', () => {
+    // Page one is still correct for the active filters. Only pagination broke.
+    expect(clipLoadFailure(true)).toEqual({ clearList: false, notify: true });
+  });
+
+  it('always tells the user exactly one way', () => {
+    for (const append of [true, false]) {
+      const { clearList, notify } = clipLoadFailure(append);
+      // Clearing reveals ClipList's error panel and retry button, so a cleared
+      // list is already a message. Neither would fail silently; both would
+      // discard good rows and talk over the panel at the same time.
+      expect(clearList !== notify).toBe(true);
+    }
+  });
+});

--- a/frontend/src/utils/clipLoadFailure.ts
+++ b/frontend/src/utils/clipLoadFailure.ts
@@ -1,0 +1,26 @@
+/** What a failed clip load should do to the rows already on screen. */
+export interface ClipLoadFailure {
+  /**
+   * Drop the visible rows. A replace load owns the whole view, so after it
+   * fails the rows on screen no longer describe the active search, folder, or
+   * type filter. Keeping them presented stale results as if they matched, and
+   * the error panel never appeared because it only renders on an empty list.
+   */
+  clearList: boolean;
+  /**
+   * Say the load failed out of band. An append failure keeps a correct first
+   * page, so clearing it would throw away good rows; the user still needs to
+   * know pagination stopped rather than reaching the end of their history.
+   */
+  notify: boolean;
+}
+
+/**
+ * Exactly one of these is always true: either the list clears and the error
+ * panel takes over, or a message fires. A failure that does neither is the
+ * silent-stale-list bug, and one that does both both discards good rows and
+ * talks over its own error panel.
+ */
+export function clipLoadFailure(append: boolean): ClipLoadFailure {
+  return append ? { clearList: false, notify: true } : { clearList: true, notify: false };
+}

--- a/frontend/src/utils/clipLoadFailure.ts
+++ b/frontend/src/utils/clipLoadFailure.ts
@@ -1,26 +1,47 @@
+/** The load whose failure is being classified. */
+export interface ClipLoadAttempt {
+  /** This load adds a page to the rows on screen instead of replacing them. */
+  append: boolean;
+  /**
+   * The rows on screen still answer this load's query. A clipboard-change
+   * refresh, a window-focus refresh, a post-edit reload, and the retry button
+   * all re-run the query the visible rows already answer, so they keep it true.
+   * A filter change makes those rows describe something the user is no longer
+   * looking at, and so does a delete or a clear — which is why those callers
+   * mark the rows stale before reloading.
+   */
+  visibleRowsStillApply: boolean;
+  /** There are rows on screen right now. */
+  hasVisibleClips: boolean;
+}
+
 /** What a failed clip load should do to the rows already on screen. */
 export interface ClipLoadFailure {
   /**
-   * Drop the visible rows. A replace load owns the whole view, so after it
-   * fails the rows on screen no longer describe the active search, folder, or
-   * type filter. Keeping them presented stale results as if they matched, and
-   * the error panel never appeared because it only renders on an empty list.
+   * Drop the visible rows. Only a replace whose rows have stopped applying owns
+   * rows that no longer describe the view; keeping those presents stale results
+   * as if they matched, and the error panel never appears because it renders on
+   * an empty list. A replace that re-runs the query the rows already answer
+   * would instead trade a correct page for an empty error panel.
    */
   clearList: boolean;
   /**
-   * Say the load failed out of band. An append failure keeps a correct first
-   * page, so clearing it would throw away good rows; the user still needs to
-   * know pagination stopped rather than reaching the end of their history.
+   * Say the load failed out of band. The error panel only renders on an empty
+   * list, so any failure that leaves rows on screen is otherwise silent.
    */
   notify: boolean;
 }
 
 /**
- * Exactly one of these is always true: either the list clears and the error
- * panel takes over, or a message fires. A failure that does neither is the
- * silent-stale-list bug, and one that does both both discards good rows and
- * talks over its own error panel.
+ * The user always learns exactly once: either the list ends up empty and the
+ * error panel takes over, or a message fires. Doing neither is the
+ * silent-stale-list bug, and doing both talks over the panel.
  */
-export function clipLoadFailure(append: boolean): ClipLoadFailure {
-  return append ? { clearList: false, notify: true } : { clearList: true, notify: false };
+export function clipLoadFailure({
+  append,
+  visibleRowsStillApply,
+  hasVisibleClips,
+}: ClipLoadAttempt): ClipLoadFailure {
+  const clearList = !append && !visibleRowsStillApply;
+  return { clearList, notify: !clearList && hasVisibleClips };
 }

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -3,6 +3,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { CheckSquare, Copy, History, Pin, PinOff, Search, Trash2, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Toaster, toast } from 'sonner';
 import { ClipboardItem, FolderItem, Settings } from '../types';
 import { ClipList } from '../components/ClipList';
@@ -51,6 +52,7 @@ const CONTENT_FILTERS: ReadonlyArray<readonly [ContentFilter, string]> = [
  * honor, so its primary action is copy rather than paste.
  */
 export function HistoryWindow() {
+  const { t } = useTranslation();
   const [clips, setClips] = useState<ClipboardItem[]>([]);
   const [folders, setFolders] = useState<FolderItem[]>([]);
   const [selectedFolder, setSelectedFolder] = useState<string | null>(null);
@@ -92,6 +94,11 @@ export function HistoryWindow() {
   // Guards against an older load landing after a newer one and restoring stale
   // results — the same discipline the flyout uses.
   const loadIdRef = useRef(0);
+  // Which query the rows on screen answer. A failed replace only has to wipe
+  // them when this no longer matches the load that failed — a same-filter
+  // refresh (clipboard change, window focus, post-edit reload) leaves a
+  // correct page.
+  const visibleFilterKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     invoke<Settings>('get_settings').then(setSettings).catch(console.error);
@@ -110,6 +117,14 @@ export function HistoryWindow() {
       const loadId = ++loadIdRef.current;
       const offset = append ? clipsRef.current.length : 0;
       const query = searchQuery.trim();
+      const filterKey = JSON.stringify([
+        selectedFolder,
+        query,
+        contentFilter,
+        dateFrom,
+        dateTo,
+        sourceApp,
+      ]);
 
       try {
         setIsLoading(true);
@@ -142,6 +157,7 @@ export function HistoryWindow() {
 
         if (loadId !== loadIdRef.current) return true;
         setClips((previous) => (append ? [...previous, ...data] : data));
+        visibleFilterKeyRef.current = filterKey;
         setHasMore(data.length === PAGE_SIZE);
         return true;
       } catch (error) {
@@ -151,9 +167,24 @@ export function HistoryWindow() {
         console.error('Failed to load clips:', error);
         setLoadError(true);
         setHasMore(false);
-        const failure = clipLoadFailure(append);
-        if (failure.clearList) setClips([]);
-        if (failure.notify) toast.error('Could not load more clips');
+        const failure = clipLoadFailure({
+          append,
+          visibleRowsStillApply: visibleFilterKeyRef.current === filterKey,
+          hasVisibleClips: clipsRef.current.length > 0,
+        });
+        if (failure.clearList) {
+          setClips([]);
+          // The empty list now stands for this query, so retrying it is a
+          // same-filter refresh rather than another filter change.
+          visibleFilterKeyRef.current = filterKey;
+        }
+        if (failure.notify) {
+          toast.error(t(append ? 'clipList.loadMoreFailed' : 'clipList.refreshFailed'), {
+            // One id, so a backend that keeps failing on every clipboard change
+            // replaces its own message instead of stacking a wall of them.
+            id: 'clip-load-failed',
+          });
+        }
         return false;
       } finally {
         if (loadId === loadIdRef.current) setIsLoading(false);
@@ -286,9 +317,23 @@ export function HistoryWindow() {
 
   const clearSelection = useCallback(() => setSelection(EMPTY_SELECTION), []);
 
+  /**
+   * Returns whether the list actually reloaded. loadClips reports failure
+   * rather than throwing, so callers must check this before announcing success:
+   * the rows on screen still describe the state before the bulk change.
+   */
   const afterBulkChange = useCallback(async () => {
     clearSelection();
-    await Promise.all([loadClips(false), loadFolders(), refreshTotalCount(), loadSourceApps()]);
+    // The bulk change already invalidated the rows on screen, so a failed
+    // reload must not keep them up the way a plain refresh failure does.
+    visibleFilterKeyRef.current = null;
+    const [reloaded] = await Promise.all([
+      loadClips(false),
+      loadFolders(),
+      refreshTotalCount(),
+      loadSourceApps(),
+    ]);
+    return reloaded;
   }, [clearSelection, loadClips, loadFolders, refreshTotalCount, loadSourceApps]);
 
   const handleBulkDelete = useCallback(async () => {
@@ -300,7 +345,10 @@ export function HistoryWindow() {
         ids: selectedIds,
         hardDelete: true,
       });
-      await afterBulkChange();
+      if (!(await afterBulkChange())) {
+        toast.error('Deleted, but the list could not be reloaded');
+        return;
+      }
       toast.success(deleted === 1 ? 'Deleted 1 clip' : `Deleted ${deleted} clips`);
     } catch (error) {
       console.error('Failed to delete clips:', error);
@@ -313,7 +361,10 @@ export function HistoryWindow() {
       if (selectionCount === 0) return;
       try {
         await invoke<number>('set_clips_pinned', { ids: selectedIds, pinned });
-        await afterBulkChange();
+        if (!(await afterBulkChange())) {
+          toast.error('Pin state changed, but the list could not be reloaded');
+          return;
+        }
         toast.success(
           pinned ? `Pinned ${selectionCount} clips` : `Unpinned ${selectionCount} clips`
         );
@@ -330,7 +381,10 @@ export function HistoryWindow() {
       if (selectionCount === 0) return;
       try {
         await invoke<number>('move_clips_to_folder', { ids: selectedIds, folderId });
-        await afterBulkChange();
+        if (!(await afterBulkChange())) {
+          toast.error('Moved, but the list could not be reloaded');
+          return;
+        }
         toast.success(
           folderId
             ? `Moved ${selectionCount} clips to ${folders.find((f) => f.id === folderId)?.name ?? 'folder'}`
@@ -456,8 +510,13 @@ export function HistoryWindow() {
         // reveal in sync so leaving this clip and coming back does not revert.
         updateRevealed(clipId, { content: text, preview: text });
         // The row still holds the pre-edit preview, and the edit may have
-        // changed which clips a filter or search matches.
-        await loadClips(false);
+        // changed which clips a filter or search matches. loadClips reports
+        // failure rather than throwing, so the toast has to read its result —
+        // otherwise the list keeps showing the old text under a success message.
+        if (!(await loadClips(false))) {
+          toast.error('Clip updated, but the list could not be reloaded');
+          return;
+        }
         toast.success('Clip updated');
       } catch (error) {
         console.error('Failed to update the clip:', error);

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -322,19 +322,24 @@ export function HistoryWindow() {
    * rather than throwing, so callers must check this before announcing success:
    * the rows on screen still describe the state before the bulk change.
    */
-  const afterBulkChange = useCallback(async () => {
-    clearSelection();
-    // The bulk change already invalidated the rows on screen, so a failed
-    // reload must not keep them up the way a plain refresh failure does.
-    visibleFilterKeyRef.current = null;
-    const [reloaded] = await Promise.all([
-      loadClips(false),
-      loadFolders(),
-      refreshTotalCount(),
-      loadSourceApps(),
-    ]);
-    return reloaded;
-  }, [clearSelection, loadClips, loadFolders, refreshTotalCount, loadSourceApps]);
+  const afterBulkChange = useCallback(
+    async (rowsStillApply = false) => {
+      clearSelection();
+      // Delete and move take rows out of this query. Pin does not, so a failed
+      // reload must keep the still-matching list instead of wiping it.
+      if (!rowsStillApply) {
+        visibleFilterKeyRef.current = null;
+      }
+      const [reloaded] = await Promise.all([
+        loadClips(false),
+        loadFolders(),
+        refreshTotalCount(),
+        loadSourceApps(),
+      ]);
+      return reloaded;
+    },
+    [clearSelection, loadClips, loadFolders, refreshTotalCount, loadSourceApps]
+  );
 
   const handleBulkDelete = useCallback(async () => {
     if (selectionCount === 0) return;
@@ -361,7 +366,7 @@ export function HistoryWindow() {
       if (selectionCount === 0) return;
       try {
         await invoke<number>('set_clips_pinned', { ids: selectedIds, pinned });
-        if (!(await afterBulkChange())) {
+        if (!(await afterBulkChange(true))) {
           toast.error('Pin state changed, but the list could not be reloaded');
           return;
         }
@@ -509,12 +514,9 @@ export function HistoryWindow() {
         // Hidden rows still ship empty content after reload; keep the session
         // reveal in sync so leaving this clip and coming back does not revert.
         updateRevealed(clipId, { content: text, preview: text });
-        // The row still holds the pre-edit preview, and the edit may have
-        // changed which clips a filter or search matches. loadClips reports
-        // failure rather than throwing, so the toast has to read its result —
-        // otherwise the list keeps showing the old text under a success message.
+        // Same-filter reload: loadClips already toasts refreshFailed on
+        // failure. A second toast here would talk over it.
         if (!(await loadClips(false))) {
-          toast.error('Clip updated, but the list could not be reloaded');
           return;
         }
         toast.success('Clip updated');

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -14,6 +14,7 @@ import { useSystemAccent } from '../hooks/useSystemAccent';
 import { useRevealedClips } from '../hooks/useRevealedClips';
 import { customRange, DATE_PRESET_LABELS, DatePreset, presetRange } from '../utils/dateRange';
 import { folderSelectionAfterReload } from '../utils/folderSelection';
+import { clipLoadFailure } from '../utils/clipLoadFailure';
 import {
   applySelectionClick,
   EMPTY_SELECTION,
@@ -150,6 +151,9 @@ export function HistoryWindow() {
         console.error('Failed to load clips:', error);
         setLoadError(true);
         setHasMore(false);
+        const failure = clipLoadFailure(append);
+        if (failure.clearList) setClips([]);
+        if (failure.notify) toast.error('Could not load more clips');
         return false;
       } finally {
         if (loadId === loadIdRef.current) setIsLoading(false);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1064,6 +1064,22 @@ fn restore_hash_material(
     )
 }
 
+/// Record that the user actually used this clip, bumping it to the top of
+/// history and restarting its retention clock.
+///
+/// `created_at` doubles as "last used" for both ordering and retention, so this
+/// only applies when the clipboard write landed. An unconditional bump reordered
+/// history and extended the life of a clip after a paste that never happened.
+async fn mark_clip_used(pool: &sqlx::SqlitePool, uuid: &str, write_succeeded: bool) {
+    if !write_succeeded {
+        return;
+    }
+    let _ = sqlx::query(r#"UPDATE clips SET created_at = CURRENT_TIMESTAMP WHERE uuid = ?"#)
+        .bind(uuid)
+        .execute(pool)
+        .await;
+}
+
 async fn restore_clip(
     id: &str,
     plain_text: bool,
@@ -1144,12 +1160,7 @@ async fn restore_clip(
                 crate::clipboard::clear_ignore_hash_if_matches(&content_hash);
             }
 
-            // Manually perform the LRU bump (update created_at)
-            let _ =
-                sqlx::query(r#"UPDATE clips SET created_at = CURRENT_TIMESTAMP WHERE uuid = ?"#)
-                    .bind(&uuid)
-                    .execute(pool)
-                    .await;
+            mark_clip_used(pool, &uuid, final_res.is_ok()).await;
 
             if final_res.is_ok() {
                 let remote_paste_mode = window
@@ -2891,7 +2902,7 @@ mod tests {
         build_ocr_highlights, build_ocr_match, clear_clips_in_pool, clipboard_contents_for_restore,
         delete_folder_in_pool, directory_size_bytes, enforce_retention_in_pool,
         get_clip_details_in_database, get_clips_in_database, get_clips_request_log,
-        load_recognized_text, migrate_clip_format_model, migrate_encrypted_storage,
+        load_recognized_text, mark_clip_used, migrate_clip_format_model, migrate_encrypted_storage,
         ocr_text_layout, remove_clip_image_files, remove_duplicate_clips_in_database,
         restore_hash_material, search_clips_in_database, set_clip_notes_in_database,
         set_clip_ocr_text_in_database, source_app_filter_log_state, toggle_clip_hidden_in_pool,
@@ -2989,6 +3000,53 @@ mod tests {
         .execute(&database.pool)
         .await
         .unwrap();
+    }
+
+    async fn created_at_of(database: &Database, uuid: &str) -> String {
+        sqlx::query_scalar("SELECT created_at FROM clips WHERE uuid = ?")
+            .bind(uuid)
+            .fetch_one(&database.pool)
+            .await
+            .expect("clip should exist")
+    }
+
+    /// A failed clipboard write must leave history ordering alone. Bumping
+    /// `created_at` anyway moved the clip to the top and restarted its
+    /// retention clock for a paste the user never received.
+    #[tokio::test]
+    async fn failed_restore_does_not_bump_the_clip() {
+        let database = test_database().await;
+        insert_search_clip(
+            &database,
+            SearchFixture::text("stale", "never pasted", "2026-03-01 12:00:00"),
+        )
+        .await;
+
+        mark_clip_used(&database.pool, "stale", false).await;
+
+        assert_eq!(
+            created_at_of(&database, "stale").await,
+            "2026-03-01 12:00:00",
+            "a failed clipboard write must not reorder history"
+        );
+    }
+
+    #[tokio::test]
+    async fn successful_restore_bumps_the_clip() {
+        let database = test_database().await;
+        insert_search_clip(
+            &database,
+            SearchFixture::text("used", "actually pasted", "2026-03-01 12:00:00"),
+        )
+        .await;
+
+        mark_clip_used(&database.pool, "used", true).await;
+
+        assert_ne!(
+            created_at_of(&database, "used").await,
+            "2026-03-01 12:00:00",
+            "a successful paste must count as recent use"
+        );
     }
 
     /// Three clips over three days from two apps, newest last.


### PR DESCRIPTION
Batch 2 of the Cubby board cleanup. Two bugs where the UI reported work that did not happen.

## SBS-803 — a failed paste still moved the clip to the top

`restore_clip` bumped `created_at` after the clipboard write regardless of whether that write succeeded. `created_at` doubles as "last used" for both history ordering and retention, so a failed paste moved the clip to the top of the list and restarted its retention clock for content the user never received. The ignore-hash cleanup right above it was already gated on the outcome; this was not.

The bump now lives in `mark_clip_used(pool, uuid, write_succeeded)`. Pulling it out of the inline SQL makes the success condition visible at the call site and testable without standing up a webview window, which `restore_clip` requires.

## SBS-805 — a failed reload kept showing the old rows

`loadClips` set `loadError` but left the previous rows on screen, and `ClipList` only renders its error panel when `clips.length === 0`. So changing search, folder, or Images/Text with a query that failed kept showing rows fetched for the *previous* filter, with nothing to say the refresh had failed.

A replace load now clears the list, which reveals the error panel and retry button that already existed.

An append load deliberately does not. Its first page is still correct for the active filters, so throwing it away to report a pagination failure would lose good rows. It toasts instead.

That choice is `clipLoadFailure`, shared by the flyout and the History window so the two cannot drift apart. Its test pins the invariant: exactly one of `clearList` or `notify` happens. Neither is the silent-stale-list bug this issue is about; both would discard good rows *and* talk over the error panel.

## Verification

| Check | Result |
| --- | --- |
| `cargo test --locked` | 205 passed |
| `cargo clippy --locked --all-targets` | clean |
| `cargo fmt --check` | clean |
| `pnpm run test` | 96 passed |
| `tsc --noEmit` | clean |
| `prettier --check` | clean |
| `node scripts/check-release.mjs` | pass |

New tests: `failed_restore_does_not_bump_the_clip`, `successful_restore_bumps_the_clip`, and three cases in `clipLoadFailure.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix failed paste and failed reload from falsely reporting success in history
> - Failed clip loads no longer clear the visible list indiscriminately; the list is only cleared when a replace load fails and the filter query has changed. Otherwise, the prior rows are preserved and an error toast is shown.
> - A new pure utility [`clipLoadFailure`](https://github.com/tsouth89/cubby-clipboard/pull/199/files#diff-0619741413b8f086db04456eec5c76674c74d135a61314cc5d4578f093c0d0c3) encapsulates the decision logic (clear vs. notify) based on whether the load was an append/replace, whether visible rows still match the current filter, and whether any clips are visible.
> - Bulk actions (`delete`, `pin`, `move`, `save text`) in [`HistoryWindow`](https://github.com/tsouth89/cubby-clipboard/pull/199/files#diff-66e4a504891e766358388fbcc59de24cd17efafbabffdf4380b98891366560f2) and [`App`](https://github.com/tsouth89/cubby-clipboard/pull/199/files#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1eb) now check the boolean return of `loadClips` and suppress success toasts — replacing them with failure toasts — when the reload fails.
> - In [`commands.rs`](https://github.com/tsouth89/cubby-clipboard/pull/199/files#diff-59f7096c7cd88d5d187e749ca400716cd225f951e78eac3d0081ec6c28ce5dcc), failed clipboard writes no longer bump a clip's `created_at`, preventing failed pastes from reordering history or extending retention.
> - Behavioral Change: clear-all and bulk operations previously always showed a success toast; they now only do so when the subsequent reload succeeds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d600a81.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->