### PR TITLE
SBS-837: Stop production logs from streaming into the WebView

### DIFF
--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -351,6 +351,39 @@ if (countWebviewKind(libSource) !== countWebviewKind(logTargetArms.get('Webview'
   );
 }
 
+// The mapper being clean is still not enough. A release build compiles
+// `to_plugin_log_target(LogTarget::Webview)`, so the *call site* could hand it
+// an extra variant -- `.chain(std::iter::once(LogTarget::Webview))` before the
+// `.map`, or a second `.targets()` -- and every check above would stay green
+// while fern installed the Webview target anyway. Pin the argument exactly, and
+// refuse `LogTarget::Webview` anywhere in lib.rs outside the mapper's own arm.
+const countLogTargetWebview = (source) => source.split('LogTarget::Webview').length - 1;
+if (countLogTargetWebview(libSource) !== countLogTargetWebview(pluginTargetMapper)) {
+  throw new Error(
+    'lib.rs must only name LogTarget::Webview inside to_plugin_log_target(); the log_builder call site must not select it',
+  );
+}
+
+const targetsCallCount = libSource.split('.targets(').length - 1;
+if (targetsCallCount !== 1) {
+  throw new Error(
+    `lib.rs must call log_builder.targets() exactly once, found ${targetsCallCount}`,
+  );
+}
+const targetsArgument = libSource.match(/\.targets\(([\s\S]*?)\n\s*\);/)?.[1];
+if (targetsArgument === undefined) {
+  throw new Error('Could not find the log_builder.targets(...) call in lib.rs');
+}
+const expectedTargetsArgument =
+  'log_targets::log_targets(cfg!(debug_assertions)).iter().copied().map(to_plugin_log_target)';
+// Whitespace-insensitive, and a trailing comma from rustfmt is not a combinator.
+const normalizedTargetsArgument = targetsArgument.replace(/\s+/g, '').replace(/,$/, '');
+if (normalizedTargetsArgument !== expectedTargetsArgument) {
+  throw new Error(
+    `log_builder.targets() must be exactly \`${expectedTargetsArgument}\`, with no extra combinators that could add a destination`,
+  );
+}
+
 const secretGates = [
   [secretsSource, 'classify_secret'],
   [secretsSource, 'DEFAULT_SENSITIVE_APP_EXES'],

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -34,6 +34,8 @@ const [
   publishStoreWorkflow,
   validateStoreWorkflow,
   verifyInstallerSignature,
+  libSource,
+  logTargetsSource,
 ] = await Promise.all([
   read('package.json'),
   read('src-tauri/tauri.conf.json'),
@@ -58,6 +60,8 @@ const [
   read('.github/workflows/publish-store-packages.yml'),
   read('.github/workflows/validate-store-submission.yml'),
   read('scripts/verify-installer-signature.ps1'),
+  read('src-tauri/src/lib.rs'),
+  read('src-tauri/src/log_targets.rs'),
 ]);
 
 const packageVersion = JSON.parse(packageText).version;
@@ -271,6 +275,35 @@ for (const sensitiveLogFragment of ['Detected self-paste for hash', 'full_path: 
   if (clipboardSource.includes(sensitiveLogFragment)) {
     throw new Error(`Clipboard source contains privacy-sensitive production logging: ${sensitiveLogFragment}`);
   }
+}
+
+// SBS-837: release builds must not stream Rust logs into the WebView.
+// Prefer an inline `#[cfg(not(debug_assertions))]` targets list when present;
+// otherwise the production arm of `log_targets()` is the source of truth.
+const inlineReleaseTargets = libSource.match(
+  /#\[cfg\(not\(debug_assertions\)\)\][\s\S]*?\.targets\(\[([\s\S]*?)\]\)/,
+)?.[1];
+if (inlineReleaseTargets?.includes('Webview')) {
+  throw new Error('Release log_builder.targets must not include Webview');
+}
+
+if (!libSource.includes('log_targets(cfg!(debug_assertions))')) {
+  throw new Error(
+    'lib.rs must install logger targets from log_targets(cfg!(debug_assertions))',
+  );
+}
+
+const productionLogTargets = logTargetsSource.match(
+  /if debug_assertions \{[\s\S]*?\} else \{([\s\S]*?)\}/,
+)?.[1];
+if (!productionLogTargets) {
+  throw new Error('Could not find the production arm of log_targets()');
+}
+if (productionLogTargets.includes('Webview')) {
+  throw new Error('Release log_builder.targets must not include Webview');
+}
+if (!productionLogTargets.includes('LogDir')) {
+  throw new Error('Release log_builder.targets must still include LogDir');
 }
 
 const secretGates = [

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -278,8 +278,10 @@ for (const sensitiveLogFragment of ['Detected self-paste for hash', 'full_path: 
 }
 
 // SBS-837: release builds must not stream Rust logs into the WebView.
-// Prefer an inline `#[cfg(not(debug_assertions))]` targets list when present;
-// otherwise the production arm of `log_targets()` is the source of truth.
+// `log_targets()` is the single source of truth and calling it is mandatory --
+// an inline `#[cfg(not(debug_assertions))]` targets list is not an accepted
+// substitute. The inline scan below only exists to reject a leftover one that
+// still names Webview.
 const inlineReleaseTargets = libSource.match(
   /#\[cfg\(not\(debug_assertions\)\)\][\s\S]*?\.targets\(\[([\s\S]*?)\]\)/,
 )?.[1];
@@ -304,6 +306,49 @@ if (productionLogTargets.includes('Webview')) {
 }
 if (!productionLogTargets.includes('LogDir')) {
   throw new Error('Release log_builder.targets must still include LogDir');
+}
+
+// The enum above is only as good as the mapping onto `tauri_plugin_log`.
+// `to_plugin_log_target` is the one place that can construct
+// `TargetKind::Webview`, so pin each arm to its own TargetKind and refuse any
+// other mention of Webview in lib.rs (for example a target appended after the
+// helper's list).
+const pluginTargetMapper = libSource.match(
+  /fn to_plugin_log_target\([\s\S]*?\n\}/,
+)?.[0];
+if (!pluginTargetMapper) {
+  throw new Error('Could not find to_plugin_log_target() in lib.rs');
+}
+
+const logTargetArms = new Map(
+  [
+    ...pluginTargetMapper.matchAll(
+      /LogTarget::(Stdout|Webview|LogDir)\s*=>([\s\S]*?)(?=LogTarget::(?:Stdout|Webview|LogDir)\s*=>|$)/g,
+    ),
+  ].map(([, variant, body]) => [variant, body]),
+);
+for (const [variant, expectedKind] of [
+  ['Stdout', 'TargetKind::Stdout'],
+  ['Webview', 'TargetKind::Webview'],
+  ['LogDir', 'TargetKind::LogDir'],
+]) {
+  const arm = logTargetArms.get(variant);
+  if (arm === undefined) {
+    throw new Error(`to_plugin_log_target() is missing the LogTarget::${variant} arm`);
+  }
+  if (!arm.includes(expectedKind)) {
+    throw new Error(`LogTarget::${variant} must map to ${expectedKind}`);
+  }
+  if (variant !== 'Webview' && arm.includes('TargetKind::Webview')) {
+    throw new Error(`LogTarget::${variant} must not map to TargetKind::Webview`);
+  }
+}
+
+const countWebviewKind = (source) => source.split('TargetKind::Webview').length - 1;
+if (countWebviewKind(libSource) !== countWebviewKind(logTargetArms.get('Webview'))) {
+  throw new Error(
+    'lib.rs must only name TargetKind::Webview inside the LogTarget::Webview arm of to_plugin_log_target()',
+  );
 }
 
 const secretGates = [

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -68,6 +68,7 @@ mod crypto;
 mod database;
 mod ditto_import;
 mod image_persist;
+mod log_targets;
 mod models;
 mod ocr;
 mod ocr_queue;
@@ -88,6 +89,20 @@ mod win_v_replacement;
 use database::Database;
 use models::get_runtime;
 use settings_manager::SettingsManager;
+
+fn to_plugin_log_target(target: log_targets::LogTarget) -> tauri_plugin_log::Target {
+    match target {
+        log_targets::LogTarget::Stdout => {
+            tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout)
+        }
+        log_targets::LogTarget::Webview => {
+            tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Webview)
+        }
+        log_targets::LogTarget::LogDir => {
+            tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir { file_name: None })
+        }
+    }
+}
 
 pub fn run_app() {
     let data_dir = get_data_dir();
@@ -179,21 +194,12 @@ pub fn run_app() {
         })
         .level_for("sqlx", log::LevelFilter::Warn);
 
-    #[cfg(debug_assertions)]
-    {
-        log_builder = log_builder.targets([
-            tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
-            tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Webview),
-        ]);
-    }
-
-    #[cfg(not(debug_assertions))]
-    {
-        log_builder = log_builder.targets([
-            tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir { file_name: None }),
-            tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Webview),
-        ]);
-    }
+    log_builder = log_builder.targets(
+        log_targets::log_targets(cfg!(debug_assertions))
+            .iter()
+            .copied()
+            .map(to_plugin_log_target),
+    );
 
     #[allow(unused_mut)]
     let mut builder = tauri::Builder::default();

--- a/src-tauri/src/log_targets.rs
+++ b/src-tauri/src/log_targets.rs
@@ -1,0 +1,59 @@
+/// Destinations Cubby installs for `tauri-plugin-log`.
+///
+/// Kept as a plain enum so the debug/release lists can be unit-tested without
+/// constructing a Tauri plugin builder, and without the Windows-only crate
+/// graph. `rustc --test src-tauri/src/log_targets.rs` runs these tests on Linux.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LogTarget {
+    Stdout,
+    Webview,
+    LogDir,
+}
+
+/// Targets for a debug (`true`) or release (`false`) build.
+///
+/// Debug keeps Stdout + Webview so `tauri dev` can show Rust logs in the
+/// console. Release stays on disk (`LogDir`) only: streaming into the WebView
+/// would put process names, clip UUIDs, and filter values in renderer memory
+/// (SBS-837).
+pub(crate) fn log_targets(debug_assertions: bool) -> &'static [LogTarget] {
+    if debug_assertions {
+        &[LogTarget::Stdout, LogTarget::Webview]
+    } else {
+        &[LogTarget::LogDir]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{log_targets, LogTarget};
+
+    #[test]
+    fn production_targets_do_not_include_webview() {
+        assert!(
+            !log_targets(false).contains(&LogTarget::Webview),
+            "release builds must not stream Rust logs into the WebView"
+        );
+    }
+
+    #[test]
+    fn production_targets_still_include_log_dir() {
+        assert!(
+            log_targets(false).contains(&LogTarget::LogDir),
+            "release builds must keep writing logs to disk"
+        );
+    }
+
+    #[test]
+    fn debug_targets_include_stdout_and_webview() {
+        let targets = log_targets(true);
+        assert!(
+            targets.contains(&LogTarget::Stdout),
+            "debug builds must keep Stdout"
+        );
+        assert!(
+            targets.contains(&LogTarget::Webview),
+            "debug builds may keep Webview"
+        );
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,7 +34,7 @@
         "default"
       ]
     },
