### PR TITLE
SBS-808: Bind backup and import IPC paths to the file picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable Cubby Clipboard changes are documented here. PastePaw entries below Cubby's first beta are retained as upstream history and attribution.
 
+## Unreleased
+
+### Fixed
+- Backup export, backup import, and Ditto import now only write or read a path chosen in the file dialog, so a compromised Settings page cannot send history to an arbitrary location (SBS-808)
+
 ## v1.3.1
 
 ### Added

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2733,7 +2733,10 @@ pub async fn pick_backup_save_path(app: AppHandle) -> Result<String, String> {
         .set_file_name(&suggested)
         .blocking_save_file()
     {
-        Some(path) => Ok(path.to_string()),
+        Some(path) => crate::path_grant::grant_picker_path(
+            crate::path_grant::PathGrantPurpose::BackupSave,
+            path.to_string(),
+        ),
         None => Err("No location selected".to_string()),
     }
 }
@@ -2748,7 +2751,10 @@ pub async fn pick_backup_file(app: AppHandle) -> Result<String, String> {
         .add_filter("Cubby backup", &["cubbybak"])
         .blocking_pick_file()
     {
-        Some(path) => Ok(path.to_string()),
+        Some(path) => crate::path_grant::grant_picker_path(
+            crate::path_grant::PathGrantPurpose::BackupOpen,
+            path.to_string(),
+        ),
         None => Err("No file selected".to_string()),
     }
 }
@@ -2759,7 +2765,7 @@ pub async fn export_backup(
     passphrase: String,
     db: tauri::State<'_, Arc<Database>>,
 ) -> Result<usize, String> {
-    crate::backup::export_backup(db.inner(), &path, &passphrase).await
+    crate::path_grant::export_granted_backup(db.inner(), path, passphrase).await
 }
 
 #[tauri::command]
@@ -2769,7 +2775,7 @@ pub async fn import_backup(
     dry_run: bool,
     db: tauri::State<'_, Arc<Database>>,
 ) -> Result<crate::backup::BackupImportResult, String> {
-    crate::backup::import_backup(db.inner(), &path, &passphrase, dry_run).await
+    crate::path_grant::import_granted_backup(db.inner(), path, passphrase, dry_run).await
 }
 
 #[tauri::command]
@@ -2785,7 +2791,10 @@ pub async fn pick_ditto_database(app: AppHandle) -> Result<String, String> {
     }
 
     match dialog.blocking_pick_file() {
-        Some(path) => Ok(path.to_string()),
+        Some(path) => crate::path_grant::grant_picker_path(
+            crate::path_grant::PathGrantPurpose::DittoOpen,
+            path.to_string(),
+        ),
         None => Err("No file selected".to_string()),
     }
 }
