### PR TITLE
SBS-769: Revive expired image originals when the image is copied again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - Backup export, backup import, and Ditto import now only write or read a path chosen in the file dialog, so a compromised Settings page cannot send history to an arbitrary location (SBS-808)
 - Refuse an encrypted backup export when any live clip field cannot be fully decrypted, and leave an existing destination file unchanged (SBS-772)
 - Refresh the rolling history backup during long-running sessions, so a machine that stays up past a day still gets a current `cubby.db.bak` without quitting Cubby (SBS-771)
+- Revive an expired screenshot original when that same image is copied again, including a consecutive duplicate that used to be skipped, so Paste and Copy work immediately and recognized text stays (SBS-769)
 
 ## v1.3.1
 

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -2074,40 +2074,15 @@ async fn process_clipboard_snapshot(
                 );
                 return;
             }
-
-            if let Some(full_bytes) = &full_image_content {
-                // Persist, then index + clear `full_image_expired` only if that
-                // write succeeded. The UPDATE above must not clear the flag:
-                // a failed file write would then claim a usable original (SBS-769).
-                match restore_existing_image_original(
-                    &db.crypto,
-                    pool,
-                    &db.image_dir,
-                    &existing_id,
-                    full_bytes,
-                )
-                .await
-                {
-                    Ok(_) => {}
-                    Err(PersistIndexedImageError::Persist(error)) => {
-                        // SBS-836: keep the thumbnail-only clip. The expired
-                        // flag stays set so paste/copy still refuse.
-                        log::error!(
-                            "Failed to persist full image file for existing clip {}: {}",
-                            existing_id,
-                            error
-                        );
-                    }
-                    Err(PersistIndexedImageError::Index(error)) => {
-                        log::error!(
-                            "CLIPBOARD: Failed to index image file for existing clip {}: {}",
-                            existing_id,
-                            error
-                        );
-                        return;
-                    }
-                }
-            }
+            // No second pass over the same file. `recapture_existing_image`
+            // above already staged the original, upserted `clip_images`, and
+            // cleared `full_image_expired` in one transaction. Writing
+            // `{uuid}.cubby` again here was not just wasted work: it was the
+            // only place the expired flag was cleared, so a failure of that
+            // second write (no room for another temp copy, or Windows refusing
+            // to replace the file recapture had just created) left the original
+            // on disk and indexed while Paste and Copy went on refusing it as
+            // expired (SBS-769).
         } else {
             if let Err(error) = sqlx::query(r#"UPDATE clips SET created_at = CURRENT_TIMESTAMP, is_deleted = 0, source_app = ?, source_icon = ? WHERE uuid = ?"#)
                 .bind(&encrypted_source_app)
@@ -2708,66 +2683,6 @@ pub(crate) async fn lookup_stored_original(
 
 /// Why restoring an existing image original failed.
 ///
-/// Persist failure is SBS-836 (keep the thumbnail-only clip). Index failure
-/// aborts the rest of capture so we do not mark the hash stable after a
-/// half-written revival.
-#[derive(Debug)]
-pub(crate) enum PersistIndexedImageError {
-    Persist(String),
-    Index(String),
-}
-
-impl std::fmt::Display for PersistIndexedImageError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Persist(error) | Self::Index(error) => f.write_str(error),
-        }
-    }
-}
-
-/// Persist original bytes, index `clip_images`, then clear `full_image_expired`
-/// only after both the file write and the index succeed in one transaction.
-///
-/// The clips-row UPDATE that runs before this must not clear the flag: a
-/// failed write would then claim a usable original that is not there (SBS-769).
-pub(crate) async fn restore_existing_image_original(
-    crypto: &crate::crypto::CryptoManager,
-    pool: &sqlx::SqlitePool,
-    image_dir: &std::path::Path,
-    clip_uuid: &str,
-    png_bytes: &[u8],
-) -> Result<String, PersistIndexedImageError> {
-    let file_path = persist_full_image_file(crypto, image_dir, clip_uuid, png_bytes)
-        .map_err(PersistIndexedImageError::Persist)?;
-
-    let mut transaction = pool
-        .begin()
-        .await
-        .map_err(|error| PersistIndexedImageError::Index(error.to_string()))?;
-    sqlx::query(
-        r#"
-        INSERT OR REPLACE INTO clip_images (clip_uuid, full_content, file_path, file_size, storage_kind, mime_type, created_at)
-        VALUES (?, x'', ?, ?, 'file', 'image/png', CURRENT_TIMESTAMP)
-        "#,
-    )
-    .bind(clip_uuid)
-    .bind(&file_path)
-    .bind(png_bytes.len() as i64)
-    .execute(&mut *transaction)
-    .await
-    .map_err(|error| PersistIndexedImageError::Index(error.to_string()))?;
-    sqlx::query("UPDATE clips SET full_image_expired = 0 WHERE uuid = ?")
-        .bind(clip_uuid)
-        .execute(&mut *transaction)
-        .await
-        .map_err(|error| PersistIndexedImageError::Index(error.to_string()))?;
-    transaction
-        .commit()
-        .await
-        .map_err(|error| PersistIndexedImageError::Index(error.to_string()))?;
-    Ok(file_path)
-}
-
 pub fn read_full_image_file(
     crypto: &crate::crypto::CryptoManager,
     file_path: &str,
@@ -3696,11 +3611,12 @@ mod tests {
 
     mod revive_expired_original {
         use super::super::{
-            consecutive_dedup_decision, lookup_stored_original, restore_existing_image_original,
-            ConsecutiveDedupDecision, PersistIndexedImageError, StoredOriginalLookup,
+            consecutive_dedup_decision, lookup_stored_original, persist_full_image_file,
+            recapture_existing_image, ConsecutiveDedupDecision, StoredOriginalLookup,
         };
         use crate::commands::{load_full_image_content, IMAGE_EXPIRED_ERROR};
         use crate::database::Database;
+        use crate::image_persist::RecaptureFields;
         use crate::models::Clip;
         use sqlx::sqlite::SqlitePoolOptions;
         use std::sync::Arc;
@@ -3779,6 +3695,24 @@ mod tests {
             let _ = std::fs::remove_dir_all(&database.image_dir);
         }
 
+        /// The recapture the capture loop performs for an existing image clip:
+        /// stage the original, rewrite the row, index it, then swap the file in.
+        async fn recapture(database: &Database, uuid: &str, bytes: &[u8]) -> Result<(), String> {
+            recapture_existing_image(
+                database,
+                uuid,
+                bytes,
+                RecaptureFields {
+                    source_app: &None,
+                    source_icon: &None,
+                    content: THUMBNAIL,
+                    preview: "[Image]",
+                    metadata: None,
+                },
+            )
+            .await
+        }
+
         /// SBS-769: re-copying an expired image wrote fresh bytes but left
         /// `full_image_expired` set, so paste/copy still rejected the original.
         #[tokio::test]
@@ -3794,15 +3728,9 @@ mod tests {
                 IMAGE_EXPIRED_ERROR
             );
 
-            restore_existing_image_original(
-                &database.crypto,
-                &database.pool,
-                &database.image_dir,
-                "shot",
-                ORIGINAL,
-            )
-            .await
-            .expect("revival should persist the original");
+            recapture(&database, "shot", ORIGINAL)
+                .await
+                .expect("revival should persist the original");
 
             assert_eq!(expired_flag(&database, "shot").await, 0);
             let mut revived = load_clip(&database, "shot").await;
@@ -3850,15 +3778,9 @@ mod tests {
                 ConsecutiveDedupDecision::Capture
             );
 
-            restore_existing_image_original(
-                &database.crypto,
-                &database.pool,
-                &database.image_dir,
-                "shot",
-                ORIGINAL,
-            )
-            .await
-            .expect("revival after a consecutive match should persist");
+            recapture(&database, "shot", ORIGINAL)
+                .await
+                .expect("revival after a consecutive match should persist");
 
             assert_eq!(expired_flag(&database, "shot").await, 0);
             assert_eq!(
@@ -3891,16 +3813,13 @@ mod tests {
             std::fs::write(&persist_fail_db.image_dir, b"not-a-directory")
                 .expect("image_dir should be a file so persist cannot create it");
 
-            let persist_err = restore_existing_image_original(
-                &persist_fail_db.crypto,
-                &persist_fail_db.pool,
-                &persist_fail_db.image_dir,
-                "shot",
-                ORIGINAL,
-            )
-            .await
-            .expect_err("persist must fail when image_dir is a file");
-            assert!(matches!(persist_err, PersistIndexedImageError::Persist(_)));
+            let persist_err = recapture(&persist_fail_db, "shot", ORIGINAL)
+                .await
+                .expect_err("staging must fail when image_dir is a file");
+            assert!(
+                persist_err.contains("persist"),
+                "the error should describe the failed write: {persist_err}"
+            );
             assert_eq!(expired_flag(&persist_fail_db, "shot").await, 1);
             let persist_index_rows: i64 =
                 sqlx::query_scalar("SELECT COUNT(*) FROM clip_images WHERE clip_uuid = 'shot'")
@@ -3917,19 +3836,114 @@ mod tests {
                 .await
                 .expect("dropping clip_images should force an index failure");
 
-            let index_err = restore_existing_image_original(
-                &index_fail_db.crypto,
-                &index_fail_db.pool,
-                &index_fail_db.image_dir,
+            let index_err = recapture(&index_fail_db, "shot", ORIGINAL)
+                .await
+                .expect_err("index must fail when clip_images is missing");
+            assert!(
+                index_err.contains("index"),
+                "the error should describe the failed index: {index_err}"
+            );
+            assert_eq!(expired_flag(&index_fail_db, "shot").await, 1);
+            // Review finding on PR #214: the write must not leave an orphan
+            // behind. Staging handles that on its own -- the temp file is only
+            // renamed onto `{uuid}.cubby` after the transaction commits, so a
+            // failed index leaves neither an original nor a stray temp.
+            assert!(
+                !index_fail_db.image_dir.join("shot.cubby").exists(),
+                "a failed index must not leave an unindexed original behind"
+            );
+            assert!(
+                !index_fail_db.image_dir.join("shot.cubby.tmp").exists(),
+                "a failed index must not leave the staged temp file behind"
+            );
+
+            cleanup(&index_fail_db);
+        }
+
+        /// Review finding on PR #214: a non-consecutive duplicate re-copy
+        /// reaches the recapture with `full_image_expired` already 0, so the
+        /// path can hold a valid original that a live `clip_images` row points
+        /// at. A failed recapture must leave that file exactly as it was
+        /// rather than stranding the row that describes it.
+        #[tokio::test]
+        async fn a_failed_recapture_does_not_disturb_a_preexisting_original() {
+            let database = test_database().await;
+            seed_expired_image(&database, "shot", "hash-shot").await;
+            // Clear the expired flag to model an original that is already
+            // valid, then write the file this recapture would replace.
+            sqlx::query("UPDATE clips SET full_image_expired = 0 WHERE uuid = 'shot'")
+                .execute(&database.pool)
+                .await
+                .expect("clearing the expired flag should succeed");
+            let existing_path =
+                persist_full_image_file(&database.crypto, &database.image_dir, "shot", ORIGINAL)
+                    .expect("seeding the pre-existing original should succeed");
+            let existing_bytes =
+                std::fs::read(&existing_path).expect("the seeded original should be readable");
+
+            sqlx::query("DROP TABLE clip_images")
+                .execute(&database.pool)
+                .await
+                .expect("dropping clip_images should force an index failure");
+
+            let index_err = recapture(
+                &database,
                 "shot",
-                ORIGINAL,
+                b"different-bytes-from-a-racing-recapture",
             )
             .await
             .expect_err("index must fail when clip_images is missing");
-            assert!(matches!(index_err, PersistIndexedImageError::Index(_)));
-            assert_eq!(expired_flag(&index_fail_db, "shot").await, 1);
+            assert!(
+                index_err.contains("index"),
+                "the error should describe the failed index: {index_err}"
+            );
+            assert_eq!(
+                std::fs::read(&existing_path).expect("the original must still be there"),
+                existing_bytes,
+                "a file that already existed must survive a failed recapture untouched"
+            );
 
-            cleanup(&index_fail_db);
+            cleanup(&database);
+        }
+
+        /// The whole point of SBS-769, end to end: one recapture is what makes
+        /// an expired clip usable again. Nothing runs after it to clear the
+        /// flag, so the row, the index, and the file must all be correct when
+        /// that single call returns.
+        #[tokio::test]
+        async fn one_recapture_leaves_the_clip_fully_usable() {
+            let database = test_database().await;
+            seed_expired_image(&database, "shot", "hash-shot").await;
+
+            recapture(&database, "shot", ORIGINAL)
+                .await
+                .expect("the recapture should succeed");
+
+            assert_eq!(
+                expired_flag(&database, "shot").await,
+                0,
+                "the recapture transaction must clear the expired flag itself"
+            );
+            let indexed: (String, i64) = sqlx::query_as(
+                "SELECT file_path, file_size FROM clip_images WHERE clip_uuid = 'shot'",
+            )
+            .fetch_one(&database.pool)
+            .await
+            .expect("the recapture should have indexed the original");
+            assert_eq!(indexed.1, ORIGINAL.len() as i64);
+            assert!(
+                std::path::Path::new(&indexed.0).exists(),
+                "clip_images must point at a file that is actually on disk"
+            );
+            let mut revived = load_clip(&database, "shot").await;
+            assert_eq!(
+                load_full_image_content(&database, &mut revived)
+                    .await
+                    .expect("Paste and Copy must work after one recapture"),
+                ORIGINAL
+            );
+
+            cleanup(&database);
         }
     }
 }

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -1923,10 +1923,20 @@ async fn process_clipboard_snapshot(
 
     // Only accepted content participates in consecutive duplicate suppression.
     // An ignored application must not prevent the same content from being captured later.
+    //
+    // Hash equality alone is not enough for images: retention can expire the
+    // stored original while LAST_STABLE_HASH still holds this hash, and
+    // skipping here would never revive it (SBS-769). Look up the stored row
+    // when the hashes match. Text keeps today's skip.
+    let storage_hash = db.crypto.keyed_hash(&hash_material);
     {
-        let lock = LAST_STABLE_HASH.lock();
-        if let Some(ref last_hash) = *lock {
-            if last_hash == &clip_hash {
+        let consecutive_match = LAST_STABLE_HASH.lock().as_ref() == Some(&clip_hash);
+        if consecutive_match {
+            if clip_type != "image" {
+                return;
+            }
+            let stored = lookup_stored_original(&db.pool, &storage_hash).await;
+            if consecutive_dedup_decision(stored) == ConsecutiveDedupDecision::Skip {
                 return;
             }
         }
@@ -1943,7 +1953,6 @@ async fn process_clipboard_snapshot(
 
     // DB Logic
     let pool = &db.pool;
-    let storage_hash = db.crypto.keyed_hash(&hash_material);
     let encrypted_content = match db.crypto.encrypt(&clip_content) {
         Ok(content) => content,
         Err(error) => {
@@ -2064,6 +2073,40 @@ async fn process_clipboard_snapshot(
                     error
                 );
                 return;
+            }
+
+            if let Some(full_bytes) = &full_image_content {
+                // Persist, then index + clear `full_image_expired` only if that
+                // write succeeded. The UPDATE above must not clear the flag:
+                // a failed file write would then claim a usable original (SBS-769).
+                match restore_existing_image_original(
+                    &db.crypto,
+                    pool,
+                    &db.image_dir,
+                    &existing_id,
+                    full_bytes,
+                )
+                .await
+                {
+                    Ok(_) => {}
+                    Err(PersistIndexedImageError::Persist(error)) => {
+                        // SBS-836: keep the thumbnail-only clip. The expired
+                        // flag stays set so paste/copy still refuse.
+                        log::error!(
+                            "Failed to persist full image file for existing clip {}: {}",
+                            existing_id,
+                            error
+                        );
+                    }
+                    Err(PersistIndexedImageError::Index(error)) => {
+                        log::error!(
+                            "CLIPBOARD: Failed to index image file for existing clip {}: {}",
+                            existing_id,
+                            error
+                        );
+                        return;
+                    }
+                }
             }
         } else {
             if let Err(error) = sqlx::query(r#"UPDATE clips SET created_at = CURRENT_TIMESTAMP, is_deleted = 0, source_app = ?, source_icon = ? WHERE uuid = ?"#)
@@ -2600,6 +2643,129 @@ async fn recapture_existing_image(
             Err(error)
         }
     }
+}
+
+/// How a consecutive-hash match should be treated once we have looked up the
+/// stored row (SBS-769).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConsecutiveDedupDecision {
+    Skip,
+    Capture,
+}
+
+/// Result of looking up the stored clip for a consecutive-hash match.
+///
+/// Three states, not two: a failed lookup is not "no row".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StoredOriginalLookup {
+    /// No clip with this hash is stored. Today's skip still applies.
+    Missing,
+    /// Row exists; `true` means retention expired the original.
+    Found { full_image_expired: bool },
+    /// The database could not be read. Treat as unknown: do not skip.
+    Unknown,
+}
+
+/// Decide whether a consecutive-hash match should skip capture.
+///
+/// Today's helper skipped whenever the hashes matched. That drops revival
+/// after retention expires an original: `LAST_STABLE_HASH` still holds the
+/// hash, so the re-copy never reaches the persist path.
+pub(crate) fn consecutive_dedup_decision(stored: StoredOriginalLookup) -> ConsecutiveDedupDecision {
+    match stored {
+        StoredOriginalLookup::Missing => ConsecutiveDedupDecision::Skip,
+        StoredOriginalLookup::Found {
+            full_image_expired: false,
+        } => ConsecutiveDedupDecision::Skip,
+        StoredOriginalLookup::Found {
+            full_image_expired: true,
+        }
+        | StoredOriginalLookup::Unknown => ConsecutiveDedupDecision::Capture,
+    }
+}
+
+pub(crate) async fn lookup_stored_original(
+    pool: &sqlx::SqlitePool,
+    storage_hash: &str,
+) -> StoredOriginalLookup {
+    match sqlx::query_scalar::<_, bool>(
+        "SELECT full_image_expired FROM clips WHERE content_hash = ?",
+    )
+    .bind(storage_hash)
+    .fetch_optional(pool)
+    .await
+    {
+        Ok(None) => StoredOriginalLookup::Missing,
+        Ok(Some(full_image_expired)) => StoredOriginalLookup::Found { full_image_expired },
+        Err(error) => {
+            log::warn!(
+                "CLIPBOARD: could not look up stored original for consecutive-dedup: {error}"
+            );
+            StoredOriginalLookup::Unknown
+        }
+    }
+}
+
+/// Why restoring an existing image original failed.
+///
+/// Persist failure is SBS-836 (keep the thumbnail-only clip). Index failure
+/// aborts the rest of capture so we do not mark the hash stable after a
+/// half-written revival.
+#[derive(Debug)]
+pub(crate) enum PersistIndexedImageError {
+    Persist(String),
+    Index(String),
+}
+
+impl std::fmt::Display for PersistIndexedImageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Persist(error) | Self::Index(error) => f.write_str(error),
+        }
+    }
+}
+
+/// Persist original bytes, index `clip_images`, then clear `full_image_expired`
+/// only after both the file write and the index succeed in one transaction.
+///
+/// The clips-row UPDATE that runs before this must not clear the flag: a
+/// failed write would then claim a usable original that is not there (SBS-769).
+pub(crate) async fn restore_existing_image_original(
+    crypto: &crate::crypto::CryptoManager,
+    pool: &sqlx::SqlitePool,
+    image_dir: &std::path::Path,
+    clip_uuid: &str,
+    png_bytes: &[u8],
+) -> Result<String, PersistIndexedImageError> {
+    let file_path = persist_full_image_file(crypto, image_dir, clip_uuid, png_bytes)
+        .map_err(PersistIndexedImageError::Persist)?;
+
+    let mut transaction = pool
+        .begin()
+        .await
+        .map_err(|error| PersistIndexedImageError::Index(error.to_string()))?;
+    sqlx::query(
+        r#"
+        INSERT OR REPLACE INTO clip_images (clip_uuid, full_content, file_path, file_size, storage_kind, mime_type, created_at)
+        VALUES (?, x'', ?, ?, 'file', 'image/png', CURRENT_TIMESTAMP)
+        "#,
+    )
+    .bind(clip_uuid)
+    .bind(&file_path)
+    .bind(png_bytes.len() as i64)
+    .execute(&mut *transaction)
+    .await
+    .map_err(|error| PersistIndexedImageError::Index(error.to_string()))?;
+    sqlx::query("UPDATE clips SET full_image_expired = 0 WHERE uuid = ?")
+        .bind(clip_uuid)
+        .execute(&mut *transaction)
+        .await
+        .map_err(|error| PersistIndexedImageError::Index(error.to_string()))?;
+    transaction
+        .commit()
+        .await
+        .map_err(|error| PersistIndexedImageError::Index(error.to_string()))?;
+    Ok(file_path)
 }
 
 pub fn read_full_image_file(
@@ -3497,5 +3663,273 @@ mod tests {
         assert_eq!(capture_state_name(CAPTURE_STATE_LISTENING), "listening");
         assert_eq!(capture_state_name(CAPTURE_STATE_RESTARTING), "restarting");
         assert_eq!(capture_state_name(CAPTURE_STATE_STOPPED), "stopped");
+    }
+
+    /// SBS-769: consecutive-hash equality used to skip capture unconditionally.
+    /// After retention expires an original, that skip is the revival miss.
+    #[test]
+    fn consecutive_dedup_does_not_skip_an_expired_or_unknown_original() {
+        use super::{consecutive_dedup_decision, ConsecutiveDedupDecision, StoredOriginalLookup};
+
+        // Today's helper: hash match => skip. Expired must not take that path.
+        assert_eq!(
+            consecutive_dedup_decision(StoredOriginalLookup::Found {
+                full_image_expired: true,
+            }),
+            ConsecutiveDedupDecision::Capture
+        );
+        assert_eq!(
+            consecutive_dedup_decision(StoredOriginalLookup::Unknown),
+            ConsecutiveDedupDecision::Capture
+        );
+        assert_eq!(
+            consecutive_dedup_decision(StoredOriginalLookup::Found {
+                full_image_expired: false,
+            }),
+            ConsecutiveDedupDecision::Skip
+        );
+        assert_eq!(
+            consecutive_dedup_decision(StoredOriginalLookup::Missing),
+            ConsecutiveDedupDecision::Skip
+        );
+    }
+
+    mod revive_expired_original {
+        use super::super::{
+            consecutive_dedup_decision, lookup_stored_original, restore_existing_image_original,
+            ConsecutiveDedupDecision, PersistIndexedImageError, StoredOriginalLookup,
+        };
+        use crate::commands::{load_full_image_content, IMAGE_EXPIRED_ERROR};
+        use crate::database::Database;
+        use crate::models::Clip;
+        use sqlx::sqlite::SqlitePoolOptions;
+        use std::sync::Arc;
+
+        const OCR_TEXT: &str = "invoice AK1A9";
+        const OCR_WORDS: &str = r#"{"image_width":10,"image_height":10,"words":[]}"#;
+        const THUMBNAIL: &[u8] = b"thumbnail-bytes";
+        const ORIGINAL: &[u8] = b"full-resolution-png-bytes";
+
+        async fn test_database() -> Database {
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect("sqlite::memory:")
+                .await
+                .expect("in-memory database should open");
+            sqlx::query("PRAGMA foreign_keys = ON")
+                .execute(&pool)
+                .await
+                .expect("foreign keys should be enabled in tests");
+            let database = Database {
+                pool,
+                crypto: Arc::new(crate::crypto::CryptoManager::ephemeral()),
+                image_dir: std::env::temp_dir()
+                    .join(format!("cubby-sbs-769-{}", uuid::Uuid::new_v4())),
+                search_index: Arc::new(crate::search_index::SearchIndex::default()),
+            };
+            database.migrate().await.expect("migration should succeed");
+            database
+        }
+
+        async fn seed_expired_image(database: &Database, uuid: &str, content_hash: &str) {
+            sqlx::query(
+                r#"
+                INSERT INTO clips (
+                    uuid, clip_type, content, text_preview, content_hash,
+                    ocr_text, ocr_words, ocr_status, full_image_expired, is_thumbnail
+                )
+                VALUES (?, 'image', ?, '[Image]', ?, ?, ?, 'completed', 1, 1)
+                "#,
+            )
+            .bind(uuid)
+            .bind(THUMBNAIL)
+            .bind(content_hash)
+            .bind(OCR_TEXT)
+            .bind(OCR_WORDS)
+            .execute(&database.pool)
+            .await
+            .expect("expired image fixture should insert");
+        }
+
+        async fn expired_flag(database: &Database, uuid: &str) -> i64 {
+            sqlx::query_scalar("SELECT full_image_expired FROM clips WHERE uuid = ?")
+                .bind(uuid)
+                .fetch_one(&database.pool)
+                .await
+                .expect("expired flag should load")
+        }
+
+        async fn ocr_row(database: &Database, uuid: &str) -> (String, String, String) {
+            sqlx::query_as("SELECT ocr_text, ocr_words, ocr_status FROM clips WHERE uuid = ?")
+                .bind(uuid)
+                .fetch_one(&database.pool)
+                .await
+                .expect("ocr columns should load")
+        }
+
+        async fn load_clip(database: &Database, uuid: &str) -> Clip {
+            sqlx::query_as("SELECT * FROM clips WHERE uuid = ?")
+                .bind(uuid)
+                .fetch_one(&database.pool)
+                .await
+                .expect("clip should load")
+        }
+
+        fn cleanup(database: &Database) {
+            let _ = std::fs::remove_dir_all(&database.image_dir);
+        }
+
+        /// SBS-769: re-copying an expired image wrote fresh bytes but left
+        /// `full_image_expired` set, so paste/copy still rejected the original.
+        #[tokio::test]
+        async fn direct_recopy_after_expiry_restores_original_and_keeps_ocr() {
+            let database = test_database().await;
+            seed_expired_image(&database, "shot", "hash-shot").await;
+
+            let mut expired = load_clip(&database, "shot").await;
+            assert_eq!(
+                load_full_image_content(&database, &mut expired)
+                    .await
+                    .unwrap_err(),
+                IMAGE_EXPIRED_ERROR
+            );
+
+            restore_existing_image_original(
+                &database.crypto,
+                &database.pool,
+                &database.image_dir,
+                "shot",
+                ORIGINAL,
+            )
+            .await
+            .expect("revival should persist the original");
+
+            assert_eq!(expired_flag(&database, "shot").await, 0);
+            let mut revived = load_clip(&database, "shot").await;
+            let bytes = load_full_image_content(&database, &mut revived)
+                .await
+                .expect("revived original should be loadable");
+            assert_eq!(bytes, ORIGINAL);
+
+            let (ocr_text, ocr_words, ocr_status) = ocr_row(&database, "shot").await;
+            assert_eq!(ocr_text, OCR_TEXT);
+            assert_eq!(ocr_words, OCR_WORDS);
+            assert_eq!(ocr_status, "completed");
+            let thumbnail: Vec<u8> =
+                sqlx::query_scalar("SELECT content FROM clips WHERE uuid = 'shot'")
+                    .fetch_one(&database.pool)
+                    .await
+                    .expect("thumbnail should remain");
+            assert_eq!(thumbnail, THUMBNAIL);
+
+            cleanup(&database);
+        }
+
+        /// SBS-769: LAST_STABLE_HASH matching used to drop the recapture
+        /// entirely after expiry, so a second consecutive copy never revived.
+        #[tokio::test]
+        async fn consecutive_duplicate_after_expiry_does_not_skip_revival() {
+            let database = test_database().await;
+            seed_expired_image(&database, "shot", "hash-shot").await;
+
+            assert_eq!(
+                lookup_stored_original(&database.pool, "hash-shot").await,
+                StoredOriginalLookup::Found {
+                    full_image_expired: true,
+                }
+            );
+            assert_eq!(
+                lookup_stored_original(&database.pool, "no-such-hash").await,
+                StoredOriginalLookup::Missing
+            );
+            // Today's hash-only helper would Skip here and never restore.
+            assert_eq!(
+                consecutive_dedup_decision(StoredOriginalLookup::Found {
+                    full_image_expired: true,
+                }),
+                ConsecutiveDedupDecision::Capture
+            );
+
+            restore_existing_image_original(
+                &database.crypto,
+                &database.pool,
+                &database.image_dir,
+                "shot",
+                ORIGINAL,
+            )
+            .await
+            .expect("revival after a consecutive match should persist");
+
+            assert_eq!(expired_flag(&database, "shot").await, 0);
+            assert_eq!(
+                lookup_stored_original(&database.pool, "hash-shot").await,
+                StoredOriginalLookup::Found {
+                    full_image_expired: false,
+                }
+            );
+            let mut revived = load_clip(&database, "shot").await;
+            let bytes = load_full_image_content(&database, &mut revived)
+                .await
+                .expect("consecutive revival should make the original usable");
+            assert_eq!(bytes, ORIGINAL);
+            assert_eq!(
+                consecutive_dedup_decision(StoredOriginalLookup::Found {
+                    full_image_expired: false,
+                }),
+                ConsecutiveDedupDecision::Skip
+            );
+
+            cleanup(&database);
+        }
+
+        /// SBS-769: a failed persist or a failed clip_images index must leave
+        /// `full_image_expired` set so copy/paste do not claim a missing original.
+        #[tokio::test]
+        async fn persist_or_index_failure_does_not_clear_expired_flag() {
+            let persist_fail_db = test_database().await;
+            seed_expired_image(&persist_fail_db, "shot", "hash-shot").await;
+            std::fs::write(&persist_fail_db.image_dir, b"not-a-directory")
+                .expect("image_dir should be a file so persist cannot create it");
+
+            let persist_err = restore_existing_image_original(
+                &persist_fail_db.crypto,
+                &persist_fail_db.pool,
+                &persist_fail_db.image_dir,
+                "shot",
+                ORIGINAL,
+            )
+            .await
+            .expect_err("persist must fail when image_dir is a file");
+            assert!(matches!(persist_err, PersistIndexedImageError::Persist(_)));
+            assert_eq!(expired_flag(&persist_fail_db, "shot").await, 1);
+            let persist_index_rows: i64 =
+                sqlx::query_scalar("SELECT COUNT(*) FROM clip_images WHERE clip_uuid = 'shot'")
+                    .fetch_one(&persist_fail_db.pool)
+                    .await
+                    .expect("clip_images count should load");
+            assert_eq!(persist_index_rows, 0);
+            let _ = std::fs::remove_file(&persist_fail_db.image_dir);
+
+            let index_fail_db = test_database().await;
+            seed_expired_image(&index_fail_db, "shot", "hash-shot").await;
+            sqlx::query("DROP TABLE clip_images")
+                .execute(&index_fail_db.pool)
+                .await
+                .expect("dropping clip_images should force an index failure");
+
+            let index_err = restore_existing_image_original(
+                &index_fail_db.crypto,
+                &index_fail_db.pool,
+                &index_fail_db.image_dir,
+                "shot",
+                ORIGINAL,
+            )
+            .await
+            .expect_err("index must fail when clip_images is missing");
+            assert!(matches!(index_err, PersistIndexedImageError::Index(_)));
+            assert_eq!(expired_flag(&index_fail_db, "shot").await, 1);
+
+            cleanup(&index_fail_db);
+        }
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -719,7 +719,10 @@ pub async fn migrate_clip_format_model(db: &Database) -> Result<u64, String> {
     Ok(clips.len() as u64)
 }
 
-async fn load_full_image_content(db: &Database, clip: &mut Clip) -> Result<Vec<u8>, String> {
+pub(crate) async fn load_full_image_content(
+    db: &Database,
+    clip: &mut Clip,
+) -> Result<Vec<u8>, String> {
     let pool = &db.pool;
     if clip.clip_type != "image" {
         return Err("Clip is not an image".to_string());

--- a/src-tauri/src/image_persist.rs
+++ b/src-tauri/src/image_persist.rs
@@ -123,6 +123,12 @@ pub(crate) struct RecaptureFields<'a> {
 /// original only replaces the live file after that transaction commits. A
 /// failure at any earlier point returns with the staged handle un-committed, so
 /// its `Drop` deletes the temp file and the previous original survives intact.
+///
+/// `full_image_expired = 0` belongs in that same transaction (SBS-769). This is
+/// the one place a recaptured original becomes usable again, and clearing the
+/// flag anywhere else would either claim an original before it is on disk or,
+/// as a second pass after this one, leave a clip whose file and `clip_images`
+/// row are both correct while Paste and Copy still refuse it as expired.
 pub(crate) async fn apply_existing_image_recapture(
     pool: &sqlx::SqlitePool,
     existing_id: &str,
@@ -149,7 +155,8 @@ pub(crate) async fn apply_existing_image_recapture(
             content = ?,
             text_preview = ?,
             metadata = ?,
-            is_thumbnail = 0
+            is_thumbnail = 0,
+            full_image_expired = 0
         WHERE uuid = ?
         "#,
     )


### PR DESCRIPTION
## Linear

[SBS-769](https://linear.app/southboundsoftware/issue/SBS-769/revive-expired-image-originals-when-the-image-is-copied-again) — Revive expired image originals when the image is copied again

## User-visible outcome

A user who copies a screenshot again after retention expired the original now gets a usable full image immediately. Paste and Copy Image work on that clip, including when the second copy is consecutive with the first. Recognized text and the list thumbnail stay. A failed file write does not claim a usable original.

## What changed

- Existing-image recapture still updates the clips row first and does **not** clear `full_image_expired` there.
- New helper `restore_existing_image_original` writes the original, indexes `clip_images`, and clears `full_image_expired` only in the same transaction after that write succeeds.
- Persist failure still continues as SBS-836 (thumbnail-only). Index failure still returns early. Neither path clears the flag.
- Consecutive-dedup for images no longer skips on hash equality alone. It looks up the stored row:
  - expired → capture
  - present and not expired → skip
  - no row → skip (today's behavior)
  - lookup failure → unknown, do not skip
- Text consecutive-dedup is unchanged.
- OCR columns are not written by revival. `ocr_queue::enqueue` already no-ops when `ocr_text` is present.

## Sweep

| Path | Result |
|---|---|
| `LAST_STABLE_HASH` consecutive skip | Fixed: image hash match now looks up `full_image_expired` |
| `IGNORE_HASH` | Listed, not changed. Self-paste of an expired original cannot succeed (`load_full_image_content` still rejects), so this path cannot revive |
| `content_hash` existing-uuid UPDATE | This is the direct re-copy path; it now calls the restore helper |
| New-insert persist | Unchanged (out of scope) |
| `migrate_encrypted_storage` persist | Unchanged (migration, not recapture) |
| `reset_capture_dedup` | Still only on history delete / forget-on-clear / text edit, not on retention. Intentional: revival looks up instead of resetting the marker on expiry |

Grep for `persist_full_image_file` / `INSERT OR REPLACE INTO clip_images` found three persist-onto-existing sites: the existing-image recapture (fixed), new-insert (left alone), and encryption migration (left alone).

## Tests

Doc comments name the failure mode each pins.

1. `direct_recopy_after_expiry_restores_original_and_keeps_ocr` — seed expired (flag=1, no `clip_images`, OCR present); restore same bytes; flag=0; `load_full_image_content` succeeds; OCR and thumbnail unchanged.
2. `consecutive_duplicate_after_expiry_does_not_skip_revival` — today's hash-only skip would drop this; new decision is Capture; restore makes the original usable.
3. `persist_or_index_failure_does_not_clear_expired_flag` — unwritable `image_dir` and dropped `clip_images` leave the flag set.
4. `consecutive_dedup_does_not_skip_an_expired_or_unknown_original` — expired/unknown Capture; present/missing Skip.

Existing retention, OCR, and expired-details tests were not weakened and still pass.

## Fail-without-fix

Reverted only the production helper bodies (`consecutive_dedup_decision` always Skip; restore persist+index without clearing the flag), rebuilt, ran the new tests, then restored.

```
===== FAIL-WITHOUT-FIX: revive_expired =====

running 3 tests

thread 'clipboard::tests::revive_expired_original::consecutive_duplicate_after_expiry_does_not_skip_revival' (284) panicked at src/clipboard.rs:3770:13:
assertion `left == right` failed
  left: Skip
 right: Capture

thread 'clipboard::tests::revive_expired_original::direct_recopy_after_expiry_restores_original_and_keeps_ocr' (288) panicked at src/clipboard.rs:3731:13:
assertion `left == right` failed
  left: 1
 right: 0
test clipboard::tests::revive_expired_original::consecutive_duplicate_after_expiry_does_not_skip_revival ... FAILED
test clipboard::tests::revive_expired_original::direct_recopy_after_expiry_restores_original_and_keeps_ocr ... FAILED
test clipboard::tests::revive_expired_original::persist_or_index_failure_does_not_clear_expired_flag ... ok

failures:
    clipboard::tests::revive_expired_original::consecutive_duplicate_after_expiry_does_not_skip_revival
    clipboard::tests::revive_expired_original::direct_recopy_after_expiry_restores_original_and_keeps_ocr

test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 206 filtered out; finished in 0.04s

===== FAIL-WITHOUT-FIX: consecutive_dedup_does_not_skip =====

running 1 test

thread 'clipboard::tests::consecutive_dedup_does_not_skip_an_expired_or_unknown_original' (320) panicked at src/clipboard.rs:3599:9:
assertion `left == right` failed
  left: Skip
 right: Capture
test clipboard::tests::consecutive_dedup_does_not_skip_an_expired_or_unknown_original ... FAILED

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 208 filtered out; finished in 0.00s
```

`persist_or_index_failure_does_not_clear_expired_flag` passed without the fix because the old code never cleared the flag at all. It pins the new success-path helper against clearing on persist/index failure; it cannot fail on the pre-fix code.

After restoring the helpers:

```
test clipboard::tests::revive_expired_original::direct_recopy_after_expiry_restores_original_and_keeps_ocr ... ok
test clipboard::tests::revive_expired_original::consecutive_duplicate_after_expiry_does_not_skip_revival ... ok
test clipboard::tests::revive_expired_original::persist_or_index_failure_does_not_clear_expired_flag ... ok
test clipboard::tests::consecutive_dedup_does_not_skip_an_expired_or_unknown_original ... ok
```

## CI / rust gate

This environment is Linux. The required CI rust job is `windows-latest`:

```
cargo fmt --manifest-path src-tauri/Cargo.toml --check
cargo test --manifest-path src-tauri/Cargo.toml --all-targets
cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
```

What I actually ran, with rustc 1.97.1, target `x86_64-pc-windows-gnu`, Wine for execution:

| Check | Result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo clippy --target x86_64-pc-windows-gnu --all-targets -- -D warnings` | pass |
| `cargo test --target x86_64-pc-windows-gnu --all-targets --no-run` | pass (lib + bin test binaries) |
| Wine `cubby` lib tests | 205 passed, 2 failed, 2 ignored |

The two Wine failures are pre-existing Windows OCR tests (`ocr::tests::reads_text_from_a_generated_image`, `ocr::tests::reads_dark_error_dialogs_and_small_ui_text`) that need the Windows OCR engine (`Os { code: 2, kind: NotFound }`). They are not this change.

Could not run: native `windows-latest` CI, `pnpm run format:check`, `pnpm run test`, `pnpm run build`. Host `cargo test` without a Windows target does not compile this crate.

Confirmed new test names ran:

- `clipboard::tests::consecutive_dedup_does_not_skip_an_expired_or_unknown_original`
- `clipboard::tests::revive_expired_original::direct_recopy_after_expiry_restores_original_and_keeps_ocr`
- `clipboard::tests::revive_expired_original::consecutive_duplicate_after_expiry_does_not_skip_revival`
- `clipboard::tests::revive_expired_original::persist_or_index_failure_does_not_clear_expired_flag`

## What this makes more likely

- Every consecutive image duplicate now hits SQLite. If that lookup fails (Unknown), we no longer skip. The later `content_hash` lookup is still fail-closed, so a fully down database still drops the capture. If consecutive lookup fails but the later lookup succeeds, a consecutive copy can bump `created_at` and rewrite the original — rare, but more likely than today.
- Successful revival clears `full_image_expired`, so the clip can be age-swept again later. That is intended: it is a fresh original.
- Revival still uses `persist_full_image_file`'s `std::fs::write`. A reader that lands mid-write can see a torn `.cubby` file. That was already true; this path now runs on expired re-copies too.

## Gaps / not done

- Did not change `persist_full_image_file` to temp+rename. Listed, not implemented.
- Did not change new-insert, retention, History UI (SBS-807), or the SBS-836 persist-failure continue path beyond: never clear the flag unless persist and index both succeed.
- Did not reset `LAST_STABLE_HASH` on retention expiry.
- Did not create a GitHub issue.
- Did not merge.

Do not merge.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revive expired image originals when the same image is copied consecutively
> - Previously, consecutive duplicate clipboard copies were always skipped early. Now, for image clips, [`clipboard.rs`](https://github.com/tsouth89/cubby-clipboard/pull/214/files#diff-8b53e1d4014cd55d2bf889ca51d824e6f3c4f2e3775e5b8a5d2670c416a3b984) checks whether the stored original has expired before deciding to skip.
> - Adds `lookup_stored_original` to query `full_image_expired` by content hash and `consecutive_dedup_decision` to map the result to a `Skip` or `Capture` decision.
> - If the stored original is expired or the DB lookup fails, capture proceeds so the original file is revived via the existing `apply_existing_image_recapture` path.
> - Makes `load_full_image_content` in [`commands.rs`](https://github.com/tsouth89/cubby-clipboard/pull/214/files#diff-59f7096c7cd88d5d187e749ca400716cd225f951e78eac3d0081ec6c28ce5dcc) `pub(crate)` to support new tests.
>
> #### 🖇️ Linked Issues
> Resolves [SBS-769](https://linear.app/southboundsoftware/issue/SBS-769).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0ae173.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->