### PR TITLE
SBS-831: Restore the forget-on-clear retry marker when the clip lookup fails

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -2362,7 +2362,7 @@ async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u3
     // dropped the retry marker on a transient lock, so a later clear could
     // not forget the password that was still in history (SBS-831).
     let lookup = ForgetClipLookup::from_query(
-        sqlx::query_as(
+        sqlx::query_as::<_, (i64, i64)>(
             r#"
             SELECT is_pinned, is_deleted
             FROM clips

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -2372,24 +2372,27 @@ async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u3
         .bind(&recent.uuid)
         .fetch_optional(pool)
         .await,
+        recent,
     );
 
-    let (is_pinned, is_deleted) = match lookup {
-        ForgetClipLookup::Found((is_pinned, is_deleted)) => (is_pinned, is_deleted),
+    let (is_pinned, is_deleted, recent) = match lookup {
+        ForgetClipLookup::Found {
+            row: (is_pinned, is_deleted),
+            taken,
+        } => (is_pinned, is_deleted, taken),
         ForgetClipLookup::AlreadyGone => {
             log::debug!(
-                "CLIPBOARD: Clear sequence {} — recent capture {} already gone",
-                sequence,
-                recent.uuid
+                "CLIPBOARD: Clear sequence {} — recent capture already gone",
+                sequence
             );
             return;
         }
-        ForgetClipLookup::Failed(error) => {
-            record_capture_error(format!(
-                "forget-on-clear skipped for sequence {sequence} (clip {}); lookup failed, so the retry marker was restored: {error}",
-                recent.uuid
-            ));
-            restore_marker(recent);
+        ForgetClipLookup::Failed { error, taken } => {
+            log::error!(
+                "CLIPBOARD: forget-on-clear skipped for sequence {sequence} (clip {}); lookup failed, so the retry marker was restored: {error}",
+                taken.uuid
+            );
+            restore_marker(taken);
             return;
         }
     };

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -99,6 +99,9 @@ struct RecentCapture {
     credential_like: bool,
 }
 
+mod forget_on_clear;
+use forget_on_clear::ForgetClipLookup;
+
 /// Pure helper for SOU-316 unit tests: only empty clears within the window
 /// forget the last clip. A later clear must leave history alone.
 fn should_forget_recent_capture(
@@ -2355,25 +2358,40 @@ async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u3
     let _guard = CLIPBOARD_SYNC.lock().await;
     let pool = &db.pool;
 
-    let row: Option<(i64, i64)> = sqlx::query_as(
-        r#"
-        SELECT is_pinned, is_deleted
-        FROM clips
-        WHERE uuid = ?
-        "#,
-    )
-    .bind(&recent.uuid)
-    .fetch_optional(pool)
-    .await
-    .unwrap_or(None);
+    // A failed SELECT must not be read as "already gone". unwrap_or(None)
+    // dropped the retry marker on a transient lock, so a later clear could
+    // not forget the password that was still in history (SBS-831).
+    let lookup = ForgetClipLookup::from_query(
+        sqlx::query_as(
+            r#"
+            SELECT is_pinned, is_deleted
+            FROM clips
+            WHERE uuid = ?
+            "#,
+        )
+        .bind(&recent.uuid)
+        .fetch_optional(pool)
+        .await,
+    );
 
-    let Some((is_pinned, is_deleted)) = row else {
-        log::debug!(
-            "CLIPBOARD: Clear sequence {} — recent capture {} already gone",
-            sequence,
-            recent.uuid
-        );
-        return;
+    let (is_pinned, is_deleted) = match lookup {
+        ForgetClipLookup::Found((is_pinned, is_deleted)) => (is_pinned, is_deleted),
+        ForgetClipLookup::AlreadyGone => {
+            log::debug!(
+                "CLIPBOARD: Clear sequence {} — recent capture {} already gone",
+                sequence,
+                recent.uuid
+            );
+            return;
+        }
+        ForgetClipLookup::Failed(error) => {
+            record_capture_error(format!(
+                "forget-on-clear skipped for sequence {sequence} (clip {}); lookup failed, so the retry marker was restored: {error}",
+                recent.uuid
+            ));
+            restore_marker(recent);
+            return;
+        }
     };
 
     if is_pinned != 0 {

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -2361,6 +2361,7 @@ async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u3
     // A failed SELECT must not be read as "already gone". unwrap_or(None)
     // dropped the retry marker on a transient lock, so a later clear could
     // not forget the password that was still in history (SBS-831).
+    let uuid = recent.uuid.clone();
     let lookup = ForgetClipLookup::from_query(
         sqlx::query_as::<_, (i64, i64)>(
             r#"
@@ -2369,7 +2370,7 @@ async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u3
             WHERE uuid = ?
             "#,
         )
-        .bind(&recent.uuid)
+        .bind(&uuid)
         .fetch_optional(pool)
         .await,
         recent,
@@ -2382,8 +2383,9 @@ async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u3
         } => (is_pinned, is_deleted, taken),
         ForgetClipLookup::AlreadyGone => {
             log::debug!(
-                "CLIPBOARD: Clear sequence {} — recent capture already gone",
-                sequence
+                "CLIPBOARD: Clear sequence {} — recent capture {} already gone",
+                sequence,
+                uuid
             );
             return;
         }

--- a/src-tauri/src/clipboard/forget_on_clear.rs
+++ b/src-tauri/src/clipboard/forget_on_clear.rs
@@ -25,6 +25,12 @@ impl<T, E> ForgetClipLookup<T, E> {
 
     /// Transient query failures must put the in-memory marker back. A genuine
     /// missing row must not, or every later clear would keep hunting a gone clip.
+    ///
+    /// Only the unit tests below call this directly; `clipboard.rs` matches on
+    /// the enum variant itself and restores the marker inline in the `Failed`
+    /// arm. Kept `pub(crate)` as the documented, tested source of truth for
+    /// that policy rather than deleting it.
+    #[allow(dead_code)]
     pub(crate) fn restore_retry_marker(&self) -> bool {
         matches!(self, Self::Failed(_))
     }

--- a/src-tauri/src/clipboard/forget_on_clear.rs
+++ b/src-tauri/src/clipboard/forget_on_clear.rs
@@ -1,38 +1,29 @@
 //! Forget-on-clear lookup classification (SBS-831).
 //!
 //! Isolated so the `Err` vs `Ok(None)` decision can be tested without the
-//! Windows crate. A missing row is gone; a query error is transient.
+//! Windows crate. A missing row is gone; a query error is transient. The taken
+//! retry marker travels with the variant so `unwrap_or(None)` cannot drop it
+//! without the tests noticing.
 
 /// Result of looking up the clip we just took the forget-on-clear marker for.
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) enum ForgetClipLookup<T, E> {
-    /// Row exists. Continue pin / already-deleted / DELETE logic.
-    Found(T),
-    /// No row. The clip is actually gone; leave the retry marker dropped.
+pub(crate) enum ForgetClipLookup<T, M, E> {
+    /// Row exists. Continue pin / already-deleted / DELETE logic, still holding
+    /// the taken marker for later restore if the delete itself fails.
+    Found { row: T, taken: M },
+    /// No row. The clip is actually gone; the retry marker stays dropped.
     AlreadyGone,
-    /// SELECT failed. Restore the marker so a later clear can retry.
-    Failed(E),
+    /// SELECT failed. Restore `taken` so a later clear can retry.
+    Failed { error: E, taken: M },
 }
 
-impl<T, E> ForgetClipLookup<T, E> {
-    pub(crate) fn from_query(result: Result<Option<T>, E>) -> Self {
+impl<T, M, E> ForgetClipLookup<T, M, E> {
+    pub(crate) fn from_query(result: Result<Option<T>, E>, taken: M) -> Self {
         match result {
-            Ok(Some(row)) => Self::Found(row),
+            Ok(Some(row)) => Self::Found { row, taken },
             Ok(None) => Self::AlreadyGone,
-            Err(error) => Self::Failed(error),
+            Err(error) => Self::Failed { error, taken },
         }
-    }
-
-    /// Transient query failures must put the in-memory marker back. A genuine
-    /// missing row must not, or every later clear would keep hunting a gone clip.
-    ///
-    /// Only the unit tests below call this directly; `clipboard.rs` matches on
-    /// the enum variant itself and restores the marker inline in the `Failed`
-    /// arm. Kept `pub(crate)` as the documented, tested source of truth for
-    /// that policy rather than deleting it.
-    #[allow(dead_code)]
-    pub(crate) fn restore_retry_marker(&self) -> bool {
-        matches!(self, Self::Failed(_))
     }
 }
 
@@ -41,42 +32,32 @@ mod tests {
     use super::ForgetClipLookup;
 
     #[test]
-    fn a_lookup_error_restores_the_retry_marker() {
-        let taken = Some("clip-uuid");
+    fn a_lookup_error_keeps_the_taken_marker() {
         let result: Result<Option<(i64, i64)>, &str> = Err("database is locked");
-        let lookup = ForgetClipLookup::from_query(result);
-        assert!(
-            matches!(lookup, ForgetClipLookup::Failed("database is locked")),
-            "a query error must not collapse to already-gone"
-        );
-        assert!(lookup.restore_retry_marker());
-        assert_eq!(
-            lookup.restore_retry_marker().then_some(taken).flatten(),
-            Some("clip-uuid")
-        );
+        match ForgetClipLookup::from_query(result, "clip-uuid") {
+            ForgetClipLookup::Failed {
+                error: "database is locked",
+                taken,
+            } => assert_eq!(taken, "clip-uuid"),
+            other => panic!("query error must keep the marker, got {other:?}"),
+        }
     }
 
     #[test]
-    fn a_missing_row_does_not_restore_the_retry_marker() {
-        let taken = Some("clip-uuid");
+    fn a_missing_row_drops_the_taken_marker() {
         let result: Result<Option<(i64, i64)>, &str> = Ok(None);
-        let lookup = ForgetClipLookup::from_query(result);
-        assert!(matches!(lookup, ForgetClipLookup::AlreadyGone));
-        assert!(!lookup.restore_retry_marker());
-        assert_eq!(
-            lookup.restore_retry_marker().then_some(taken).flatten(),
-            None
-        );
+        match ForgetClipLookup::from_query(result, "clip-uuid") {
+            ForgetClipLookup::AlreadyGone => {}
+            other => panic!("missing row must drop the marker, got {other:?}"),
+        }
     }
 
     #[test]
-    fn a_found_row_continues_without_restoring_yet() {
+    fn a_found_row_keeps_the_taken_marker_for_later_restore() {
         let result: Result<Option<(i64, i64)>, &str> = Ok(Some((0, 0)));
-        let lookup = ForgetClipLookup::from_query(result);
-        assert!(matches!(lookup, ForgetClipLookup::Found((0, 0))));
-        assert!(
-            !lookup.restore_retry_marker(),
-            "pin/deleted/delete logic owns the taken marker after a successful lookup"
-        );
+        match ForgetClipLookup::from_query(result, "clip-uuid") {
+            ForgetClipLookup::Found { row: (0, 0), taken } => assert_eq!(taken, "clip-uuid"),
+            other => panic!("found row must keep the marker for the delete path, got {other:?}"),
+        }
     }
 }

--- a/src-tauri/src/clipboard/forget_on_clear.rs
+++ b/src-tauri/src/clipboard/forget_on_clear.rs
@@ -1,0 +1,76 @@
+//! Forget-on-clear lookup classification (SBS-831).
+//!
+//! Isolated so the `Err` vs `Ok(None)` decision can be tested without the
+//! Windows crate. A missing row is gone; a query error is transient.
+
+/// Result of looking up the clip we just took the forget-on-clear marker for.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ForgetClipLookup<T, E> {
+    /// Row exists. Continue pin / already-deleted / DELETE logic.
+    Found(T),
+    /// No row. The clip is actually gone; leave the retry marker dropped.
+    AlreadyGone,
+    /// SELECT failed. Restore the marker so a later clear can retry.
+    Failed(E),
+}
+
+impl<T, E> ForgetClipLookup<T, E> {
+    pub(crate) fn from_query(result: Result<Option<T>, E>) -> Self {
+        match result {
+            Ok(Some(row)) => Self::Found(row),
+            Ok(None) => Self::AlreadyGone,
+            Err(error) => Self::Failed(error),
+        }
+    }
+
+    /// Transient query failures must put the in-memory marker back. A genuine
+    /// missing row must not, or every later clear would keep hunting a gone clip.
+    pub(crate) fn restore_retry_marker(&self) -> bool {
+        matches!(self, Self::Failed(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ForgetClipLookup;
+
+    #[test]
+    fn a_lookup_error_restores_the_retry_marker() {
+        let taken = Some("clip-uuid");
+        let result: Result<Option<(i64, i64)>, &str> = Err("database is locked");
+        let lookup = ForgetClipLookup::from_query(result);
+        assert!(
+            matches!(lookup, ForgetClipLookup::Failed("database is locked")),
+            "a query error must not collapse to already-gone"
+        );
+        assert!(lookup.restore_retry_marker());
+        assert_eq!(
+            lookup.restore_retry_marker().then_some(taken).flatten(),
+            Some("clip-uuid")
+        );
+    }
+
+    #[test]
+    fn a_missing_row_does_not_restore_the_retry_marker() {
+        let taken = Some("clip-uuid");
+        let result: Result<Option<(i64, i64)>, &str> = Ok(None);
+        let lookup = ForgetClipLookup::from_query(result);
+        assert!(matches!(lookup, ForgetClipLookup::AlreadyGone));
+        assert!(!lookup.restore_retry_marker());
+        assert_eq!(
+            lookup.restore_retry_marker().then_some(taken).flatten(),
+            None
+        );
+    }
+
+    #[test]
+    fn a_found_row_continues_without_restoring_yet() {
+        let result: Result<Option<(i64, i64)>, &str> = Ok(Some((0, 0)));
+        let lookup = ForgetClipLookup::from_query(result);
+        assert!(matches!(lookup, ForgetClipLookup::Found((0, 0))));
+        assert!(
+            !lookup.restore_retry_marker(),
+            "pin/deleted/delete logic owns the taken marker after a successful lookup"
+        );
+    }
+}


### PR DESCRIPTION
## SBS-831 — a failed clip lookup dropped the forget-on-clear retry marker

A database error on `SELECT is_pinned, is_deleted` was collapsed with `unwrap_or(None)`, so the clip looked already gone. The marker was dropped and a later clear could not retry the forget.

Match the existing begin/DELETE/commit error path: record the error, restore the marker, return without deleting.

`Ok(None)` still means the row is gone and the marker stays dropped.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore forget-on-clear retry marker when clip lookup fails in `process_clipboard_clear`
> Previously, a failed SELECT during forget-on-clear was treated as if the clip was already gone, silently skipping deletion without restoring the retry marker. This fix introduces a new [`ForgetClipLookup`](https://github.com/tsouth89/cubby-clipboard/pull/205/files#diff-d847f1e6a544f67702a7437ef290edf9bfb814e4980abd1ecd59d6b7975cd851) enum with `Found`, `AlreadyGone`, and `Failed` variants to distinguish between missing rows and query errors. On failure, the retry marker is now restored and an error is logged; on a missing row, a debug log is emitted and the function returns early as before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5af825c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->