@@ -2828,7 +2837,7 @@ pub async fn import_from_ditto(
     dry_run: bool,
     db: tauri::State<'_, Arc<Database>>,
 ) -> Result<crate::ditto_import::DittoImportResult, String> {
-    let result = crate::ditto_import::import_from_ditto(&db, &db_path, dry_run).await?;
+    let result = crate::path_grant::import_granted_ditto(&db, db_path, dry_run).await?;
     if !dry_run && result.imported > 0 {
         db.search_index.invalidate();
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -70,6 +70,7 @@ mod models;
 mod ocr;
 mod ocr_queue;
 pub mod paste_engine;
+mod path_grant;
 // SBS-219 budgets. Compiled for tests (which measure them) and for the
 // dev-harness binaries; a release build compiles neither arm.
 #[cfg(any(test, feature = "dev-harness"))]

--- a/src-tauri/src/path_grant.rs
+++ b/src-tauri/src/path_grant.rs
@@ -1,0 +1,531 @@
+//! Process-local grants that bind backup/import IPC paths to the file picker.
+//!
+//! SBS-808: `export_backup`, `import_backup`, and `import_from_ditto` used to
+//! take a raw renderer-supplied path and pass it to `std::fs`. A compromised
+//! Settings page could then write decrypted history (re-encrypted under an
+//! attacker passphrase) to a UNC path. Same-user malware can already unwrap
+//! `storage.key`, so this is defense-in-depth: the native command must not
+//! accept a path the dialog did not produce.
+//!
+//! Grants are in-memory only, keyed by purpose, and compared as the exact
+//! string the picker returned. The library functions in `backup` and
+//! `ditto_import` stay callable from their own tests without a grant.
+
+use crate::database::Database;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+/// Why a path was picked. A save grant must not authorize import, and a Ditto
+/// pick must not authorize backup export.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PathGrantPurpose {
+    BackupSave,
+    BackupOpen,
+    DittoOpen,
+}
+
+const UNTRUSTED_PATH: &str = "That path was not selected in the file dialog";
+const EMPTY_PATH: &str = "A file path is required";
+const GRANT_TABLE_UNREADABLE: &str = "Could not verify the selected file path";
+
+pub struct PathGrantTable {
+    grants: Mutex<HashMap<PathGrantPurpose, String>>,
+}
+
+impl PathGrantTable {
+    pub fn new() -> Self {
+        Self {
+            grants: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn grant(&self, purpose: PathGrantPurpose, path: String) -> Result<String, String> {
+        if path.is_empty() {
+            return Err(EMPTY_PATH.to_string());
+        }
+        let mut grants = lock_grants(&self.grants)?;
+        grants.insert(purpose, path.clone());
+        Ok(path)
+    }
+
+    /// SBS-808: reject a renderer path the matching picker did not produce.
+    ///
+    /// Compare the IPC string to the grant as returned by the dialog. Do not
+    /// canonicalize a renderer-supplied path into a grant, and do not accept a
+    /// different string that happens to resolve to the same file.
+    ///
+    /// A dry-run (`consume == false`) leaves the grant in place so preview
+    /// then confirm can reuse the same path. The first mutating attempt
+    /// consumes the grant whether the later read or write succeeds or fails.
+    pub fn authorize(
+        &self,
+        purpose: PathGrantPurpose,
+        path: &str,
+        consume: bool,
+    ) -> Result<(), String> {
+        if path.is_empty() {
+            return Err(EMPTY_PATH.to_string());
+        }
+        let mut grants = lock_grants(&self.grants)?;
+        match grants.get(&purpose) {
+            Some(granted) if granted == path => {
+                if consume {
+                    grants.remove(&purpose);
+                }
+                Ok(())
+            }
+            _ => Err(UNTRUSTED_PATH.to_string()),
+        }
+    }
+}
+
+impl Default for PathGrantTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn lock_grants(
+    grants: &Mutex<HashMap<PathGrantPurpose, String>>,
+) -> Result<std::sync::MutexGuard<'_, HashMap<PathGrantPurpose, String>>, String> {
+    // Poison and any other unreadable table are unknown, not empty. Fail closed.
+    grants
+        .lock()
+        .map_err(|_| GRANT_TABLE_UNREADABLE.to_string())
+}
+
+static GRANTS: OnceLock<PathGrantTable> = OnceLock::new();
+
+fn grants() -> &'static PathGrantTable {
+    GRANTS.get_or_init(PathGrantTable::new)
+}
+
+pub fn grant_picker_path(purpose: PathGrantPurpose, path: String) -> Result<String, String> {
+    grants().grant(purpose, path)
+}
+
+pub fn authorize_picker_path(
+    purpose: PathGrantPurpose,
+    path: &str,
+    consume: bool,
+) -> Result<(), String> {
+    grants().authorize(purpose, path, consume)
+}
+
+/// IPC body for `export_backup`. The grant is checked before any write.
+pub async fn export_granted_backup(
+    db: &Database,
+    path: String,
+    passphrase: String,
+) -> Result<usize, String> {
+    authorize_picker_path(PathGrantPurpose::BackupSave, &path, true)?;
+    crate::backup::export_backup(db, &path, &passphrase).await
+}
+
+/// IPC body for `import_backup`. Dry-run keeps the grant; a mutating call
+/// consumes it before the file is read.
+pub async fn import_granted_backup(
+    db: &Database,
+    path: String,
+    passphrase: String,
+    dry_run: bool,
+) -> Result<crate::backup::BackupImportResult, String> {
+    authorize_picker_path(PathGrantPurpose::BackupOpen, &path, !dry_run)?;
+    crate::backup::import_backup(db, &path, &passphrase, dry_run).await
+}
+
+/// IPC body for `import_from_ditto`. Dry-run keeps the grant; a mutating call
+/// consumes it before the Ditto database is copied.
+pub async fn import_granted_ditto(
+    db: &Database,
+    db_path: String,
+    dry_run: bool,
+) -> Result<crate::ditto_import::DittoImportResult, String> {
+    authorize_picker_path(PathGrantPurpose::DittoOpen, &db_path, !dry_run)?;
+    crate::ditto_import::import_from_ditto(db, &db_path, dry_run).await
+}
+
+#[cfg(test)]
+pub(crate) fn reset_grants_for_tests() {
+    let mut grants = grants()
+        .grants
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    grants.clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::Database;
+
+    async fn isolated_grants() -> tokio::sync::MutexGuard<'static, ()> {
+        static LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+        let guard = LOCK.lock().await;
+        reset_grants_for_tests();
+        guard
+    }
+
+    fn temp_path(label: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "cubby-grant-{label}-{}.cubbybak",
+            uuid::Uuid::new_v4()
+        ))
+    }
+
+    async fn test_database() -> Database {
+        let database = Database {
+            pool: sqlx::sqlite::SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect("sqlite::memory:")
+                .await
+                .expect("in-memory database should open"),
+            crypto: std::sync::Arc::new(crate::crypto::CryptoManager::ephemeral()),
+            image_dir: std::env::temp_dir().join(format!("cubby-grant-{}", uuid::Uuid::new_v4())),
+            search_index: std::sync::Arc::new(crate::search_index::SearchIndex::default()),
+        };
+        database.migrate().await.expect("migration should succeed");
+        database
+    }
+
+    async fn insert_text_clip(db: &Database, text: &str) {
+        let material = crate::clipboard::build_clip_hash_material(
+            "text",
+            text.as_bytes(),
+            std::iter::empty::<(&str, &[u8])>(),
+        );
+        sqlx::query(
+            r#"INSERT INTO clips (uuid, clip_type, content, text_preview, content_hash, is_pinned, created_at, last_accessed)
+               VALUES (?, 'text', ?, ?, ?, 0, '2026-05-01 09:00:00', '2026-05-01 09:00:00')"#,
+        )
+        .bind(uuid::Uuid::new_v4().to_string())
+        .bind(db.crypto.encrypt(text.as_bytes()).unwrap())
+        .bind(db.crypto.encrypt_text(text).unwrap())
+        .bind(db.crypto.keyed_hash(&material))
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    async fn live_clip_count(db: &Database) -> i64 {
+        sqlx::query_scalar("SELECT COUNT(*) FROM clips WHERE is_deleted = 0")
+            .fetch_one(&db.pool)
+            .await
+            .unwrap()
+    }
+
+    async fn write_library_backup(text: &str) -> (std::path::PathBuf, String) {
+        let source = test_database().await;
+        insert_text_clip(&source, text).await;
+        let path = temp_path("library");
+        let path_str = path.to_string_lossy().to_string();
+        crate::backup::export_backup(&source, &path_str, "correct horse")
+            .await
+            .expect("library export does not need a grant");
+        (path, path_str)
+    }
+
+    /// A renderer-supplied export path that was never picked must not create a file.
+    #[tokio::test]
+    async fn never_picked_path_is_rejected_for_export_backup() {
+        let _lock = isolated_grants().await;
+        let db = test_database().await;
+        insert_text_clip(&db, "secret history").await;
+        let path = temp_path("never-export");
+        let path_str = path.to_string_lossy().to_string();
+
+        let error = export_granted_backup(&db, path_str, "passphrase".into())
+            .await
+            .expect_err("export_backup must reject a never-picked path");
+        assert_eq!(error, UNTRUSTED_PATH);
+        assert!(
+            !error.to_lowercase().contains("secret"),
+            "the reject error must not include clipboard contents: {error}"
+        );
+        assert!(
+            !path.exists(),
+            "rejected export_backup must not create the destination"
+        );
+    }
+
+    /// A renderer-supplied import path that was never picked must not restore clips.
+    #[tokio::test]
+    async fn never_picked_path_is_rejected_for_import_backup() {
+        let _lock = isolated_grants().await;
+        let (bundle, path_str) = write_library_backup("secret history").await;
+        let target = test_database().await;
+
+        let error = import_granted_backup(&target, path_str, "correct horse".into(), false)
+            .await
+            .expect_err("import_backup must reject a never-picked path");
+        assert_eq!(error, UNTRUSTED_PATH);
+        assert!(
+            !error.to_lowercase().contains("secret"),
+            "the reject error must not include clipboard contents: {error}"
+        );
+        assert_eq!(
+            live_clip_count(&target).await,
+            0,
+            "rejected import_backup must not read the bundle into history"
+        );
+        let _ = std::fs::remove_file(bundle);
+    }
+
+    /// A renderer-supplied Ditto path that was never picked must not be copied.
+    #[tokio::test]
+    async fn never_picked_path_is_rejected_for_import_from_ditto() {
+        let _lock = isolated_grants().await;
+        let db = test_database().await;
+        let path = std::env::temp_dir().join(format!(
+            "cubby-grant-never-ditto-{}.db",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(&path, b"not a ditto database").unwrap();
+        let path_str = path.to_string_lossy().to_string();
+
+        let error = import_granted_ditto(&db, path_str, false)
+            .await
+            .expect_err("import_from_ditto must reject a never-picked path");
+        assert_eq!(error, UNTRUSTED_PATH);
+        assert_eq!(
+            live_clip_count(&db).await,
+            0,
+            "rejected import_from_ditto must not copy or import the file"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// A save grant must not authorize import, and an open grant must not authorize export.
+    #[tokio::test]
+    async fn wrong_purpose_grant_is_rejected() {
+        let _lock = isolated_grants().await;
+        let db = test_database().await;
+        insert_text_clip(&db, "secret history").await;
+        let (bundle, import_path) = write_library_backup("secret history").await;
+        let export_path = temp_path("wrong-purpose");
+        let export_str = export_path.to_string_lossy().to_string();
+
+        grant_picker_path(PathGrantPurpose::BackupSave, import_path.clone()).unwrap();
+        let import_error =
+            import_granted_backup(&db, import_path.clone(), "correct horse".into(), false)
+                .await
+                .expect_err("a save grant must not authorize import_backup");
+        assert_eq!(import_error, UNTRUSTED_PATH);
+        assert_eq!(live_clip_count(&db).await, 1);
+
+        reset_grants_for_tests();
+        grant_picker_path(PathGrantPurpose::BackupOpen, export_str.clone()).unwrap();
+        let export_error = export_granted_backup(&db, export_str.clone(), "passphrase".into())
+            .await
+            .expect_err("an open grant must not authorize export_backup");
+        assert_eq!(export_error, UNTRUSTED_PATH);
+        assert!(
+            !export_path.exists(),
+            "wrong-purpose export_backup must not create a file"
+        );
+
+        reset_grants_for_tests();
+        grant_picker_path(PathGrantPurpose::DittoOpen, export_str.clone()).unwrap();
+        let ditto_export_error = export_granted_backup(&db, export_str, "passphrase".into())
+            .await
+            .expect_err("a Ditto grant must not authorize export_backup");
+        assert_eq!(ditto_export_error, UNTRUSTED_PATH);
+        assert!(!export_path.exists());
+
+        let _ = std::fs::remove_file(bundle);
+    }
+
+    /// Preview then confirm reuses the same granted path; dry-run must not consume it.
+    #[tokio::test]
+    async fn granted_path_survives_dry_run_then_is_consumed_by_mutating_import() {
+        let _lock = isolated_grants().await;
+        let (bundle, path_str) = write_library_backup("restored clip").await;
+        grant_picker_path(PathGrantPurpose::BackupOpen, path_str.clone()).unwrap();
+
+        let target = test_database().await;
+        let preview =
+            import_granted_backup(&target, path_str.clone(), "correct horse".into(), true)
+                .await
+                .expect("dry-run import_backup must accept a granted path");
+        assert!(preview.dry_run);
+        assert_eq!(preview.imported, 1);
+        assert_eq!(live_clip_count(&target).await, 0);
+
+        let imported =
+            import_granted_backup(&target, path_str.clone(), "correct horse".into(), false)
+                .await
+                .expect("mutating import_backup must still accept the path after dry-run");
+        assert!(!imported.dry_run);
+        assert_eq!(imported.imported, 1);
+        assert_eq!(live_clip_count(&target).await, 1);
+
+        let reused = import_granted_backup(&target, path_str, "correct horse".into(), false)
+            .await
+            .expect_err("the grant must be consumed by the first mutating call");
+        assert_eq!(reused, UNTRUSTED_PATH);
+
+        let _ = std::fs::remove_file(bundle);
+    }
+
+    /// The first mutating export consumes the grant even when the write later fails.
+    #[tokio::test]
+    async fn mutating_export_consumes_the_grant() {
+        let _lock = isolated_grants().await;
+        let db = test_database().await;
+        insert_text_clip(&db, "exported clip").await;
+        let path = temp_path("consume-export");
+        let path_str = path.to_string_lossy().to_string();
+        grant_picker_path(PathGrantPurpose::BackupSave, path_str.clone()).unwrap();
+
+        let count = export_granted_backup(&db, path_str.clone(), "passphrase".into())
+            .await
+            .expect("export_backup must accept a granted save path");
+        assert_eq!(count, 1);
+        assert!(path.exists());
+
+        let reused = export_granted_backup(&db, path_str, "passphrase".into())
+            .await
+            .expect_err("the save grant must be consumed after the mutating export");
+        assert_eq!(reused, UNTRUSTED_PATH);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// A mutating attempt consumes the grant even if the later filesystem call fails.
+    #[tokio::test]
+    async fn mutating_attempt_consumes_grant_on_failure() {
+        let _lock = isolated_grants().await;
+        let db = test_database().await;
+        let path = temp_path("consume-on-fail");
+        let path_str = path.to_string_lossy().to_string();
+        grant_picker_path(PathGrantPurpose::BackupSave, path_str.clone()).unwrap();
+
+        let first = export_granted_backup(&db, path_str.clone(), String::new())
+            .await
+            .expect_err("an empty passphrase should fail after the grant is consumed");
+        assert_ne!(first, UNTRUSTED_PATH);
+        assert!(!path.exists());
+
+        let second = export_granted_backup(&db, path_str, "passphrase".into())
+            .await
+            .expect_err("a failed mutating call must still consume the grant");
+        assert_eq!(second, UNTRUSTED_PATH);
+    }
+
+    /// An empty path is unknown, not a picker result.
+    #[tokio::test]
+    async fn empty_path_is_rejected() {
+        let _lock = isolated_grants().await;
+        let db = test_database().await;
+        grant_picker_path(
+            PathGrantPurpose::BackupSave,
+            "C:\\picked\\backup.cubbybak".into(),
+        )
+        .unwrap();
+        grant_picker_path(
+            PathGrantPurpose::BackupOpen,
+            "C:\\picked\\backup.cubbybak".into(),
+        )
+        .unwrap();
+        grant_picker_path(PathGrantPurpose::DittoOpen, "C:\\picked\\Ditto.db".into()).unwrap();
+
+        let export = export_granted_backup(&db, String::new(), "passphrase".into())
+            .await
+            .expect_err("export_backup must reject an empty path");
+        let import = import_granted_backup(&db, String::new(), "passphrase".into(), false)
+            .await
+            .expect_err("import_backup must reject an empty path");
+        let ditto = import_granted_ditto(&db, String::new(), false)
+            .await
+            .expect_err("import_from_ditto must reject an empty path");
+        assert_eq!(export, EMPTY_PATH);
+        assert_eq!(import, EMPTY_PATH);
+        assert_eq!(ditto, EMPTY_PATH);
+        assert_eq!(
+            grant_picker_path(PathGrantPurpose::BackupSave, String::new())
+                .expect_err("an empty picker result must not become a grant"),
+            EMPTY_PATH
+        );
+    }
+
+    /// A different string is not the grant, even if it looks like the same file.
+    #[tokio::test]
+    async fn lookalike_path_is_rejected_without_canonicalizing() {
+        let _lock = isolated_grants().await;
+        let db = test_database().await;
+        insert_text_clip(&db, "secret history").await;
+        let granted = "C:\\Users\\me\\backup.cubbybak".to_string();
+        grant_picker_path(PathGrantPurpose::BackupSave, granted.clone()).unwrap();
+
+        for lookalike in [
+            "C:\\Users\\me\\backup.cubbybak.exe",
+            "C:/Users/me/backup.cubbybak",
+            "\\\\localhost\\C$\\Users\\me\\backup.cubbybak",
+            "C:\\\\Users\\\\me\\\\backup.cubbybak",
+            "C:\\Users\\me\\backup.cubbybak ",
+        ] {
+            let error = export_granted_backup(&db, lookalike.to_string(), "passphrase".into())
+                .await
+                .expect_err("a lookalike string must not satisfy the grant");
+            assert_eq!(error, UNTRUSTED_PATH, "rejected {lookalike}");
+        }
+
+        // A rejected lookalike must not consume the real grant.
+        let granted_error = export_granted_backup(&db, granted, String::new())
+            .await
+            .expect_err("the real grant should still be present and then fail on passphrase");
+        assert_ne!(granted_error, UNTRUSTED_PATH);
+    }
+
+    /// Purpose is part of the grant even when the path strings match.
+    #[test]
+    fn table_rejects_wrong_purpose_for_the_same_path() {
+        let table = PathGrantTable::new();
+        table
+            .grant(
+                PathGrantPurpose::BackupSave,
+                "C:\\Users\\me\\backup.cubbybak".into(),
+            )
+            .unwrap();
+        let error = table
+            .authorize(
+                PathGrantPurpose::BackupOpen,
+                "C:\\Users\\me\\backup.cubbybak",
+                true,
+            )
+            .expect_err("the same string under another purpose is not a grant");
+        assert_eq!(error, UNTRUSTED_PATH);
+        table
+            .authorize(
+                PathGrantPurpose::BackupSave,
+                "C:\\Users\\me\\backup.cubbybak",
+                false,
+            )
+            .expect("wrong-purpose authorize must not consume the matching grant");
+    }
+
+    /// Mutex poison is unknown, not an empty table.
+    #[test]
+    fn poisoned_grant_table_is_rejected() {
+        let table = PathGrantTable::new();
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = table.grants.lock().unwrap();
+            panic!("poison the grant table");
+        }));
+        let error = table
+            .authorize(
+                PathGrantPurpose::BackupSave,
+                "C:\\picked\\backup.cubbybak",
+                true,
+            )
+            .expect_err("a poisoned table must fail closed");
+        assert_eq!(error, GRANT_TABLE_UNREADABLE);
+        let grant_error = table
+            .grant(
+                PathGrantPurpose::BackupSave,
+                "C:\\picked\\backup.cubbybak".into(),
+            )
+            .expect_err("granting into a poisoned table must fail closed");
+        assert_eq!(grant_error, GRANT_TABLE_UNREADABLE);
+    }
+}


### PR DESCRIPTION
## Linear

[SBS-808](https://linear.app/southboundsoftware/issue/SBS-808/backup-and-import-ipc-commands-trust-an-arbitrary-filesystem-path) — Backup and import IPC commands trust an arbitrary filesystem path

## User-visible outcome

Settings backup export, backup import, and Ditto import still work after the user picks a file. A renderer-supplied path that was never picked is rejected with `That path was not selected in the file dialog` and does not include clipboard contents. A user who never hits a compromised renderer sees the same dialogs as today. Frontend IPC names and argument shapes are unchanged.

## What changed

- New process-local grant table (`src-tauri/src/path_grant.rs`). Purpose is part of the grant:
  - `pick_backup_save_path` → `BackupSave`
  - `pick_backup_file` → `BackupOpen`
  - `pick_ditto_database` → `DittoOpen`
- On a successful pick, the exact string the command returns is the only string the matching write/read command may accept.
- `export_backup` / `import_backup` / `import_from_ditto` check the grant **before** any filesystem read/write/copy. Missing grant, wrong purpose, empty path, string mismatch, or a poisoned/unreadable table fail closed.
- Dry-run does not consume the grant (preview then confirm reuses the same path). The first mutating attempt consumes it, success or failure.
- Compare the IPC path to the grant as the exact picker string. Do not canonicalize a renderer-supplied path into a grant.
- `backup.rs` and `ditto_import.rs` stay callable from their existing unit tests without a grant. The check lives at the IPC command layer.

## Sweep

Grep (this worktree):

```
rg -n "fn export_backup|fn import_backup|fn pick_backup|fn import_from_ditto|fn pick_ditto|fn pick_file" src-tauri/src
rg -n "#\[tauri::command\]" -A 8 src-tauri/src/commands.rs src-tauri/src/settings_commands.rs src-tauri/src/ocr_queue.rs
rg -n "path: String|db_path|std::fs::(write|read|copy)" src-tauri/src
rg -n "pick_file|invoke<.*>\('pick_|export_backup|import_backup|import_from_ditto" frontend/src
```

| IPC command | Takes a renderer path? | Reads/writes/copies? | This PR |
|---|---|---|---|
| `export_backup(path)` | yes | `std::fs::write` via `backup.rs` | bound to `BackupSave` |
| `import_backup(path)` | yes | `std::fs::metadata` / `read` via `backup.rs` | bound to `BackupOpen` |
| `import_from_ditto(db_path)` | yes | `std::fs::copy` via `ditto_import.rs` | bound to `DittoOpen` |
| `pick_backup_save_path` / `pick_backup_file` / `pick_ditto_database` | picker | no IO; now registers the grant | grant on success |
| `pick_file` | returns a path | **no** IO consumer | left unbound |
| `add_ignored_app(appName)` | filename only | settings set, not a filesystem path | not this class |
| `save_settings` / `get_settings` | no | internal settings file | not this class |
| image/`clip_images.file_path` reads | no | stored under the managed image dir | not renderer-supplied |
| rolling backup / `Database::new` | no | app data dir | not renderer-supplied |

`pick_file` is only used in `SettingsPanel.tsx` to fill the ignored-apps text box (`path.split(/[\\/]/).pop()`). It is never passed to a read/write command. No grant invented for it.

## Tests

Doc comments name the failure mode they pin. They live next to the helper in `src-tauri/src/path_grant.rs` and ran under `cargo test --manifest-path src-tauri/Cargo.toml --lib path_grant`.

1. `never_picked_path_is_rejected_for_export_backup` — never-picked export does not create a file.
2. `never_picked_path_is_rejected_for_import_backup` — never-picked import does not restore clips.
3. `never_picked_path_is_rejected_for_import_from_ditto` — never-picked Ditto path is not copied/imported.
4. `wrong_purpose_grant_is_rejected` — save cannot import; open cannot export; Ditto cannot export.
5. `granted_path_survives_dry_run_then_is_consumed_by_mutating_import` — dry-run then mutate both accept; a later mutate is rejected.
6. `mutating_export_consumes_the_grant` / `mutating_attempt_consumes_grant_on_failure` — first mutating attempt consumes, success or failure.
7. `empty_path_is_rejected` — empty path is rejected for all three commands.
8. `lookalike_path_is_rejected_without_canonicalizing` — extra suffix, slash flip, UNC lookalike, doubled slashes, trailing space.

Existing `backup.rs` / `ditto_import.rs` tests still pass; they call the library functions directly and do not need a grant.

Restored run (new test names confirmed):

```
test path_grant::tests::empty_path_is_rejected ... ok
test path_grant::tests::granted_path_survives_dry_run_then_is_consumed_by_mutating_import ... ok
test path_grant::tests::lookalike_path_is_rejected_without_canonicalizing ... ok
test path_grant::tests::mutating_attempt_consumes_grant_on_failure ... ok
test path_grant::tests::mutating_export_consumes_the_grant ... ok
test path_grant::tests::never_picked_path_is_rejected_for_export_backup ... ok
test path_grant::tests::never_picked_path_is_rejected_for_import_backup ... ok
test path_grant::tests::never_picked_path_is_rejected_for_import_from_ditto ... ok
test path_grant::tests::poisoned_grant_table_is_rejected ... ok
test path_grant::tests::table_rejects_wrong_purpose_for_the_same_path ... ok
test path_grant::tests::wrong_purpose_grant_is_rejected ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 205 filtered out
```

`backup` library tests: 7 passed. `ditto_import` tests: 7 passed.

## Fail-without-fix

Reverted only the three `authorize_picker_path(...)` lines in the IPC wrappers, rebuilt, ran the new tests, then restored.

```
running 11 tests

thread 'path_grant::tests::empty_path_is_rejected' panicked at src/path_grant.rs:445:9:
assertion `left == right` failed
  left: "Could not save the backup: Path not found. (os error 3)"
 right: "A file path is required"
test path_grant::tests::empty_path_is_rejected ... FAILED

test path_grant::tests::poisoned_grant_table_is_rejected ... ok
test path_grant::tests::table_rejects_wrong_purpose_for_the_same_path ... ok

thread 'path_grant::tests::granted_path_survives_dry_run_then_is_consumed_by_mutating_import' panicked:
the grant must be consumed by the first mutating call: BackupImportResult { total: 1, imported: 0, duplicates: 1, errors: [], dry_run: false }
test path_grant::tests::granted_path_survives_dry_run_then_is_consumed_by_mutating_import ... FAILED

thread 'path_grant::tests::mutating_export_consumes_the_grant' panicked:
the save grant must be consumed after the mutating export: 1
test path_grant::tests::mutating_export_consumes_the_grant ... FAILED

thread 'path_grant::tests::mutating_attempt_consumes_grant_on_failure' panicked:
a failed mutating call must still consume the grant: 0
test path_grant::tests::mutating_attempt_consumes_grant_on_failure ... FAILED

thread 'path_grant::tests::lookalike_path_is_rejected_without_canonicalizing' panicked:
assertion `left == right` failed: rejected C:\Users\me\backup.cubbybak.exe
  left: "Could not save the backup: Path not found. (os error 3)"
 right: "That path was not selected in the file dialog"
test path_grant::tests::lookalike_path_is_rejected_without_canonicalizing ... FAILED

thread 'path_grant::tests::never_picked_path_is_rejected_for_import_from_ditto' panicked:
  left: "Could not read Ditto clips: error returned from database: (code: 26) file is not a database"
 right: "That path was not selected in the file dialog"
test path_grant::tests::never_picked_path_is_rejected_for_import_from_ditto ... FAILED

thread 'path_grant::tests::never_picked_path_is_rejected_for_export_backup' panicked:
export_backup must reject a never-picked path: 1
test path_grant::tests::never_picked_path_is_rejected_for_export_backup ... FAILED

thread 'path_grant::tests::never_picked_path_is_rejected_for_import_backup' panicked:
import_backup must reject a never-picked path: BackupImportResult { total: 1, imported: 1, duplicates: 0, errors: [], dry_run: false }
test path_grant::tests::never_picked_path_is_rejected_for_import_backup ... FAILED

thread 'path_grant::tests::wrong_purpose_grant_is_rejected' panicked:
a save grant must not authorize import_backup: BackupImportResult { total: 1, imported: 0, duplicates: 1, errors: [], dry_run: false }
test path_grant::tests::wrong_purpose_grant_is_rejected ... FAILED

failures:
    path_grant::tests::empty_path_is_rejected
    path_grant::tests::granted_path_survives_dry_run_then_is_consumed_by_mutating_import
    path_grant::tests::lookalike_path_is_rejected_without_canonicalizing
    path_grant::tests::mutating_attempt_consumes_grant_on_failure
    path_grant::tests::mutating_export_consumes_the_grant
    path_grant::tests::never_picked_path_is_rejected_for_export_backup
    path_grant::tests::never_picked_path_is_rejected_for_import_backup
    path_grant::tests::never_picked_path_is_rejected_for_import_from_ditto
    path_grant::tests::wrong_purpose_grant_is_rejected

test result: FAILED. 2 passed; 9 failed; 0 ignored; 0 measured; 205 filtered out
```

The two table-only tests still passed, as expected: they exercise `PathGrantTable` directly, not the production IPC wrappers.

## CI / rust gate

This environment is Linux. The required CI rust job is `windows-latest`:

```
cargo fmt --manifest-path src-tauri/Cargo.toml --check
cargo test --manifest-path src-tauri/Cargo.toml --all-targets
cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
```

What I actually ran, with rustc 1.97.1, target `x86_64-pc-windows-gnu`, Wine for execution:

| Check | Result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo clippy --target x86_64-pc-windows-gnu --all-targets -- -D warnings` | pass |
| `cargo test --target x86_64-pc-windows-gnu --lib path_grant` | 11 passed |
| `cargo test --target x86_64-pc-windows-gnu --lib` | 212 passed, 2 failed, 2 ignored |

The two Wine failures are pre-existing Windows OCR tests (`ocr::tests::reads_text_from_a_generated_image`, `ocr::tests::reads_dark_error_dialogs_and_small_ui_text`) that cannot find their fixture images under Wine (`Os { code: 2, kind: NotFound }`). They are not this change.

Could not run: native `windows-latest` CI, host `cargo test` without a Windows target (the crate does not compile on Linux), `pnpm run format:check`, `pnpm run test`, `pnpm run build`. No frontend change.

## Gaps

- `backup.rs` still writes the bundle with `std::fs::write` (truncate-in-place). I did not change that write to temp+rename. That is a leftover atomic-write gap and is not SBS-772.
- `pick_file` remains unbound. It has no IO consumer today.
- Grants are process-local and not persisted. Restarting Cubby clears them, which is intended.
- One live grant per purpose; a second pick replaces the first.
- Did not implement SBS-772 (backup export completeness), SBS-773, SBS-809, SBS-777, SBS-779, SBS-771, or ceiling/toolport.

## What this makes more likely

- A legitimate export/import now fails if the frontend ever sends a slightly different string than the picker returned (slash conversion, trailing space, `to_string()` vs `to_string_lossy()`). That is the point of exact-string comparison, but it is a new user-visible failure mode if the dialog string and the IPC argument ever drift.
- A failed mutating attempt consumes the grant, so a user who mistypes the passphrase or hits a disk error must pick the file again. That is intended so a later IPC call cannot reuse the grant.
- The grant check now sits in front of every backup/import IO path. Any latent bug in `backup.rs` / `ditto_import.rs` that only fired on a renderer-supplied path will fire less often; bugs that fire after a real picker still fire.

## Read my own diff

Read the staged diff top to bottom before opening. Frontend contract unchanged. `linux-schema.json` generated by the local Windows-gnu compile is untracked and not committed. `docs/audit/` was not touched.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind backup and Ditto import IPC commands to file picker path grants
> - Introduces a new [`path_grant`](https://github.com/tsouth89/cubby-clipboard/pull/215/files#diff-07af00ae3cdab1e33971985e09642a2d6009ab2f0304c91766a8fe081c175153) module that maintains a process-local in-memory table of paths granted by the file picker, scoped by purpose (`BackupSave`, `BackupOpen`, `DittoOpen`).
> - `pick_backup_save_path`, `pick_backup_file`, and `pick_ditto_database` now store the picker-selected path as a grant before returning it to the frontend.
> - `export_backup`, `import_backup`, and `import_from_ditto` now reject any path that was not previously granted by the picker for the matching purpose; grants are consumed on mutating operations but preserved during dry-runs.
> - Risk: these commands now return errors in cases that previously always succeeded — e.g. if the grant table mutex is poisoned or the path is empty.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31c4e40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->