### PR TITLE
SBS-778: Pin privileged release Actions to immutable commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,10 @@ updates:
           - "patch"
     open-pull-requests-limit: 10
 
+  # SHA-pinned third-party actions in privileged workflows (release / Store /
+  # signing) are updated here. Dependabot rewrites both the commit pin and the
+  # adjacent version comment. Review the commit range and
+  # docs/RELEASE_CHECKLIST.md before merging; do not retarget a pin to a tag.
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/scripts/check-privileged-action-pins.mjs
+++ b/.github/scripts/check-privileged-action-pins.mjs
@@ -1,0 +1,142 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const PRIVILEGED_WORKFLOWS = [
+  '.github/workflows/release.yml',
+  '.github/workflows/publish-store-packages.yml',
+  '.github/workflows/validate-store-submission.yml',
+];
+
+const FIRST_PARTY_OWNERS = new Set(['actions']);
+const SHA_RE = /^[0-9a-f]{40}$/;
+const USES_RE = /^(?:-\s+)?uses:\s*(?:['"]([^'"]+)['"]|(\S+))/;
+
+/**
+ * SBS-778: third-party actions in privileged workflows must be pinned to a
+ * full commit SHA with a human-readable version comment. First-party
+ * `actions/*` refs may stay mutable. Unknown / unparseable uses fail closed.
+ */
+export function classifyUses(rawSpec, comment) {
+  const spec = rawSpec.trim();
+  if (!spec) {
+    return { ok: false, reason: 'empty uses value', kind: 'unknown' };
+  }
+  if (spec.startsWith('docker://')) {
+    return { ok: false, reason: 'docker:// actions are not SHA-pinned commits', kind: 'docker' };
+  }
+  if (spec.startsWith('./')) {
+    return { ok: true, kind: 'local', spec };
+  }
+
+  const at = spec.lastIndexOf('@');
+  if (at <= 0) {
+    return { ok: false, reason: 'uses is missing an @ref', kind: 'unknown', spec };
+  }
+
+  const action = spec.slice(0, at);
+  const ref = spec.slice(at + 1);
+  const owner = action.split('/')[0];
+
+  if (!action.includes('/')) {
+    return { ok: false, reason: 'unparseable action name', kind: 'unknown', spec };
+  }
+
+  if (FIRST_PARTY_OWNERS.has(owner)) {
+    return { ok: true, kind: 'first-party', spec, action, ref };
+  }
+
+  if (!SHA_RE.test(ref)) {
+    return {
+      ok: false,
+      reason: `third-party action is not pinned to a 40-character commit SHA (ref=${ref})`,
+      kind: 'mutable-third-party',
+      spec,
+      action,
+      ref,
+    };
+  }
+
+  const version = (comment ?? '').replace(/^#\s*/, '').trim();
+  if (!version) {
+    return {
+      ok: false,
+      reason: 'SHA pin is missing an adjacent human-readable version comment',
+      kind: 'missing-version-comment',
+      spec,
+      action,
+      ref,
+    };
+  }
+
+  return { ok: true, kind: 'pinned-third-party', spec, action, ref, version };
+}
+
+export function parseWorkflowUses(text, filePath = 'workflow.yml') {
+  const findings = [];
+  const lines = text.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+    const match = trimmed.match(USES_RE);
+    if (!match) {
+      continue;
+    }
+    const spec = match[1] ?? match[2];
+    const hash = line.indexOf('#');
+    const specAt = line.indexOf(spec);
+    const comment = hash >= 0 && hash > specAt ? line.slice(hash) : '';
+    const classification = classifyUses(spec, comment);
+    findings.push({
+      file: filePath,
+      line: index + 1,
+      spec,
+      comment,
+      ...classification,
+    });
+  }
+  return findings;
+}
+
+export function violationsOf(findings) {
+  return findings.filter((finding) => !finding.ok);
+}
+
+export async function checkPrivilegedActionPins(rootDir) {
+  const findings = [];
+  for (const relativePath of PRIVILEGED_WORKFLOWS) {
+    const text = await readFile(path.join(rootDir, relativePath), 'utf8');
+    findings.push(...parseWorkflowUses(text, relativePath));
+  }
+  return {
+    findings,
+    violations: violationsOf(findings),
+    pinnedThirdParty: findings.filter((finding) => finding.kind === 'pinned-third-party'),
+  };
+}
+
+function repoRootFromHere() {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const root = process.argv[2] ? path.resolve(process.argv[2]) : repoRootFromHere();
+  const { findings, violations, pinnedThirdParty } = await checkPrivilegedActionPins(root);
+  if (violations.length > 0) {
+    for (const violation of violations) {
+      console.error(
+        `${violation.file}:${violation.line}: ${violation.reason} (${violation.spec})`,
+      );
+    }
+    console.error(
+      `Privileged workflow pin check failed: ${violations.length} mutable or unknown third-party uses.`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    `Privileged workflow pin check passed: ${pinnedThirdParty.length} SHA-pinned third-party actions, ${findings.length} uses scanned.`,
+  );
+}

--- a/.github/scripts/check-privileged-action-pins.mjs
+++ b/.github/scripts/check-privileged-action-pins.mjs
@@ -9,8 +9,8 @@ export const PRIVILEGED_WORKFLOWS = [
 ];
 
 const FIRST_PARTY_OWNERS = new Set(['actions']);
-const SHA_RE = /^[0-9a-f]{40}$/;
-const USES_RE = /^(?:-\s+)?uses:\s*(?:['"]([^'"]+)['"]|(\S+))/;
+const SHA_RE = /^[0-9a-f]{40}$/i;
+const USES_RE = /^(?:-\s+)?uses\s*:\s*(?:['"]([^'"]+)['"]|(\S+))/;
 
 /**
  * SBS-778: third-party actions in privileged workflows must be pinned to a

--- a/.github/scripts/check-privileged-action-pins.test.mjs
+++ b/.github/scripts/check-privileged-action-pins.test.mjs
@@ -53,6 +53,20 @@ test('SHA pin without a version comment fails', () => {
   assert.equal(result.kind, 'missing-version-comment');
 });
 
+test('uses line with a space before the colon is still parsed', () => {
+  const findings = parseWorkflowUses('  uses : evil/action@v1\n', 'sample.yml');
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].spec, 'evil/action@v1');
+  assert.equal(findings[0].ok, false);
+  assert.equal(findings[0].kind, 'mutable-third-party');
+});
+
+test('uppercase 40-character SHA is accepted as a valid pin', () => {
+  const result = classifyUses(`foo/bar@${'A'.repeat(40)}`, '# v1');
+  assert.equal(result.ok, true);
+  assert.equal(result.kind, 'pinned-third-party');
+});
+
 test('commented-out uses lines are ignored', () => {
   const findings = parseWorkflowUses(
     '# uses: evil/action@v1\n      - uses: actions/checkout@v7\n',

--- a/.github/scripts/check-privileged-action-pins.test.mjs
+++ b/.github/scripts/check-privileged-action-pins.test.mjs
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import {
+  PRIVILEGED_WORKFLOWS,
+  checkPrivilegedActionPins,
+  classifyUses,
+  parseWorkflowUses,
+} from './check-privileged-action-pins.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+test('SHA pin with a version comment is accepted', () => {
+  const result = classifyUses(
+    'azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca',
+    '# v3.0.1',
+  );
+  assert.equal(result.ok, true);
+  assert.equal(result.kind, 'pinned-third-party');
+  assert.equal(result.version, 'v3.0.1');
+});
+
+test('mutable major and floating tags fail closed', () => {
+  for (const spec of ['azure/login@v3', 'dtolnay/rust-toolchain@stable', 'taiki-e/install-action@v2.85.10']) {
+    const result = classifyUses(spec, '');
+    assert.equal(result.ok, false, spec);
+    assert.equal(result.kind, 'mutable-third-party', spec);
+  }
+});
+
+test('first-party actions may stay on a mutable tag', () => {
+  const result = classifyUses('actions/checkout@v7', '');
+  assert.equal(result.ok, true);
+  assert.equal(result.kind, 'first-party');
+});
+
+test('local composite actions are allowed', () => {
+  const result = classifyUses('./.github/actions/sign', '');
+  assert.equal(result.ok, true);
+  assert.equal(result.kind, 'local');
+});
+
+test('SHA pin without a version comment fails', () => {
+  const result = classifyUses(
+    'softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228',
+    '',
+  );
+  assert.equal(result.ok, false);
+  assert.equal(result.kind, 'missing-version-comment');
+});
+
+test('commented-out uses lines are ignored', () => {
+  const findings = parseWorkflowUses(
+    '# uses: evil/action@v1\n      - uses: actions/checkout@v7\n',
+    'sample.yml',
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].spec, 'actions/checkout@v7');
+});
+
+test('docker:// and missing @ref are unknown-fail, not empty-ok', () => {
+  assert.equal(classifyUses('docker://alpine:3', '').ok, false);
+  assert.equal(classifyUses('docker://alpine:3', '').kind, 'docker');
+  assert.equal(classifyUses('owner/action', '').ok, false);
+  assert.equal(classifyUses('owner/action', '').kind, 'unknown');
+  assert.equal(classifyUses('', '').kind, 'unknown');
+});
+
+test('parser keeps the version comment that sits after the spec', () => {
+  const findings = parseWorkflowUses(
+    '        uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0 # v1.4\n',
+    'sample.yml',
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].ok, true);
+  assert.equal(findings[0].version, 'v1.4');
+});
+
+test('checker fails a privileged workflow that still uses a mutable third-party tag', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'sbs-778-'));
+  await mkdir(path.join(root, '.github', 'workflows'), { recursive: true });
+  for (const relativePath of PRIVILEGED_WORKFLOWS) {
+    const body =
+      relativePath.endsWith('release.yml')
+        ? 'jobs:\n  build:\n    steps:\n      - uses: azure/login@v3\n'
+        : 'jobs:\n  publish:\n    steps:\n      - uses: actions/checkout@v7\n';
+    await writeFile(path.join(root, relativePath), body);
+  }
+  const { violations } = await checkPrivilegedActionPins(root);
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].reason, /not pinned to a 40-character commit SHA/);
+  assert.equal(violations[0].spec, 'azure/login@v3');
+});
+
+/** Pins SBS-778: a retargeted @v3/@stable in release.yml must fail this suite. */
+test('shipped privileged workflows have no mutable third-party uses', async () => {
+  const { violations, pinnedThirdParty, findings } = await checkPrivilegedActionPins(repoRoot);
+  assert.deepEqual(
+    violations,
+    [],
+    violations.map((item) => `${item.file}:${item.line} ${item.reason}`).join('\n'),
+  );
+  assert.ok(findings.length > 0, 'expected to scan at least one uses: line');
+  assert.ok(
+    pinnedThirdParty.length > 0,
+    'expected at least one SHA-pinned third-party action in privileged workflows',
+  );
+});
+
+/** Pins SBS-778 wiring: the existing release:check gate must invoke the checker. */
+test('release:check imports the privileged pin checker', async () => {
+  const source = await readFile(path.join(repoRoot, 'scripts/check-release.mjs'), 'utf8');
+  assert.match(source, /checkPrivilegedActionPins/);
+});
+
+/** Pins SBS-778: Dependabot must keep proposing reviewed github-actions pin updates. */
+test('Dependabot is configured to propose GitHub Actions pin updates', async () => {
+  const source = await readFile(path.join(repoRoot, '.github/dependabot.yml'), 'utf8');
+  assert.match(source, /package-ecosystem:\s*github-actions/);
+  assert.match(source, /RELEASE_CHECKLIST/);
+});
+
+/** Pins SBS-778: the review procedure for pin upgrades must stay in the checklist. */
+test('release checklist documents the action-upgrade review procedure', async () => {
+  const source = await readFile(path.join(repoRoot, 'docs/RELEASE_CHECKLIST.md'), 'utf8');
+  assert.match(source, /SBS-778/);
+  assert.match(source, /Do not retarget/);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,9 @@ jobs:
       - run: pnpm run release:check
       - run: pnpm run build
       - run: node .github/scripts/check-site.mjs
+      - run: node .github/scripts/check-privileged-action-pins.mjs
       - run: pnpm run test
-      - run: node --test product_pages/worker.test.mjs product_pages/analytics.test.mjs
+      - run: node --test product_pages/worker.test.mjs product_pages/analytics.test.mjs .github/scripts/check-privileged-action-pins.test.mjs
       - run: pnpm audit --prod
       # The rule that decides whether a live download URL may be overwritten.
       - name: Publish-guard rules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 9
 
@@ -33,19 +33,19 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: clippy, rustfmt
 
       # Cache the cargo registry + src-tauri/target across runs so the cargo test
       # and clippy compiles below are incremental instead of cold every run.
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri
 
       # Install a prebuilt cargo-audit binary instead of compiling it from source
       # (cargo install cargo-audit) on every run.
-      - uses: taiki-e/install-action@v2.85.12
+      - uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
         with:
           tool: cargo-audit
 
@@ -160,7 +160,7 @@ jobs:
 
       - name: Create release
         id: release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ steps.metadata.outputs.tag }}
           name: ${{ steps.metadata.outputs.name }}
@@ -199,7 +199,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 9
 
@@ -210,13 +210,13 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: ${{ matrix.target }}
 
       # Per-target cargo cache (keyed by matrix.target so x64 and arm64 don't
       # clobber each other) to keep the installer compiles incremental.
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri
           key: ${{ matrix.target }}
@@ -231,7 +231,7 @@ jobs:
       # credentials to Invoke-ArtifactSigning, via its DefaultAzureCredential
       # chain.
       - name: Sign in to Azure with GitHub OIDC
-        uses: azure/login@v3
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -246,7 +246,7 @@ jobs:
         run: Install-Module -Name ArtifactSigning -RequiredVersion 0.1.8 -Force -Repository PSGallery
 
       - name: Build NSIS installer
-        uses: tauri-apps/tauri-action@v1
+        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
         env:
           # createUpdaterArtifacts is on, so the build needs the updater key.
           # This produces a .sig over the UNSIGNED installer; it is regenerated
@@ -355,7 +355,7 @@ jobs:
       # because the Store installer is copied out to a staging path after the
       # build and the updater .sig has to be regenerated over the final bytes.
       - name: Sign the installers with Trusted Signing
-        uses: Azure/artifact-signing-action@v2
+        uses: Azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           endpoint: ${{ vars.ARTIFACT_SIGNING_ENDPOINT }}
           signing-account-name: ${{ vars.ARTIFACT_SIGNING_ACCOUNT_NAME }}
@@ -460,7 +460,7 @@ jobs:
 
       - name: Sign the portable executable
         if: matrix.arch == 'x64'
-        uses: Azure/artifact-signing-action@v2
+        uses: Azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           endpoint: ${{ vars.ARTIFACT_SIGNING_ENDPOINT }}
           signing-account-name: ${{ vars.ARTIFACT_SIGNING_ACCOUNT_NAME }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 
 ## Unreleased
 
+### Security
+- Pin third-party GitHub Actions in privileged release and Store workflows to immutable commit SHAs, and reject new mutable pins in CI
+
 ### Fixed
 - Backup export, backup import, and Ditto import now only write or read a path chosen in the file dialog, so a compromised Settings page cannot send history to an arbitrary location (SBS-808)
 
@@ -26,7 +29,6 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - Accessibility problems found by a static audit, including missing names for icon-only buttons
 
 ### Changed
-- Pin third-party GitHub Actions in privileged release and Store workflows to immutable commit SHAs
 - Search uses roughly a fifth of the memory it used to per clip, and returns results faster on a large history
 - Refreshed the interface icon set. The filter, settings, shield, play, pause, file, and flask icons are redrawn with the same meanings and slightly different shapes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - Accessibility problems found by a static audit, including missing names for icon-only buttons
 
 ### Changed
+- Pin third-party GitHub Actions in privileged release and Store workflows to immutable commit SHAs
 - Search uses roughly a fifth of the memory it used to per clip, and returns results faster on a large history
 - Refreshed the interface icon set. The filter, settings, shield, play, pause, file, and flask icons are redrawn with the same meanings and slightly different shapes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ pnpm run release:check
 pnpm run build
 node .github/scripts/check-site.mjs
 pnpm run test
-node --test product_pages/worker.test.mjs product_pages/analytics.test.mjs
+node --test product_pages/worker.test.mjs product_pages/analytics.test.mjs .github/scripts/check-privileged-action-pins.test.mjs
 
 Push-Location src-tauri
 cargo fmt --check

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,11 @@ Cubby release candidates must pass the JavaScript production dependency audit, t
 - Reviewed: 2026-07-19
 - Next review: 2026-10-19 (or immediately if SQLx or the lockfile graph changes)
 
+
+## Privileged GitHub Actions pins
+
+Third-party actions in privileged release, Store, and signing workflows must be pinned to a 40-character commit SHA with a version comment. See docs/RELEASE_CHECKLIST.md for reviewing Dependabot action pin updates.
+
 ## Sensitive clipboard handling
 
 In addition to AES-256-GCM at rest, Cubby skips:

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -47,7 +47,7 @@ Run from the repository root on Windows:
 
 That script enforces:
 
-- Release metadata consistency (`pnpm run release:check`), including CSP, scoped Tauri capabilities, encrypted-storage invariants, secret-aware privacy gates, and the no-`dangerouslySetInnerHTML` frontend check.
+- Release metadata consistency (`pnpm run release:check`), including CSP, scoped Tauri capabilities, encrypted-storage invariants, secret-aware privacy gates, the no-`dangerouslySetInnerHTML` frontend check, and the privileged-workflow action pin check.
 - JavaScript production dependency audit (`pnpm audit --prod`).
 - Target-aware Rust advisory audit (`./scripts/audit-rust.ps1`), including the documented RSA waiver.
 - Frontend production build.
@@ -139,3 +139,21 @@ payload. A Settings/About surface for this status is still optional.
 - Do not enable Winget publishing until `SouthForgeAI.CubbyClipboard` is reserved and the installer identity is final.
 - Do not submit to Microsoft Store until Partner Center identity, signing, privacy text, and clean upgrade/uninstall behavior are verified.
 - Keep GPL-3.0 source, `NOTICE.md`, and PastePaw attribution available with every release.
+
+## Privileged GitHub Action pins (SBS-778)
+
+Release, Store, and signing workflows may only consume third-party Actions by
+full commit SHA, with the human-readable version in an adjacent comment. First-party
+`actions/*` refs may stay on a major tag. The release metadata check and CI run
+`.github/scripts/check-privileged-action-pins.mjs` and reject a new mutable
+third-party `uses:` line.
+
+When Dependabot opens an actions pin update:
+
+1. Read the action changelog and the commit range, not only the new SHA.
+2. Confirm the pin is a 40-character commit object (not an annotated-tag SHA).
+3. Confirm the adjacent `# version` comment still names the reviewed release.
+4. Run `node .github/scripts/check-privileged-action-pins.mjs` and
+   `node --test .github/scripts/check-privileged-action-pins.test.mjs`.
+5. Merge the pin update. Do not retarget the `uses:` ref back to a floating
+   tag such as `@v3` or `@stable`.

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -2,6 +2,8 @@ import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { checkPrivilegedActionPins } from '../.github/scripts/check-privileged-action-pins.mjs';
+
 const root = new URL('../', import.meta.url);
 const rootDir = fileURLToPath(root);
 const read = (relativePath) => readFile(new URL(relativePath, root), 'utf8');
@@ -238,6 +240,14 @@ for (const inheritedIdentity of ['PastePaw', 'XueshiQiao.PastePaw', 'XueshiQiao.
   if (releaseWorkflow.includes(inheritedIdentity)) {
     throw new Error(`Release workflow still contains inherited identity: ${inheritedIdentity}`);
   }
+}
+
+const pinCheck = await checkPrivilegedActionPins(rootDir);
+if (pinCheck.violations.length > 0) {
+  const details = pinCheck.violations
+    .map((item) => `${item.file}:${item.line}: ${item.reason} (${item.spec})`)
+    .join('; ');
+  throw new Error(`Privileged workflows have mutable third-party actions: ${details}`);
 }
 
 console.log(`Cubby Clipboard v${version} release metadata is consistent.`);


### PR DESCRIPTION
## Summary

Privileged release, Store, and signing workflows now pin third-party GitHub Actions to immutable commit SHAs with version comments. CI rejects a new mutable third-party uses line in those files. Dependabot already updates github-actions; reviewers should follow docs/RELEASE_CHECKLIST.md.

A signed release still produces the same installers. A retargeted upstream tag can no longer run in the job that holds write and Trusted Signing credentials.

Linear: https://linear.app/southboundsoftware/issue/SBS-778/pin-privileged-release-actions-to-immutable-commits

## Checks

- node --test .github/scripts/check-privileged-action-pins.test.mjs — 13/13 pass
- node scripts/check-release.mjs — v1.3.1 metadata consistent
- pin checker — 14 SHA-pinned third-party actions, 25 uses scanned
- Reverted only release.yml to origin/main: live-file test failed on @v6/@stable/@v2/@v3/@v1. Restored pins: pass.

Not run here: format:check (frontend/src untouched), cargo test/clippy, vitest. Required CI is windows-latest.

## Left out

Did not pin actions/* or ci.yml third-party tags. Did not merge. Did not change Linear state.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin third-party GitHub Actions in privileged release workflows to immutable commit SHAs
> - Replaces mutable tag refs with 40-character commit SHA pins (plus inline version comments) for all third-party actions in [release.yml](.github/workflows/release.yml) and related Store workflows.
> - Adds [check-privileged-action-pins.mjs](.github/scripts/check-privileged-action-pins.mjs), a script that parses privileged workflow files and rejects any third-party action not pinned to a full SHA with a version comment.
> - Integrates the checker into CI ([ci.yml](.github/workflows/ci.yml)) and the pre-release gate ([check-release.mjs](scripts/check-release.mjs)) so builds and releases fail on violations.
> - Configures Dependabot ([dependabot.yml](.github/dependabot.yml)) to update SHA-pinned actions weekly, with review guidance in the release checklist and `SECURITY.md`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ea9269.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->