### PR TITLE
Say secret heuristics are off by default, matching the shipped setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - run: node .github/scripts/check-privileged-action-pins.mjs
       - run: node .github/scripts/check-shipped-windows-ci.mjs
       - run: pnpm run test
-      - run: node --test product_pages/worker.test.mjs product_pages/analytics.test.mjs .github/scripts/check-privileged-action-pins.test.mjs .github/scripts/check-shipped-windows-ci.test.mjs scripts/product-page-claims.test.mjs
+      - run: node --test product_pages/worker.test.mjs product_pages/analytics.test.mjs .github/scripts/check-privileged-action-pins.test.mjs .github/scripts/check-shipped-windows-ci.test.mjs scripts/product-page-claims.test.mjs scripts/release-check-helpers.test.mjs
       - run: pnpm audit --prod
       # The rule that decides whether a live download URL may be overwritten.
       - name: Publish-guard rules

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { checkPrivilegedActionPins } from '../.github/scripts/check-privileged-action-pins.mjs';
 import { findFileListHistoryClaims } from './product-page-claims.mjs';
+import { extractDefaultSkipLikelySecrets, evaluateSecretHeuristicsDoc } from './release-check-helpers.mjs';
 
 const root = new URL('../', import.meta.url);
 const rootDir = fileURLToPath(root);
