### PR TITLE
SBS-836: Keep the previous original when a recapture cannot write the full image

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -2011,19 +2011,21 @@ async fn process_clipboard_snapshot(
         was_existing = true;
         if clip_type == "image" {
             if let Some(full_bytes) = &full_image_content {
-                // Persist the new original first (temp file, then rename) so a
-                // failed write never commits this recapture and never truncates
-                // the previous `{uuid}.cubby`. A persist error is a capture
-                // miss: keep the prior row and do not enqueue OCR.
+                // Stage the new original to a temp file, commit the row change,
+                // and only then move it over the previous `{uuid}.cubby`. A
+                // failure at any step is a capture miss: keep the prior row and
+                // the prior original, and do not enqueue OCR.
                 if recapture_existing_image(
                     &db,
                     &existing_id,
                     full_bytes,
-                    &encrypted_source_app,
-                    &encrypted_source_icon,
-                    &encrypted_content,
-                    &encrypted_preview,
-                    encrypted_metadata.clone(),
+                    crate::image_persist::RecaptureFields {
+                        source_app: &encrypted_source_app,
+                        source_icon: &encrypted_source_icon,
+                        content: &encrypted_content,
+                        preview: &encrypted_preview,
+                        metadata: encrypted_metadata.clone(),
+                    },
                 )
                 .await
                 .is_err()
@@ -2545,29 +2547,27 @@ pub fn create_image_preview(png_bytes: &[u8]) -> Result<Vec<u8>, String> {
 
 pub use crate::image_persist::persist_full_image_file;
 
-/// Persist a recaptured full-resolution original, then update the existing
-/// image row. The write happens first so a persist failure never commits the
-/// recapture `UPDATE` and never queues OCR against a missing file.
+/// Stage a recaptured full-resolution original, update the existing image row
+/// inside one transaction, and replace the previous original only after that
+/// transaction commits. Any failure leaves the prior row and the prior file
+/// intact and never queues OCR against a file that was never written.
 async fn recapture_existing_image(
     db: &Database,
     existing_id: &str,
     full_bytes: &[u8],
-    encrypted_source_app: &Option<String>,
-    encrypted_source_icon: &Option<String>,
-    encrypted_content: &[u8],
-    encrypted_preview: &str,
-    encrypted_metadata: Option<String>,
+    fields: crate::image_persist::RecaptureFields<'_>,
 ) -> Result<(), String> {
     match crate::image_persist::apply_existing_image_recapture(
         &db.pool,
         existing_id,
-        persist_full_image_file(&db.crypto, &db.image_dir, existing_id, full_bytes),
+        crate::image_persist::stage_full_image_file(
+            &db.crypto,
+            &db.image_dir,
+            existing_id,
+            full_bytes,
+        ),
         full_bytes.len() as i64,
-        encrypted_source_app,
-        encrypted_source_icon,
-        encrypted_content,
-        encrypted_preview,
-        encrypted_metadata,
+        fields,
     )
     .await
     {

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -2010,7 +2010,27 @@ async fn process_clipboard_snapshot(
     let (emitted_id, inserted_new) = if let Some(existing_id) = existing_uuid {
         was_existing = true;
         if clip_type == "image" {
-            if let Err(error) = sqlx::query(
+            if let Some(full_bytes) = &full_image_content {
+                // Persist the new original first (temp file, then rename) so a
+                // failed write never commits this recapture and never truncates
+                // the previous `{uuid}.cubby`. A persist error is a capture
+                // miss: keep the prior row and do not enqueue OCR.
+                if recapture_existing_image(
+                    &db,
+                    &existing_id,
+                    full_bytes,
+                    &encrypted_source_app,
+                    &encrypted_source_icon,
+                    &encrypted_content,
+                    &encrypted_preview,
+                    encrypted_metadata.clone(),
+                )
+                .await
+                .is_err()
+                {
+                    return;
+                }
+            } else if let Err(error) = sqlx::query(
                 r#"
                 UPDATE clips
                 SET created_at = CURRENT_TIMESTAMP,
@@ -2039,44 +2059,6 @@ async fn process_clipboard_snapshot(
                     error
                 );
                 return;
-            }
-
-            if let Some(full_bytes) = &full_image_content {
-                match persist_full_image_file(
-                    &db.crypto,
-                    &db.image_dir,
-                    &existing_id,
-                    full_bytes,
-                ) {
-                    Ok(file_path) => {
-                        if let Err(error) = sqlx::query(
-                            r#"
-                            INSERT OR REPLACE INTO clip_images (clip_uuid, full_content, file_path, file_size, storage_kind, mime_type, created_at)
-                            VALUES (?, x'', ?, ?, 'file', 'image/png', CURRENT_TIMESTAMP)
-                            "#,
-                        )
-                        .bind(&existing_id)
-                        .bind(&file_path)
-                        .bind(full_bytes.len() as i64)
-                        .execute(pool)
-                        .await
-                        {
-                            log::error!(
-                                "CLIPBOARD: Failed to index image file for existing clip {}: {}",
-                                existing_id,
-                                error
-                            );
-                            return;
-                        }
-                    }
-                    Err(e) => {
-                        log::error!(
-                            "Failed to persist full image file for existing clip {}: {}",
-                            existing_id,
-                            e
-                        );
-                    }
-                }
             }
         } else {
             if let Err(error) = sqlx::query(r#"UPDATE clips SET created_at = CURRENT_TIMESTAMP, is_deleted = 0, source_app = ?, source_icon = ? WHERE uuid = ?"#)
@@ -2561,17 +2543,40 @@ pub fn create_image_preview(png_bytes: &[u8]) -> Result<Vec<u8>, String> {
     Ok(bytes.into_inner())
 }
 
-pub fn persist_full_image_file(
-    crypto: &crate::crypto::CryptoManager,
-    image_dir: &std::path::Path,
-    clip_uuid: &str,
-    png_bytes: &[u8],
-) -> Result<String, String> {
-    std::fs::create_dir_all(image_dir).map_err(|e| e.to_string())?;
-    let file_path = image_dir.join(format!("{}.cubby", clip_uuid));
-    let encrypted = crypto.encrypt(png_bytes)?;
-    std::fs::write(&file_path, encrypted).map_err(|e| e.to_string())?;
-    Ok(file_path.to_string_lossy().to_string())
+pub use crate::image_persist::persist_full_image_file;
+
+/// Persist a recaptured full-resolution original, then update the existing
+/// image row. The write happens first so a persist failure never commits the
+/// recapture `UPDATE` and never queues OCR against a missing file.
+async fn recapture_existing_image(
+    db: &Database,
+    existing_id: &str,
+    full_bytes: &[u8],
+    encrypted_source_app: &Option<String>,
+    encrypted_source_icon: &Option<String>,
+    encrypted_content: &[u8],
+    encrypted_preview: &str,
+    encrypted_metadata: Option<String>,
+) -> Result<(), String> {
+    match crate::image_persist::apply_existing_image_recapture(
+        &db.pool,
+        existing_id,
+        persist_full_image_file(&db.crypto, &db.image_dir, existing_id, full_bytes),
+        full_bytes.len() as i64,
+        encrypted_source_app,
+        encrypted_source_icon,
+        encrypted_content,
+        encrypted_preview,
+        encrypted_metadata,
+    )
+    .await
+    {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            record_capture_error(error.clone());
+            Err(error)
+        }
+    }
 }
 
 pub fn read_full_image_file(

--- a/src-tauri/src/image_persist.rs
+++ b/src-tauri/src/image_persist.rs
@@ -1,0 +1,439 @@
+use crate::crypto::CryptoManager;
+use std::path::Path;
+
+pub fn persist_full_image_file(
+    crypto: &CryptoManager,
+    image_dir: &Path,
+    clip_uuid: &str,
+    png_bytes: &[u8],
+) -> Result<String, String> {
+    std::fs::create_dir_all(image_dir).map_err(|e| e.to_string())?;
+    let file_path = image_dir.join(format!("{}.cubby", clip_uuid));
+    // Write the new original to a sibling temp file first. `std::fs::write`
+    // truncates on open, so replacing the live `{uuid}.cubby` in place would
+    // destroy the previous good file if the write failed mid-stream.
+    let temp_path = image_dir.join(format!("{}.cubby.tmp", clip_uuid));
+    let encrypted = crypto.encrypt(png_bytes)?;
+    std::fs::write(&temp_path, encrypted).map_err(|e| e.to_string())?;
+    if let Err(error) = replace_image_file_atomically(&temp_path, &file_path) {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(error);
+    }
+    Ok(file_path.to_string_lossy().to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn replace_image_file_atomically(source: &Path, destination: &Path) -> Result<(), String> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows::core::PCWSTR;
+    use windows::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let source_wide = source
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let destination_wide = destination
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+
+    unsafe {
+        MoveFileExW(
+            PCWSTR(source_wide.as_ptr()),
+            PCWSTR(destination_wide.as_ptr()),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    }
+    .map_err(|error| error.to_string())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn replace_image_file_atomically(source: &Path, destination: &Path) -> Result<(), String> {
+    std::fs::rename(source, destination).map_err(|error| error.to_string())
+}
+
+/// Apply a recapture after (or instead of) a persist attempt. Passing `Err`
+/// leaves the previous `clips` row, `clip_images` index, and on-disk original
+/// untouched so tests can pin the persist-failure path without AppHandle.
+pub(crate) async fn apply_existing_image_recapture(
+    pool: &sqlx::SqlitePool,
+    existing_id: &str,
+    persist_result: Result<String, String>,
+    full_bytes_len: i64,
+    encrypted_source_app: &Option<String>,
+    encrypted_source_icon: &Option<String>,
+    encrypted_content: &[u8],
+    encrypted_preview: &str,
+    encrypted_metadata: Option<String>,
+) -> Result<(), String> {
+    let file_path = persist_result.map_err(|error| {
+        format!("Failed to persist full image file for existing clip {existing_id}: {error}")
+    })?;
+
+    sqlx::query(
+        r#"
+        UPDATE clips
+        SET created_at = CURRENT_TIMESTAMP,
+            is_deleted = 0,
+            source_app = ?,
+            source_icon = ?,
+            content = ?,
+            text_preview = ?,
+            metadata = ?,
+            is_thumbnail = 0
+        WHERE uuid = ?
+        "#,
+    )
+    .bind(encrypted_source_app)
+    .bind(encrypted_source_icon)
+    .bind(encrypted_content)
+    .bind(encrypted_preview)
+    .bind(encrypted_metadata)
+    .bind(existing_id)
+    .execute(pool)
+    .await
+    .map_err(|error| {
+        format!("CLIPBOARD: Failed to update existing image clip {existing_id}: {error}")
+    })?;
+
+    sqlx::query(
+        r#"
+        INSERT OR REPLACE INTO clip_images (clip_uuid, full_content, file_path, file_size, storage_kind, mime_type, created_at)
+        VALUES (?, x'', ?, ?, 'file', 'image/png', CURRENT_TIMESTAMP)
+        "#,
+    )
+    .bind(existing_id)
+    .bind(&file_path)
+    .bind(full_bytes_len)
+    .execute(pool)
+    .await
+    .map_err(|error| {
+        format!("CLIPBOARD: Failed to index image file for existing clip {existing_id}: {error}")
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{apply_existing_image_recapture, persist_full_image_file};
+    use crate::crypto::CryptoManager;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    fn read_original(crypto: &CryptoManager, path: &str) -> Vec<u8> {
+        let encrypted = std::fs::read(path).expect("original file should exist");
+        crypto
+            .decrypt(&encrypted)
+            .expect("original file should still decrypt")
+    }
+
+    #[test]
+    fn persist_full_image_file_does_not_truncate_the_live_original_when_the_temp_write_fails() {
+        let crypto = CryptoManager::ephemeral();
+        let image_dir =
+            std::env::temp_dir().join(format!("cubby-image-persist-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&image_dir).unwrap();
+        let uuid = "existing-original";
+        let live_path =
+            persist_full_image_file(&crypto, &image_dir, uuid, b"previous-full-res").unwrap();
+        assert_eq!(read_original(&crypto, &live_path), b"previous-full-res");
+
+        // Occupy the staging name with a directory so `fs::write` cannot
+        // create the temp file. The live `{uuid}.cubby` must stay intact.
+        let temp_path = image_dir.join(format!("{uuid}.cubby.tmp"));
+        std::fs::create_dir(&temp_path).unwrap();
+
+        let persist_err = persist_full_image_file(&crypto, &image_dir, uuid, b"new-full-res");
+        assert!(
+            persist_err.is_err(),
+            "staging-path collision should fail the persist"
+        );
+        assert_eq!(
+            read_original(&crypto, &live_path),
+            b"previous-full-res",
+            "a failed persist must not truncate or replace the previous original"
+        );
+
+        let _ = std::fs::remove_dir_all(&image_dir);
+    }
+
+    async fn recapture_pool() -> sqlx::SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory database should open");
+        sqlx::query("PRAGMA foreign_keys = ON")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            r#"
+            CREATE TABLE clips (
+                uuid TEXT PRIMARY KEY,
+                clip_type TEXT NOT NULL,
+                content BLOB NOT NULL,
+                text_preview TEXT,
+                content_hash TEXT NOT NULL,
+                is_deleted INTEGER NOT NULL DEFAULT 0,
+                is_thumbnail INTEGER NOT NULL DEFAULT 0,
+                source_app TEXT,
+                source_icon TEXT,
+                metadata TEXT,
+                ocr_status TEXT,
+                ocr_text TEXT,
+                full_image_expired INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                last_accessed TEXT NOT NULL
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r#"
+            CREATE TABLE clip_images (
+                clip_uuid TEXT PRIMARY KEY,
+                full_content BLOB NOT NULL,
+                file_path TEXT,
+                file_size INTEGER,
+                storage_kind TEXT NOT NULL,
+                mime_type TEXT NOT NULL,
+                created_at TEXT,
+                FOREIGN KEY (clip_uuid) REFERENCES clips(uuid) ON DELETE CASCADE
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    async fn seed_healthy_image_clip(
+        pool: &sqlx::SqlitePool,
+        crypto: &CryptoManager,
+        image_dir: &std::path::Path,
+        uuid: &str,
+        original_png: &[u8],
+    ) -> (Vec<u8>, String, String) {
+        let file_path = persist_full_image_file(crypto, image_dir, uuid, original_png).unwrap();
+        let content = crypto.encrypt(b"old-thumbnail").unwrap();
+        let preview = crypto.encrypt_text("[Image]").unwrap();
+        sqlx::query(
+            r#"
+            INSERT INTO clips (
+                uuid, clip_type, content, text_preview, content_hash,
+                is_deleted, is_thumbnail, ocr_status, ocr_text,
+                full_image_expired, created_at, last_accessed
+            )
+            VALUES (
+                ?, 'image', ?, ?, 'existing-hash',
+                0, 0, 'completed', 'already-recognized',
+                0, '2026-01-15 12:00:00', '2026-01-15 12:00:00'
+            )
+            "#,
+        )
+        .bind(uuid)
+        .bind(&content)
+        .bind(&preview)
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r#"
+            INSERT INTO clip_images (
+                clip_uuid, full_content, file_path, file_size, storage_kind, mime_type
+            )
+            VALUES (?, x'', ?, ?, 'file', 'image/png')
+            "#,
+        )
+        .bind(uuid)
+        .bind(&file_path)
+        .bind(original_png.len() as i64)
+        .execute(pool)
+        .await
+        .unwrap();
+        (content, preview, file_path)
+    }
+
+    type RecaptureRow = (
+        Vec<u8>,
+        Option<String>,
+        i64,
+        i64,
+        Option<String>,
+        Option<String>,
+        String,
+    );
+
+    async fn load_recapture_row(pool: &sqlx::SqlitePool, uuid: &str) -> RecaptureRow {
+        sqlx::query_as(
+            r#"
+            SELECT content, text_preview, is_thumbnail, full_image_expired,
+                   ocr_status, ocr_text, created_at
+            FROM clips WHERE uuid = ?
+            "#,
+        )
+        .bind(uuid)
+        .fetch_one(pool)
+        .await
+        .expect("clip row should still exist")
+    }
+
+    fn assert_still_prior_healthy_clip(row: &RecaptureRow, old_content: &[u8], old_preview: &str) {
+        assert_eq!(row.0, old_content, "thumbnail bytes must stay prior");
+        assert_eq!(
+            row.1.as_deref(),
+            Some(old_preview),
+            "preview must stay prior"
+        );
+        assert_eq!(row.2, 0, "prior clip was already full-resolution");
+        assert_eq!(
+            row.3, 0,
+            "a persist miss must not look like retention expiry"
+        );
+        assert_eq!(row.4.as_deref(), Some("completed"));
+        assert_eq!(row.5.as_deref(), Some("already-recognized"));
+        assert_eq!(row.6, "2026-01-15 12:00:00");
+    }
+
+    #[tokio::test]
+    async fn persist_err_on_an_existing_image_uuid_keeps_the_previous_original() {
+        let pool = recapture_pool().await;
+        let crypto = CryptoManager::ephemeral();
+        let image_dir =
+            std::env::temp_dir().join(format!("cubby-recapture-test-{}", uuid::Uuid::new_v4()));
+        let uuid = "existing-image-recapture";
+        let (old_content, old_preview, file_path) =
+            seed_healthy_image_clip(&pool, &crypto, &image_dir, uuid, b"previous-full-res").await;
+
+        let recapture = apply_existing_image_recapture(
+            &pool,
+            uuid,
+            Err("disk full".to_string()),
+            99,
+            &None,
+            &None,
+            b"new-thumbnail",
+            "new-preview",
+            None,
+        )
+        .await;
+
+        assert!(
+            recapture.is_err(),
+            "persist Err must fail the recapture, not continue as success"
+        );
+        let error = recapture.unwrap_err();
+        assert!(
+            error.contains(uuid),
+            "the error should name the existing clip: {error}"
+        );
+        assert!(
+            error.contains("persist"),
+            "the error should describe the persist failure: {error}"
+        );
+
+        let row = load_recapture_row(&pool, uuid).await;
+        assert_still_prior_healthy_clip(&row, &old_content, &old_preview);
+
+        let indexed_size: i64 =
+            sqlx::query_scalar("SELECT file_size FROM clip_images WHERE clip_uuid = ?")
+                .bind(uuid)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(indexed_size, b"previous-full-res".len() as i64);
+        assert_eq!(read_original(&crypto, &file_path), b"previous-full-res");
+
+        let pending: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM clips WHERE uuid = ? AND ocr_status = 'pending'",
+        )
+        .bind(uuid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(pending, 0, "OCR must not be queued against a missing file");
+
+        let _ = std::fs::remove_dir_all(&image_dir);
+    }
+
+    #[tokio::test]
+    async fn persist_err_from_a_failed_file_write_does_not_commit_the_recapture() {
+        let pool = recapture_pool().await;
+        let crypto = CryptoManager::ephemeral();
+        let image_dir = std::env::temp_dir().join(format!(
+            "cubby-recapture-write-fail-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let uuid = "existing-image-write-fail";
+        let (old_content, old_preview, file_path) =
+            seed_healthy_image_clip(&pool, &crypto, &image_dir, uuid, b"previous-full-res").await;
+
+        let temp_path = image_dir.join(format!("{uuid}.cubby.tmp"));
+        std::fs::create_dir(&temp_path).unwrap();
+        let persist_result = persist_full_image_file(&crypto, &image_dir, uuid, b"new-full-res");
+        assert!(persist_result.is_err());
+
+        let recapture = apply_existing_image_recapture(
+            &pool,
+            uuid,
+            persist_result,
+            b"new-full-res".len() as i64,
+            &None,
+            &None,
+            b"new-thumbnail",
+            "new-preview",
+            None,
+        )
+        .await;
+        assert!(recapture.is_err());
+
+        let row = load_recapture_row(&pool, uuid).await;
+        assert_still_prior_healthy_clip(&row, &old_content, &old_preview);
+        assert_eq!(read_original(&crypto, &file_path), b"previous-full-res");
+
+        let _ = std::fs::remove_dir_all(&image_dir);
+    }
+
+    #[tokio::test]
+    async fn a_successful_persist_commits_the_recapture_and_replaces_the_original() {
+        let pool = recapture_pool().await;
+        let crypto = CryptoManager::ephemeral();
+        let image_dir =
+            std::env::temp_dir().join(format!("cubby-recapture-ok-{}", uuid::Uuid::new_v4()));
+        let uuid = "existing-image-success";
+        let (_old_content, _old_preview, file_path) =
+            seed_healthy_image_clip(&pool, &crypto, &image_dir, uuid, b"previous-full-res").await;
+
+        let persist_result = persist_full_image_file(&crypto, &image_dir, uuid, b"new-full-res");
+        apply_existing_image_recapture(
+            &pool,
+            uuid,
+            persist_result,
+            b"new-full-res".len() as i64,
+            &None,
+            &None,
+            b"new-thumbnail",
+            "new-preview",
+            None,
+        )
+        .await
+        .expect("successful persist should commit the recapture");
+
+        let row = load_recapture_row(&pool, uuid).await;
+        assert_eq!(row.0, b"new-thumbnail");
+        assert_eq!(row.1.as_deref(), Some("new-preview"));
+        assert_eq!(row.2, 0);
+        assert_ne!(row.6, "2026-01-15 12:00:00", "timestamp should bump");
+        assert_eq!(read_original(&crypto, &file_path), b"new-full-res");
+
+        let _ = std::fs::remove_dir_all(&image_dir);
+    }
+}

--- a/src-tauri/src/image_persist.rs
+++ b/src-tauri/src/image_persist.rs
@@ -1,25 +1,73 @@
 use crate::crypto::CryptoManager;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+/// A full-resolution original that is already written and encrypted on disk as
+/// `{uuid}.cubby.tmp` but has not yet taken the place of the live
+/// `{uuid}.cubby`. Nothing observes the new bytes until `commit` runs, so every
+/// early return between staging and commit leaves the previous original
+/// byte-identical. Dropping the handle without committing removes the temp file.
+pub(crate) struct StagedImageFile {
+    temp_path: PathBuf,
+    final_path: PathBuf,
+    committed: bool,
+}
+
+impl StagedImageFile {
+    /// The path the original will occupy once `commit` succeeds. This is what
+    /// `clip_images.file_path` must record, because the commit only ever moves
+    /// the staged bytes onto exactly this name.
+    pub(crate) fn final_path(&self) -> String {
+        self.final_path.to_string_lossy().to_string()
+    }
+
+    /// Replace the live original with the staged bytes.
+    pub(crate) fn commit(mut self) -> Result<String, String> {
+        replace_image_file_atomically(&self.temp_path, &self.final_path)?;
+        self.committed = true;
+        Ok(self.final_path.to_string_lossy().to_string())
+    }
+}
+
+impl Drop for StagedImageFile {
+    fn drop(&mut self) {
+        if !self.committed {
+            let _ = std::fs::remove_file(&self.temp_path);
+        }
+    }
+}
+
+/// Encrypt and write the new original to a sibling temp file without touching
+/// the live `{uuid}.cubby`. `std::fs::write` truncates on open, so writing the
+/// live name in place would destroy the previous good file if the write failed
+/// mid-stream.
+pub(crate) fn stage_full_image_file(
+    crypto: &CryptoManager,
+    image_dir: &Path,
+    clip_uuid: &str,
+    png_bytes: &[u8],
+) -> Result<StagedImageFile, String> {
+    std::fs::create_dir_all(image_dir).map_err(|e| e.to_string())?;
+    let final_path = image_dir.join(format!("{}.cubby", clip_uuid));
+    let temp_path = image_dir.join(format!("{}.cubby.tmp", clip_uuid));
+    let encrypted = crypto.encrypt(png_bytes)?;
+    std::fs::write(&temp_path, encrypted).map_err(|e| e.to_string())?;
+    Ok(StagedImageFile {
+        temp_path,
+        final_path,
+        committed: false,
+    })
+}
+
+/// Stage and immediately commit a full original. Used by the paths that write a
+/// brand-new `{uuid}.cubby` (a new clip, the encryption migration), where there
+/// is no previous original that a failed follow-up step could destroy.
 pub fn persist_full_image_file(
     crypto: &CryptoManager,
     image_dir: &Path,
     clip_uuid: &str,
     png_bytes: &[u8],
 ) -> Result<String, String> {
-    std::fs::create_dir_all(image_dir).map_err(|e| e.to_string())?;
-    let file_path = image_dir.join(format!("{}.cubby", clip_uuid));
-    // Write the new original to a sibling temp file first. `std::fs::write`
-    // truncates on open, so replacing the live `{uuid}.cubby` in place would
-    // destroy the previous good file if the write failed mid-stream.
-    let temp_path = image_dir.join(format!("{}.cubby.tmp", clip_uuid));
-    let encrypted = crypto.encrypt(png_bytes)?;
-    std::fs::write(&temp_path, encrypted).map_err(|e| e.to_string())?;
-    if let Err(error) = replace_image_file_atomically(&temp_path, &file_path) {
-        let _ = std::fs::remove_file(&temp_path);
-        return Err(error);
-    }
-    Ok(file_path.to_string_lossy().to_string())
+    stage_full_image_file(crypto, image_dir, clip_uuid, png_bytes)?.commit()
 }
 
 #[cfg(target_os = "windows")]
@@ -56,22 +104,39 @@ fn replace_image_file_atomically(source: &Path, destination: &Path) -> Result<()
     std::fs::rename(source, destination).map_err(|error| error.to_string())
 }
 
-/// Apply a recapture after (or instead of) a persist attempt. Passing `Err`
+/// The already-encrypted column values a recapture writes back onto the
+/// existing `clips` row. Grouped so the recapture entry points stay under the
+/// argument-count lint instead of threading six loose encrypted blobs through.
+pub(crate) struct RecaptureFields<'a> {
+    pub source_app: &'a Option<String>,
+    pub source_icon: &'a Option<String>,
+    pub content: &'a [u8],
+    pub preview: &'a str,
+    pub metadata: Option<String>,
+}
+
+/// Apply a recapture after (or instead of) a staging attempt. Passing `Err`
 /// leaves the previous `clips` row, `clip_images` index, and on-disk original
-/// untouched so tests can pin the persist-failure path without AppHandle.
+/// untouched so tests can pin the staging-failure path without AppHandle.
+///
+/// Ordering matters: both statements run inside one transaction, and the staged
+/// original only replaces the live file after that transaction commits. A
+/// failure at any earlier point returns with the staged handle un-committed, so
+/// its `Drop` deletes the temp file and the previous original survives intact.
 pub(crate) async fn apply_existing_image_recapture(
     pool: &sqlx::SqlitePool,
     existing_id: &str,
-    persist_result: Result<String, String>,
+    staged: Result<StagedImageFile, String>,
     full_bytes_len: i64,
-    encrypted_source_app: &Option<String>,
-    encrypted_source_icon: &Option<String>,
-    encrypted_content: &[u8],
-    encrypted_preview: &str,
-    encrypted_metadata: Option<String>,
+    fields: RecaptureFields<'_>,
 ) -> Result<(), String> {
-    let file_path = persist_result.map_err(|error| {
+    let staged = staged.map_err(|error| {
         format!("Failed to persist full image file for existing clip {existing_id}: {error}")
+    })?;
+    let file_path = staged.final_path();
+
+    let mut transaction = pool.begin().await.map_err(|error| {
+        format!("CLIPBOARD: Failed to start the recapture transaction for existing clip {existing_id}: {error}")
     })?;
 
     sqlx::query(
@@ -88,13 +153,13 @@ pub(crate) async fn apply_existing_image_recapture(
         WHERE uuid = ?
         "#,
     )
-    .bind(encrypted_source_app)
-    .bind(encrypted_source_icon)
-    .bind(encrypted_content)
-    .bind(encrypted_preview)
-    .bind(encrypted_metadata)
+    .bind(fields.source_app)
+    .bind(fields.source_icon)
+    .bind(fields.content)
+    .bind(fields.preview)
+    .bind(fields.metadata)
     .bind(existing_id)
-    .execute(pool)
+    .execute(&mut *transaction)
     .await
     .map_err(|error| {
         format!("CLIPBOARD: Failed to update existing image clip {existing_id}: {error}")
@@ -109,18 +174,35 @@ pub(crate) async fn apply_existing_image_recapture(
     .bind(existing_id)
     .bind(&file_path)
     .bind(full_bytes_len)
-    .execute(pool)
+    .execute(&mut *transaction)
     .await
     .map_err(|error| {
         format!("CLIPBOARD: Failed to index image file for existing clip {existing_id}: {error}")
     })?;
 
+    transaction.commit().await.map_err(|error| {
+        format!(
+            "CLIPBOARD: Failed to commit the recapture for existing clip {existing_id}: {error}"
+        )
+    })?;
+
+    // The database now describes the staged bytes, so replacing the previous
+    // original is the last step. If this single rename fails the previous
+    // original is still the one on disk; that leaves the row's thumbnail and
+    // file_size ahead of the file, which is reported as an error rather than
+    // silently losing the original.
+    staged.commit().map_err(|error| {
+        format!("CLIPBOARD: Failed to replace the stored original for existing clip {existing_id}: {error}")
+    })?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_existing_image_recapture, persist_full_image_file};
+    use super::{
+        apply_existing_image_recapture, persist_full_image_file, stage_full_image_file,
+        RecaptureFields, StagedImageFile,
+    };
     use crate::crypto::CryptoManager;
     use sqlx::sqlite::SqlitePoolOptions;
 
@@ -129,6 +211,16 @@ mod tests {
         crypto
             .decrypt(&encrypted)
             .expect("original file should still decrypt")
+    }
+
+    fn new_fields<'a>(content: &'a [u8], preview: &'a str) -> RecaptureFields<'a> {
+        RecaptureFields {
+            source_app: &None,
+            source_icon: &None,
+            content,
+            preview,
+            metadata: None,
+        }
     }
 
     #[test]
@@ -157,6 +249,31 @@ mod tests {
             b"previous-full-res",
             "a failed persist must not truncate or replace the previous original"
         );
+
+        let _ = std::fs::remove_dir_all(&image_dir);
+    }
+
+    #[test]
+    fn dropping_a_staged_file_without_committing_removes_the_temp_and_keeps_the_original() {
+        let crypto = CryptoManager::ephemeral();
+        let image_dir =
+            std::env::temp_dir().join(format!("cubby-image-staged-{}", uuid::Uuid::new_v4()));
+        let uuid = "staged-but-abandoned";
+        let live_path =
+            persist_full_image_file(&crypto, &image_dir, uuid, b"previous-full-res").unwrap();
+
+        let temp_path = image_dir.join(format!("{uuid}.cubby.tmp"));
+        {
+            let staged = stage_full_image_file(&crypto, &image_dir, uuid, b"new-full-res").unwrap();
+            assert!(temp_path.exists(), "staging should write the temp file");
+            assert_eq!(staged.final_path(), live_path);
+        }
+
+        assert!(
+            !temp_path.exists(),
+            "an un-committed staged file must clean up its temp file"
+        );
+        assert_eq!(read_original(&crypto, &live_path), b"previous-full-res");
 
         let _ = std::fs::remove_dir_all(&image_dir);
     }
@@ -316,13 +433,9 @@ mod tests {
         let recapture = apply_existing_image_recapture(
             &pool,
             uuid,
-            Err("disk full".to_string()),
+            Err::<StagedImageFile, String>("disk full".to_string()),
             99,
-            &None,
-            &None,
-            b"new-thumbnail",
-            "new-preview",
-            None,
+            new_fields(b"new-thumbnail", "new-preview"),
         )
         .await;
 
@@ -378,19 +491,15 @@ mod tests {
 
         let temp_path = image_dir.join(format!("{uuid}.cubby.tmp"));
         std::fs::create_dir(&temp_path).unwrap();
-        let persist_result = persist_full_image_file(&crypto, &image_dir, uuid, b"new-full-res");
-        assert!(persist_result.is_err());
+        let staged = stage_full_image_file(&crypto, &image_dir, uuid, b"new-full-res");
+        assert!(staged.is_err());
 
         let recapture = apply_existing_image_recapture(
             &pool,
             uuid,
-            persist_result,
+            staged,
             b"new-full-res".len() as i64,
-            &None,
-            &None,
-            b"new-thumbnail",
-            "new-preview",
-            None,
+            new_fields(b"new-thumbnail", "new-preview"),
         )
         .await;
         assert!(recapture.is_err());
@@ -398,6 +507,78 @@ mod tests {
         let row = load_recapture_row(&pool, uuid).await;
         assert_still_prior_healthy_clip(&row, &old_content, &old_preview);
         assert_eq!(read_original(&crypto, &file_path), b"previous-full-res");
+
+        let _ = std::fs::remove_dir_all(&image_dir);
+    }
+
+    /// The opposite order of the write-failure test: the new original is
+    /// written successfully and only the database write fails. The rename must
+    /// not have happened yet, so the previous original is still on disk and the
+    /// half-applied `UPDATE clips` is rolled back with it.
+    #[tokio::test]
+    async fn a_db_failure_after_a_successful_write_keeps_the_previous_original() {
+        let pool = recapture_pool().await;
+        let crypto = CryptoManager::ephemeral();
+        let image_dir =
+            std::env::temp_dir().join(format!("cubby-recapture-db-fail-{}", uuid::Uuid::new_v4()));
+        let uuid = "existing-image-db-fail";
+        let (old_content, old_preview, file_path) =
+            seed_healthy_image_clip(&pool, &crypto, &image_dir, uuid, b"previous-full-res").await;
+
+        // Fail the second statement only, after `UPDATE clips` has already
+        // succeeded. Without a transaction that leaves the new thumbnail
+        // beside the old file_size.
+        sqlx::query(
+            r#"
+            CREATE TRIGGER block_clip_images_insert BEFORE INSERT ON clip_images
+            BEGIN
+                SELECT RAISE(ABORT, 'injected clip_images failure');
+            END
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let staged = stage_full_image_file(&crypto, &image_dir, uuid, b"new-full-res");
+        assert!(staged.is_ok(), "the file write itself must succeed here");
+
+        let recapture = apply_existing_image_recapture(
+            &pool,
+            uuid,
+            staged,
+            b"new-full-res".len() as i64,
+            new_fields(b"new-thumbnail", "new-preview"),
+        )
+        .await;
+        assert!(
+            recapture.is_err(),
+            "a failed clip_images write must fail the recapture"
+        );
+
+        let row = load_recapture_row(&pool, uuid).await;
+        assert_still_prior_healthy_clip(&row, &old_content, &old_preview);
+
+        let indexed_size: i64 =
+            sqlx::query_scalar("SELECT file_size FROM clip_images WHERE clip_uuid = ?")
+                .bind(uuid)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            indexed_size,
+            b"previous-full-res".len() as i64,
+            "clip_images must still describe the file that is actually on disk"
+        );
+        assert_eq!(
+            read_original(&crypto, &file_path),
+            b"previous-full-res",
+            "a failed database write must not have replaced the previous original"
+        );
+        assert!(
+            !image_dir.join(format!("{uuid}.cubby.tmp")).exists(),
+            "the abandoned staged file must be cleaned up"
+        );
 
         let _ = std::fs::remove_dir_all(&image_dir);
     }
@@ -412,17 +593,13 @@ mod tests {
         let (_old_content, _old_preview, file_path) =
             seed_healthy_image_clip(&pool, &crypto, &image_dir, uuid, b"previous-full-res").await;
 
-        let persist_result = persist_full_image_file(&crypto, &image_dir, uuid, b"new-full-res");
+        let staged = stage_full_image_file(&crypto, &image_dir, uuid, b"new-full-res");
         apply_existing_image_recapture(
             &pool,
             uuid,
-            persist_result,
+            staged,
             b"new-full-res".len() as i64,
-            &None,
-            &None,
-            b"new-thumbnail",
-            "new-preview",
-            None,
+            new_fields(b"new-thumbnail", "new-preview"),
         )
         .await
         .expect("successful persist should commit the recapture");
@@ -433,6 +610,18 @@ mod tests {
         assert_eq!(row.2, 0);
         assert_ne!(row.6, "2026-01-15 12:00:00", "timestamp should bump");
         assert_eq!(read_original(&crypto, &file_path), b"new-full-res");
+
+        let indexed_size: i64 =
+            sqlx::query_scalar("SELECT file_size FROM clip_images WHERE clip_uuid = ?")
+                .bind(uuid)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(indexed_size, b"new-full-res".len() as i64);
+        assert!(
+            !image_dir.join(format!("{uuid}.cubby.tmp")).exists(),
+            "a committed staged file must leave no temp file behind"
+        );
 
         let _ = std::fs::remove_dir_all(&image_dir);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -66,6 +66,7 @@ mod constants;
 mod crypto;
 mod database;
 mod ditto_import;
+mod image_persist;
 mod models;
 mod ocr;
 mod ocr_queue;


### PR DESCRIPTION
## SBS-836 — a failed full-image persist left a thumbnail-only recapture marked complete

A failed `persist_full_image_file` on an already-stored image used to log and continue. The recapture UPDATE had already committed `is_thumbnail = 0`, OCR could be re-queued against a missing file, and paste later hit the expired/missing-original path.

Write the new original to `{uuid}.cubby.tmp` and rename it over the live file so `std::fs::write` cannot truncate the previous good bytes. Persist before the clips UPDATE. On persist Err, `record_capture_error`, leave the prior row and file alone, and do not enqueue OCR.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep the previous image file when a recapture fails to write the full original
> - Introduces a new [image_persist.rs](https://github.com/tsouth89/cubby-clipboard/pull/208/files#diff-aca32a5e129a1566b01ef4d4ef0468598aa604fca59c8d800e16610bb12a84df) module with a staged write flow: new image data is written to a `{uuid}.cubby.tmp` temp file first, then atomically renamed to the live `{uuid}.cubby` only after the DB transaction commits.
> - Adds `StagedImageFile`, a RAII handle that deletes the temp file on drop if `commit()` is never called, ensuring no orphaned temp files on failure.
> - Updates `process_clipboard_snapshot` in [clipboard.rs](https://github.com/tsouth89/cubby-clipboard/pull/208/files#diff-8b53e1d4014cd55d2bf889ca51d824e6f3c4f2e3775e5b8a5d2670c416a3b984) to use the new `recapture_existing_image` helper, which applies DB updates and file replacement together; on any error the prior DB row and file remain intact and OCR is not enqueued.
> - Behavioral Change: previously a failed recapture write could truncate the live image file; now the original is preserved on any failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3fe6210.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->