-    "withGlobalTauri": true
+    "withGlobalTauri": false
   },
   "plugins": {
     "updater": {


### PR DESCRIPTION
## SBS-837 — production logs streamed into the WebView

Release builds installed `tauri-plugin-log` with LogDir and Webview, so every Rust info/warn/error landed in the renderer as well as on disk. That includes source-app filters, paste target process names, and clip UUIDs. Production now logs only to LogDir. Debug still uses Stdout and Webview.

`withGlobalTauri` is off because the UI talks to Tauri through `@tauri-apps/api` imports, not `window.__TAURI__`.

Linux cannot compile this Windows crate. Target selection lives in `log_targets.rs` so `rustc --test` can prove the lists without Windows. `scripts/check-release.mjs` fails if the production arm includes Webview or drops LogDir.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop production logs from streaming into the WebView
> - Adds a new [`log_targets.rs`](https://github.com/tsouth89/cubby-clipboard/pull/209/files#diff-7746912cd8f2a0347b9d62c531ec7531c173be2a6ccb8722ee5138e2fb82e401) module with a `LogTarget` enum and a `log_targets(debug: bool)` function that returns `[Stdout, Webview]` in debug builds and `[LogDir]` in release builds.
> - Replaces inline `#[cfg(debug_assertions)]` / `#[cfg(not(debug_assertions))]` target blocks in [`lib.rs`](https://github.com/tsouth89/cubby-clipboard/pull/209/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c) with a single `log_builder.targets(...)` call driven by `log_targets::log_targets(cfg!(debug_assertions))`.
> - Extends [`check-release.mjs`](https://github.com/tsouth89/cubby-clipboard/pull/209/files#diff-14ac66f5d0a1f9e003460f1b27bce6e68f7665390d99e23d897038130d21cdca) with validations that enforce the new logging policy, failing the release check if `Webview` appears in production targets or the call site deviates from the required iterator chain.
> - Sets `withGlobalTauri` to `false` in [`tauri.conf.json`](https://github.com/tsouth89/cubby-clipboard/pull/209/files#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7), removing the global Tauri API injection into the webview window object.
> - Behavioral Change: In release builds, log output goes only to `LogDir`; `Webview` is no longer a logging target.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a1a647.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->