@@ -269,30 +270,28 @@ for (const [source, gate] of secretGates) {
 // SBS-811: SECURITY.md once said secret heuristics were "default on" while
 // AppSettings::default set skip_likely_secrets: false. Pin the shipped default
 // to the security page and Settings copy so they cannot drift again.
-const defaultSkipLikelySecrets = modelsSource.match(
-  /impl Default for AppSettings \{[\s\S]*?skip_likely_secrets:\s*(true|false)/
-)?.[1];
+const defaultSkipLikelySecrets = extractDefaultSkipLikelySecrets(modelsSource);
 if (defaultSkipLikelySecrets !== 'true' && defaultSkipLikelySecrets !== 'false') {
   throw new Error('Could not read skip_likely_secrets from AppSettings::default');
 }
 
-const secretHeuristicLine = securityDoc
-  .split(/\r?\n/)
-  .find((line) => /secret heuristics/i.test(line));
-if (!secretHeuristicLine) {
+const {
+  bullets: secretHeuristicBullets,
+  sayOn: securitySaysOn,
+  sayOff: securitySaysOff,
+} = evaluateSecretHeuristicsDoc(securityDoc);
+if (secretHeuristicBullets.length === 0) {
   throw new Error('SECURITY.md must document high-confidence secret heuristics');
 }
 
-const securitySaysOn = /\bdefault on\b/i.test(secretHeuristicLine);
-const securitySaysOff = /\b(off by default|opt-in)\b/i.test(secretHeuristicLine);
 if (defaultSkipLikelySecrets === 'false' && (securitySaysOn || !securitySaysOff)) {
   throw new Error(
-    `Shipped skip_likely_secrets default is off; SECURITY.md must say off by default / opt-in, not default on: ${secretHeuristicLine.trim()}`
+    `Shipped skip_likely_secrets default is off; SECURITY.md must say off by default / opt-in, not default on: ${secretHeuristicBullets.join(' | ')}`
   );
 }
 if (defaultSkipLikelySecrets === 'true' && (!securitySaysOn || securitySaysOff)) {
   throw new Error(
-    `Shipped skip_likely_secrets default is on; SECURITY.md must say default on: ${secretHeuristicLine.trim()}`
+    `Shipped skip_likely_secrets default is on; SECURITY.md must say default on: ${secretHeuristicBullets.join(' | ')}`
   );
 }
 

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { checkPrivilegedActionPins } from '../.github/scripts/check-privileged-action-pins.mjs';
 import { findFileListHistoryClaims } from './product-page-claims.mjs';
-import { extractDefaultSkipLikelySecrets, evaluateSecretHeuristicsDoc } from './release-check-helpers.mjs';
+import { extractDefaultSkipLikelySecrets, evaluateSecretHeuristicsDoc, saysDefaultOff } from './release-check-helpers.mjs';
 
 const root = new URL('../', import.meta.url);
 const rootDir = fileURLToPath(root);
@@ -299,7 +299,7 @@ const skipLikelySecretsDesc = JSON.parse(settingsLocaleText).settings?.skipLikel
 if (typeof skipLikelySecretsDesc !== 'string') {
   throw new Error('Settings locale must describe skipLikelySecrets');
 }
-if (defaultSkipLikelySecrets === 'false' && !/off by default/i.test(skipLikelySecretsDesc)) {
+if (defaultSkipLikelySecrets === 'false' && !saysDefaultOff(skipLikelySecretsDesc)) {
   throw new Error('Settings copy must say secret heuristics are off by default');
 }
 if (defaultSkipLikelySecrets === 'true' && !/on by default/i.test(skipLikelySecretsDesc)) {

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -29,6 +29,7 @@ const [
   privacyPageDoc,
   supportPageDoc,
   settingsPanelSource,
+  settingsLocaleText,
 ] = await Promise.all([
   read('package.json'),
   read('src-tauri/tauri.conf.json'),
@@ -49,6 +50,7 @@ const [
   read('product_pages/privacy.html'),
   read('product_pages/support.html'),
   read('frontend/src/components/SettingsPanel.tsx'),
+  read('frontend/src/i18n/locales/en.json'),
 ]);
 
 const packageVersion = JSON.parse(packageText).version;
@@ -262,6 +264,47 @@ for (const [source, gate] of secretGates) {
   if (!source.includes(gate)) {
     throw new Error(`Secret-aware privacy release gate is missing: ${gate}`);
   }
+}
+
+// SBS-811: SECURITY.md once said secret heuristics were "default on" while
+// AppSettings::default set skip_likely_secrets: false. Pin the shipped default
+// to the security page and Settings copy so they cannot drift again.
+const defaultSkipLikelySecrets = modelsSource.match(
+  /impl Default for AppSettings \{[\s\S]*?skip_likely_secrets:\s*(true|false)/
+)?.[1];
+if (defaultSkipLikelySecrets !== 'true' && defaultSkipLikelySecrets !== 'false') {
+  throw new Error('Could not read skip_likely_secrets from AppSettings::default');
+}
+
+const secretHeuristicLine = securityDoc
+  .split(/\r?\n/)
+  .find((line) => /secret heuristics/i.test(line));
+if (!secretHeuristicLine) {
+  throw new Error('SECURITY.md must document high-confidence secret heuristics');
+}
+
+const securitySaysOn = /\bdefault on\b/i.test(secretHeuristicLine);
+const securitySaysOff = /\b(off by default|opt-in)\b/i.test(secretHeuristicLine);
+if (defaultSkipLikelySecrets === 'false' && (securitySaysOn || !securitySaysOff)) {
+  throw new Error(
+    `Shipped skip_likely_secrets default is off; SECURITY.md must say off by default / opt-in, not default on: ${secretHeuristicLine.trim()}`
+  );
+}
+if (defaultSkipLikelySecrets === 'true' && (!securitySaysOn || securitySaysOff)) {
+  throw new Error(
+    `Shipped skip_likely_secrets default is on; SECURITY.md must say default on: ${secretHeuristicLine.trim()}`
+  );
+}
+
+const skipLikelySecretsDesc = JSON.parse(settingsLocaleText).settings?.skipLikelySecretsDesc;
+if (typeof skipLikelySecretsDesc !== 'string') {
+  throw new Error('Settings locale must describe skipLikelySecrets');
+}
+if (defaultSkipLikelySecrets === 'false' && !/off by default/i.test(skipLikelySecretsDesc)) {
+  throw new Error('Settings copy must say secret heuristics are off by default');
+}
+if (defaultSkipLikelySecrets === 'true' && !/on by default/i.test(skipLikelySecretsDesc)) {
+  throw new Error('Settings copy must say secret heuristics are on by default');
 }
 
 if (!securityDoc.includes('RUSTSEC-2023-0071')) {

--- a/scripts/release-check-helpers.mjs
+++ b/scripts/release-check-helpers.mjs
@@ -1,0 +1,76 @@
+// Shared helpers for scripts/check-release.mjs's SBS-811 secret-heuristics
+// gate. Split out so they can be unit-tested without running the whole
+// release-check script, which reads live repo files (and checks today's
+// date) as soon as it's imported.
+
+/**
+ * Strip Rust line and block comments so a stale commented-out assignment
+ * (e.g. `// skip_likely_secrets: false,`) can never be mistaken for the live
+ * one.
+ */
+export function stripRustComments(source) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+
+/**
+ * Read the shipped `skip_likely_secrets` default out of
+ * `impl Default for AppSettings { fn default() -> Self { Self { ... } } }`.
+ * Comments are stripped first, and the search is anchored to the `Self {`
+ * struct literal inside that specific impl block (found by its true
+ * top-level closing brace, i.e. a `}` at the very start of a line), so
+ * neither a commented-out value above the real one nor an unrelated
+ * `skip_likely_secrets: ...` occurrence elsewhere in the file can be picked
+ * up instead.
+ */
+export function extractDefaultSkipLikelySecrets(modelsSource) {
+  const stripped = stripRustComments(modelsSource);
+  const implMatch = stripped.match(/impl Default for AppSettings \{[\s\S]*?\n\}/);
+  if (!implMatch) return undefined;
+  const selfIndex = implMatch[0].indexOf('Self {');
+  if (selfIndex === -1) return undefined;
+  const structLiteral = implMatch[0].slice(selfIndex);
+  return structLiteral.match(/skip_likely_secrets:\s*(true|false)/)?.[1];
+}
+
+/**
+ * Split a markdown document into logical bullet lines, joining a wrapped
+ * bullet's continuation lines back into the bullet they belong to so a
+ * phrase split across two physical lines is still checked as a whole.
+ */
+export function extractMarkdownBullets(markdown) {
+  const bullets = [];
+  for (const rawLine of markdown.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (/^-\s/.test(line)) {
+      bullets.push(line);
+    } else if (bullets.length > 0 && line !== '') {
+      bullets[bullets.length - 1] += ` ${line}`;
+    }
+  }
+  return bullets;
+}
+
+// Word-boundary phrases, not preceded by "not ", so a sentence like
+// "not opt-in" does not read as saying the default is off. "disabled by
+// default" is accepted deliberately alongside "off by default" / "opt-in".
+const DEFAULT_ON_PATTERN = /(?<!\bnot )\bdefault on\b/i;
+const DEFAULT_OFF_PATTERN = /(?<!\bnot )\b(off by default|opt-in|disabled by default)\b/i;
+
+/**
+ * Find every bullet documenting the secret-heuristics gate and report
+ * whether any of them says the default is on / off. Checking every matching
+ * bullet (not just the first hit) means a second, unrelated mention of
+ * "secret heuristics" cannot shadow the real bullet, and joining wrapped
+ * lines first means a phrase split across two physical lines is still
+ * detected.
+ */
+export function evaluateSecretHeuristicsDoc(securityDoc) {
+  const bullets = extractMarkdownBullets(securityDoc).filter((bullet) =>
+    /secret heuristics/i.test(bullet)
+  );
+  return {
+    bullets,
+    sayOn: bullets.some((bullet) => DEFAULT_ON_PATTERN.test(bullet)),
+    sayOff: bullets.some((bullet) => DEFAULT_OFF_PATTERN.test(bullet)),
+  };
+}

--- a/scripts/release-check-helpers.mjs
+++ b/scripts/release-check-helpers.mjs
@@ -40,11 +40,21 @@ export function extractDefaultSkipLikelySecrets(modelsSource) {
 export function extractMarkdownBullets(markdown) {
   const bullets = [];
   for (const rawLine of markdown.split(/\r?\n/)) {
-    const line = rawLine.trim();
-    if (/^-\s/.test(line)) {
-      bullets.push(line);
-    } else if (bullets.length > 0 && line !== '') {
-      bullets[bullets.length - 1] += ` ${line}`;
+    const trimmed = rawLine.trim();
+    if (/^-\s/.test(trimmed)) {
+      bullets.push(trimmed);
+      continue;
+    }
+    // Only wrapped continuations of the current dash item. Headings, later
+    // paragraphs, and other list markers stay out of the previous bullet.
+    const isContinuation =
+      bullets.length > 0 &&
+      /^\s+\S/.test(rawLine) &&
+      !/^#{1,6}\s/.test(trimmed) &&
+      !/^[-*+]\s/.test(trimmed) &&
+      !/^\d+\.\s/.test(trimmed);
+    if (isContinuation) {
+      bullets[bullets.length - 1] += ` ${trimmed}`;
     }
   }
   return bullets;
@@ -54,7 +64,15 @@ export function extractMarkdownBullets(markdown) {
 // "not opt-in" does not read as saying the default is off. "disabled by
 // default" is accepted deliberately alongside "off by default" / "opt-in".
 const DEFAULT_ON_PATTERN = /(?<!\bnot )\bdefault on\b/i;
-const DEFAULT_OFF_PATTERN = /(?<!\bnot )\b(off by default|opt-in|disabled by default)\b/i;
+export const DEFAULT_OFF_PATTERN = /(?<!\bnot )\b(off by default|opt-in|disabled by default)\b/i;
+
+export function saysDefaultOff(text) {
+  return DEFAULT_OFF_PATTERN.test(text);
+}
+
+export function saysDefaultOn(text) {
+  return DEFAULT_ON_PATTERN.test(text);
+}
 
 /**
  * Find every bullet documenting the secret-heuristics gate and report

--- a/scripts/release-check-helpers.test.mjs
+++ b/scripts/release-check-helpers.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  evaluateSecretHeuristicsDoc,
+  extractDefaultSkipLikelySecrets,
+} from './release-check-helpers.mjs';
+
+test('reads the live default when a stale commented-out value sits above it', () => {
+  const modelsSource = `
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            // skip_likely_secrets: false,
+            skip_likely_secrets: true,
+        }
+    }
+}
+`;
+  assert.equal(extractDefaultSkipLikelySecrets(modelsSource), 'true');
+});
+
+test('ignores a skip_likely_secrets occurrence outside the AppSettings default impl', () => {
+  const modelsSource = `
+// A test helper that also mentions skip_likely_secrets: true, but is not
+// the shipped default.
+fn make_test_settings() -> AppSettings {
+    AppSettings { skip_likely_secrets: true, ..Default::default() }
+}
+
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            skip_likely_secrets: false,
+        }
+    }
+}
+`;
+  assert.equal(extractDefaultSkipLikelySecrets(modelsSource), 'false');
+});
+
+test('returns undefined when there is no AppSettings default impl at all', () => {
+  const modelsSource = 'pub struct AppSettings { pub skip_likely_secrets: bool }';
+  assert.equal(extractDefaultSkipLikelySecrets(modelsSource), undefined);
+});
+
+test('detects a secret-heuristics bullet wrapped across two lines', () => {
+  const securityDoc = `
+- Text that matches high-confidence secret heuristics such as private keys
+  and cloud API tokens (off by default, enable in Settings).
+`;
+  const { bullets, sayOff, sayOn } = evaluateSecretHeuristicsDoc(securityDoc);
+  assert.equal(bullets.length, 1);
+  assert.equal(sayOff, true);
+  assert.equal(sayOn, false);
+});
+
+test('checks every bullet mentioning secret heuristics, not just the first', () => {
+  const securityDoc = `
+- Secret heuristics are mentioned here in an unrelated aside with no on/off phrase.
+- The real bullet: secret heuristics are off by default, opt-in in Settings.
+`;
+  const { sayOff } = evaluateSecretHeuristicsDoc(securityDoc);
+  assert.equal(sayOff, true);
+});
+
+test("does not read 'not opt-in' as saying the default is off", () => {
+  const securityDoc = '- Our secret heuristics are not opt-in; they run automatically.';
+  const { sayOff } = evaluateSecretHeuristicsDoc(securityDoc);
+  assert.equal(sayOff, false);
+});
+
+test("accepts 'disabled by default' as a deliberate off-by-default phrasing", () => {
+  const securityDoc = '- Secret heuristics scanning is disabled by default.';
+  const { sayOff } = evaluateSecretHeuristicsDoc(securityDoc);
+  assert.equal(sayOff, true);
+});

--- a/scripts/release-check-helpers.test.mjs
+++ b/scripts/release-check-helpers.test.mjs
@@ -1,10 +1,17 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
 import {
   evaluateSecretHeuristicsDoc,
   extractDefaultSkipLikelySecrets,
+  extractMarkdownBullets,
+  saysDefaultOff,
 } from './release-check-helpers.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 test('reads the live default when a stale commented-out value sits above it', () => {
   const modelsSource = `
@@ -74,4 +81,38 @@ test("accepts 'disabled by default' as a deliberate off-by-default phrasing", ()
   const securityDoc = '- Secret heuristics scanning is disabled by default.';
   const { sayOff } = evaluateSecretHeuristicsDoc(securityDoc);
   assert.equal(sayOff, true);
+});
+
+test('does not glue a following heading or paragraph onto the previous bullet', () => {
+  const securityDoc = `
+- Text that matches high-confidence secret heuristics such as private keys and cloud API tokens (off by default, enable in Settings).
+## Later
+A later paragraph mentions secret heuristics and says they are default on.
+`;
+  const { sayOn, sayOff } = evaluateSecretHeuristicsDoc(securityDoc);
+  assert.equal(sayOff, true);
+  assert.equal(sayOn, false);
+  const bullets = extractMarkdownBullets(securityDoc);
+  assert.equal(bullets.length, 1);
+  assert.equal(/Later/.test(bullets[0]), false);
+});
+
+test('locale helper accepts the same off-phrasings as the security-doc gate', () => {
+  assert.equal(saysDefaultOff('Off by default. Turn it on in Settings.'), true);
+  assert.equal(saysDefaultOff('Disabled by default.'), true);
+  assert.equal(saysDefaultOff('This is opt-in.'), true);
+  assert.equal(saysDefaultOff('Always on.'), false);
+});
+
+test('live models.rs, SECURITY.md, and en.json agree the default is off', async () => {
+  const models = await readFile(path.join(repoRoot, 'src-tauri/src/models.rs'), 'utf8');
+  const security = await readFile(path.join(repoRoot, 'SECURITY.md'), 'utf8');
+  const en = JSON.parse(
+    await readFile(path.join(repoRoot, 'frontend/src/i18n/locales/en.json'), 'utf8'),
+  );
+  assert.equal(extractDefaultSkipLikelySecrets(models), 'false');
+  const { sayOn, sayOff } = evaluateSecretHeuristicsDoc(security);
+  assert.equal(sayOn, false);
+  assert.equal(sayOff, true);
+  assert.equal(saysDefaultOff(en.settings.skipLikelySecretsDesc), true);
 });


### PR DESCRIPTION
Fixes SBS-811. Product intent is default-off, so this corrects the security page rather than flipping the setting.

## Why this direction

`AppSettings::default` sets `skip_likely_secrets: false` on purpose (`src-tauri/src/models.rs`). The field comment, the Default comment, `secret_privacy_defaults_are_opt_in`, Settings copy (`skipLikelySecretsDesc`: "Off by default"), and the frontend fallback all agree: heuristic sniffing is opt-in because a wrong guess silently drops a clip the user meant to keep. OS sensitive-tag skipping (`skip_sensitive`) and the seeded password-manager ignore list stay default-on.

`SECURITY.md` was the only place that said secret heuristics were "default on".

A user who reads SECURITY.md now sees the same default the app ships and Settings already describes. Existing installs are unchanged.

## What changed

- `SECURITY.md`: secret heuristics are off by default / opt-in; enable in Settings. Category is still logged, never content.
- `scripts/check-release.mjs`: reads `AppSettings::default`, the secret-heuristics line in SECURITY.md, and Settings `skipLikelySecretsDesc`, and fails if they disagree. If someone later flips the Rust default, the security page and Settings copy have to follow or CI fails.

## Sweep

```
rg -n -i "secret heuristic|skip_likely|likely secret|default on" \
  SECURITY.md README.md CHANGELOG.md docs/RELEASE_CHECKLIST.md \
  frontend/src/i18n/locales src-tauri/src/models.rs
```

Hits that remain:

- `SECURITY.md` line 24: Windows `ExcludeClipboardContentFromMonitorProcessing` is still "default on" — that is `skip_sensitive: true` and is correct.
- `models.rs` / Settings / tests: already said off / opt-in. Left them alone.
- Other locales do not define `skipLikelySecretsDesc` (English fallback).
- README does not mention this default.

Open PR #198 already rewrites this SECURITY.md sentence as part of a three-issue batch, but it does not pin `skip_likely_secrets` to the docs. This PR is the focused SBS-811 fix plus that pin.

## Checks

CI-equivalent from `.github/workflows/ci.yml`, run on Linux with fnm Node 24.

**`node scripts/check-release.mjs` — pass after the fix**

```
Cubby Clipboard v1.3.1 release metadata is consistent.
```

**Same check with only the SECURITY.md wording reverted — fail (proves the new gate)**

```
Error: Shipped skip_likely_secrets default is off; SECURITY.md must say off by default / opt-in, not default on: - Text that matches high-confidence secret heuristics such as private keys, cloud API tokens, and grouped payment-card numbers (default on; category logged, never content).
```

**`node --test product_pages/worker.test.mjs product_pages/analytics.test.mjs`**

```
tests 18
pass 18
fail 0
```

**`node .github/scripts/check-site.mjs`**

```
Validated 5 indexable Cubby pages, 404 handling, social metadata, and crawl assets.
```

## What I did not run

- Frontend install/format/build/test/audit: package-manager install was rejected here. No frontend or package files changed.
- cargo fmt / clippy: this box cargo 1.85.0 has neither. rustup has no default toolchain.
- cargo test --all-targets: not run. Cubby is Windows-only. No Rust sources changed.
- test-publish-guard.ps1 and audit-rust.ps1: PowerShell, Windows CI only.

## What this makes more likely

The new gate fails a release if SECURITY.md or Settings copy disagrees with AppSettings::default. A later default-on decision has to update the Rust default, SECURITY.md, and Settings copy together.

It does not make the heuristic fire more often. Capture behavior is unchanged.

## Left out

- No CHANGELOG / version bump: v1.3.1 is already tagged.
- Did not touch PR 198 file-history or Settings-link work.
- Did not add a standalone Node test file; check-release.mjs is the CI gate.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add release checks to enforce secret heuristics are documented as off by default
> - Adds [`release-check-helpers.mjs`](https://github.com/tsouth89/cubby-clipboard/pull/210/files#diff-b226dc2ff9068dad9fcbdf633557126e57d4f14facb28dcb5d5836f1803991f2) with utilities to extract the `skip_likely_secrets` default from `models.rs`, parse markdown bullets, and detect on/off phrasing in copy.
> - Extends [`check-release.mjs`](https://github.com/tsouth89/cubby-clipboard/pull/210/files#diff-14ac66f5d0a1f9e003460f1b27bce6e68f7665390d99e23d897038130d21cdca) to validate that the shipped `skip_likely_secrets` default matches the wording in `SECURITY.md` and the Settings locale string, failing with explicit errors on mismatch.
> - Adds [`release-check-helpers.test.mjs`](https://github.com/tsouth89/cubby-clipboard/pull/210/files#diff-5be1ac4d53ebe5899d8407d30c0211b55d59c7a3d3659645f10805d20629d91d) with unit and integration tests, including a live check that the repo currently agrees the default is off.
> - Registers the new test file in [ci.yml](https://github.com/tsouth89/cubby-clipboard/pull/210/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) so it runs in CI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2d08e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Clipboard text matching secret-like patterns is no longer skipped by default, reducing unexpected drops.
  - Secret detection bypass can now be explicitly enabled in Settings.

- **Documentation**
  - Updated security guidance and Settings descriptions to clearly explain the opt-in behavior.
  - Category logging continues to avoid recording clipboard content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->