### PR TITLE
SBS-773: Stop writing History source-app filter values to persistent logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 ## Unreleased
 
 ### Security
+- History source-app filter values are no longer written to the persistent Info log (SBS-773)
 - Pin third-party GitHub Actions in privileged release and Store workflows to immutable commit SHAs, and reject new mutable pins in CI
 
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,6 +30,8 @@ In addition to AES-256-GCM at rest, Cubby skips:
 - Text that matches high-confidence secret heuristics such as private keys, cloud API tokens, and grouped payment-card numbers (off by default, enable in Settings; category logged, never content). This one is opt-in because a wrong guess silently drops a clip the user wanted to keep.
 - A one-time seeded ignore list of major password-manager executables, editable in Settings.
 
+Release Info logs persist under the application log directory. The History source-app filter is recorded there as `none` / `blank` / `set`, not as the selected application name.
+
 ## Clipboard history at rest
 
 Cubby encrypts clipboard payloads, previews, source attribution, metadata, and image files with AES-256-GCM. Dedupe values use a keyed HMAC rather than a plain content hash. The random storage key is protected for the current Windows user with DPAPI and is never stored in plaintext.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -850,6 +850,38 @@ pub async fn get_clips(
     .await
 }
 
+/// Release builds persist Info logs under LogDir. The History source-app
+/// filter is a record of which applications the user copied from, and the
+/// value itself is user-controlled, so Info must not print it. SBS-773.
+///
+/// Three states: not asked is not blank, and neither is a real selection.
+fn source_app_filter_log_state(source_app: Option<&str>) -> &'static str {
+    match source_app {
+        None => "none",
+        Some(app) if app.trim().is_empty() => "blank",
+        Some(_) => "set",
+    }
+}
+
+fn get_clips_request_log(
+    filter_id: Option<&str>,
+    preview_only: bool,
+    content_filter: Option<&str>,
+    date_from: Option<&str>,
+    date_to: Option<&str>,
+    source_app: Option<&str>,
+) -> String {
+    format!(
+        "get_clips called with filter_id: {:?}, preview_only: {}, content_filter: {:?}, date: {:?}..{:?}, source_app: {}",
+        filter_id,
+        preview_only,
+        content_filter,
+        date_from,
+        date_to,
+        source_app_filter_log_state(source_app)
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn get_clips_in_database(
     filter_id: Option<String>,
@@ -867,13 +899,22 @@ async fn get_clips_in_database(
     let started = Instant::now();
 
     log::info!(
-        "get_clips called with filter_id: {:?}, preview_only: {}, content_filter: {:?}, date: {:?}..{:?}, source_app: {:?}",
-        filter_id,
-        preview_only,
-        content_filter,
-        date_from,
-        date_to,
-        source_app
+        "{}",
+        get_clips_request_log(
+            filter_id.as_deref(),
+            preview_only,
+            content_filter.as_deref(),
+            date_from.as_deref(),
+            date_to.as_deref(),
+            source_app.as_deref(),
+        )
+    );
+    // Debug-only structured fields: state and length, never the raw value.
+    // Release LogDir is Info, so this does not persist. SBS-773.
+    log::debug!(
+        "get_clips source_app filter state={} byte_len={}",
+        source_app_filter_log_state(source_app.as_deref()),
+        source_app.as_deref().map(str::len).unwrap_or(0)
     );
 
     let folder_id = match filter_id.as_deref() {
@@ -2849,12 +2890,13 @@ mod tests {
     use super::{
         build_ocr_highlights, build_ocr_match, clear_clips_in_pool, clipboard_contents_for_restore,
         delete_folder_in_pool, directory_size_bytes, enforce_retention_in_pool,
-        get_clip_details_in_database, get_clips_in_database, load_recognized_text,
-        migrate_clip_format_model, migrate_encrypted_storage, ocr_text_layout,
-        remove_clip_image_files, remove_duplicate_clips_in_database, restore_hash_material,
-        search_clips_in_database, set_clip_notes_in_database, set_clip_ocr_text_in_database,
-        toggle_clip_hidden_in_pool, toggle_clip_pin_in_pool, update_clip_text_in_database,
-        ClipboardContent, NOTE_CHAR_LIMIT, OCR_SNIPPET_CHAR_LIMIT,
+        get_clip_details_in_database, get_clips_in_database, get_clips_request_log,
+        load_recognized_text, migrate_clip_format_model, migrate_encrypted_storage,
+        ocr_text_layout, remove_clip_image_files, remove_duplicate_clips_in_database,
+        restore_hash_material, search_clips_in_database, set_clip_notes_in_database,
+        set_clip_ocr_text_in_database, source_app_filter_log_state, toggle_clip_hidden_in_pool,
+        toggle_clip_pin_in_pool, update_clip_text_in_database, ClipboardContent, NOTE_CHAR_LIMIT,
+        OCR_SNIPPET_CHAR_LIMIT,
     };
     use crate::clipboard::CapturedFormat;
     use crate::database::Database;
@@ -3748,6 +3790,50 @@ mod tests {
         .unwrap();
         assert_eq!(page_two.len(), 1);
         assert_eq!(page_two[0].id, "day-one");
+    }
+
+    /// Pins SBS-773: the Info request log that release builds persist must
+    /// not contain the selected source-app filter value.
+    #[test]
+    fn get_clips_request_log_omits_raw_source_app_filter() {
+        let marker = "UniqueBankingApp.exe";
+        let line = get_clips_request_log(
+            Some("12"),
+            true,
+            Some("text"),
+            Some("2026-03-01 00:00:00"),
+            Some("2026-03-02 00:00:00"),
+            Some(marker),
+        );
+        assert!(
+            !line.contains(marker),
+            "release Info log must not contain the selected source app: {line}"
+        );
+        assert!(
+            line.contains("source_app: set"),
+            "a real selection should be categorical, got {line}"
+        );
+        assert!(
+            line.contains("filter_id: Some(\"12\")"),
+            "folder id is not source-app metadata and stays in the line: {line}"
+        );
+    }
+
+    /// Pins SBS-773: not asked, blank, and set stay distinct so a missing
+    /// filter cannot be read as "the user chose an empty app".
+    #[test]
+    fn source_app_filter_log_state_keeps_none_blank_and_set_apart() {
+        assert_eq!(source_app_filter_log_state(None), "none");
+        assert_eq!(source_app_filter_log_state(Some("")), "blank");
+        assert_eq!(source_app_filter_log_state(Some("   ")), "blank");
+        assert_eq!(source_app_filter_log_state(Some("code.exe")), "set");
+        assert!(
+            get_clips_request_log(None, false, None, None, None, None).contains("source_app: none")
+        );
+        assert!(
+            get_clips_request_log(None, false, None, None, None, Some(""))
+                .contains("source_app: blank")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Linear: https://linear.app/southboundsoftware/issue/SBS-773/stop-writing-source-app-filter-values-to-persistent-logs
- The History source-app filter was logged at info with the raw selected value. Release builds persist Info to LogDir.
- get_clips now logs that filter as none / blank / set. Debug adds only state and byte length.

A user who hits this now sees the same filtered History list. Their persistent log file no longer contains the selected application name.

## Sweep

rg for log macros that print source_app in src-tauri/src.
- get_clips request log: fixed (categorical state).
- perf get_clips / search_clips: no source_app. left as-is.
- clipboard attribution: already categorical at debug.
- get_source_apps: no log. search_clips never logged the raw filter.

## What this makes more likely
- Support logs can no longer name the filtered app.
- The set token still reveals that a source-app filter was used.
- Appending source_app to the perf get_clips line would reintroduce the leak.

## Fail-without-fix
Reverted only get_clips_request_log to Debug-print the raw Option. Both new tests failed. Restored; both passed.
The omit-raw test failed because the line contained the selected exe name.
The three-state test failed because the line said None instead of none.

## CI gate
Linux box; required job is windows-latest. Rust half via x86_64-pc-windows-gnu plus Wine, same flags as ci.yml.
- cargo fmt --check: pass
- cargo clippy --all-targets -D warnings: pass
- cargo test --all-targets: 214 passed, 2 ignored, 2 pre-existing Wine OCR fixture failures. New tests ran and passed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop writing raw History source-app filter values to persistent Info logs
> - Replaces the raw `source_app` value in Info-level logs with a categorical state: `none`, `blank`, or `set`, preventing user-selected app names from being persisted to disk.
> - Introduces `source_app_filter_log_state` and `get_clips_request_log` helpers in [commands.rs](https://github.com/tsouth89/cubby-clipboard/pull/218/files#diff-59f7096c7cd88d5d187e749ca400716cd225f951e78eac3d0081ec6c28ce5dcc) to encapsulate this mapping.
> - Adds a debug-level log recording only the categorical state and byte length of the source-app string, never the raw value.
> - Behavioral Change: existing log parsers expecting a raw `source_app` value in request log lines will now see `none`/`blank`/`set` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63f05a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->