### PR TITLE
SBS-777: Reject a signed Store installer that packs an unsigned cubby.exe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,10 @@ jobs:
       - name: Publish-guard rules
         shell: pwsh
         run: ./scripts/test-publish-guard.ps1
+      # Signed outer installer + unsigned packed cubby.exe/uninstall.exe must fail.
+      - name: Embedded installer signature rules
+        shell: pwsh
+        run: ./scripts/test-verify-installer-signature.ps1
       # Compiling cargo-audit from source took 5m55s of a 9m17s job, to then run
       # for 7 seconds. Cache the built binary instead. The key pins the exact
       # version, so the only way to get a stale tool is to change the pin, which

--- a/.github/workflows/publish-store-packages.yml
+++ b/.github/workflows/publish-store-packages.yml
@@ -59,6 +59,19 @@ jobs:
 
           "version=$version" >> $env:GITHUB_OUTPUT
 
+      # Separate from the outer Authenticode loop above. A signed container can
+      # still pack an unsigned cubby.exe or uninstall.exe (SBS-777).
+      - name: Verify embedded cubby and uninstaller signatures
+        shell: pwsh
+        run: |
+          $version = "${{ steps.release.outputs.version }}"
+          foreach ($architecture in @("x64", "arm64")) {
+            $installerPath = "release-assets/Cubby.Clipboard_${version}_${architecture}-Store-setup.exe"
+            ./scripts/verify-installer-signature.ps1 `
+              -Installer $installerPath `
+              -ExpectedSubject "CN=Brandon South"
+          }
+
       - name: Publish x64 installer
         shell: pwsh
         env:

--- a/.github/workflows/publish-store-packages.yml
+++ b/.github/workflows/publish-store-packages.yml
@@ -52,6 +52,9 @@ jobs:
             if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
               throw "$architecture installer has an invalid Authenticode signature: $($signature.StatusMessage)"
             }
+            if (-not $signature.SignerCertificate) {
+              throw "$architecture installer has a Valid Authenticode status but no signer certificate."
+            }
             if ($signature.SignerCertificate.Subject -ne $expectedSignerSubject) {
               throw "$architecture installer signer is unexpected: $($signature.SignerCertificate.Subject)"
             }
@@ -69,7 +72,7 @@ jobs:
             $installerPath = "release-assets/Cubby.Clipboard_${version}_${architecture}-Store-setup.exe"
             ./scripts/verify-installer-signature.ps1 `
               -Installer $installerPath `
-              -ExpectedSubject "CN=Brandon South"
+              -ExpectedSubject "CN=Brandon South, O=Brandon South, L=Wilmore, S=ky, C=US"
           }
 
       - name: Publish x64 installer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,7 +281,7 @@ jobs:
           # Verify the cubby.exe inside the installer, not the one on disk:
           # Tauri restores the unsigned original to target/release after packing
           # the signed copy, so the file here is NotSigned even on a good build.
-          ./scripts/verify-installer-signature.ps1 -Installer $stagedPath -ExpectedSubject "CN=Brandon South"
+          ./scripts/verify-installer-signature.ps1 -Installer $stagedPath -ExpectedSubject "CN=Brandon South, O=Brandon South, L=Wilmore, S=ky, C=US"
 
           # The dev-harness bins are feature-gated off, so nothing but the app
           # binary should be bundled. Catch any new stray executable that would
@@ -334,7 +334,7 @@ jobs:
           }
           # The Store build is a second `tauri build`, so it runs signCommand
           # again over its own copy of the app binary. Verify it independently.
-          ./scripts/verify-installer-signature.ps1 -Installer $stagedPath -ExpectedSubject "CN=Brandon South"
+          ./scripts/verify-installer-signature.ps1 -Installer $stagedPath -ExpectedSubject "CN=Brandon South, O=Brandon South, L=Wilmore, S=ky, C=US"
           "path=$stagedPath" >> $env:GITHUB_OUTPUT
           "name=$name" >> $env:GITHUB_OUTPUT
 

--- a/.github/workflows/validate-store-submission.yml
+++ b/.github/workflows/validate-store-submission.yml
@@ -75,6 +75,39 @@ jobs:
             Write-Host "Verified immutable R2 installer: $url"
           }
 
+      # Outer Authenticode is a separate check from the SHA-256 loop above and
+      # from the packed-binary verifier below. None of the three waives another.
+      - name: Verify outer installer signatures
+        shell: pwsh
+        env:
+          STORE_VERSION: ${{ inputs.version }}
+        run: |
+          $expectedSignerSubject = "CN=Brandon South, O=Brandon South, L=Wilmore, S=ky, C=US"
+          foreach ($architecture in @("x64", "arm64")) {
+            $name = "Cubby.Clipboard_$env:STORE_VERSION`_$architecture-Store-setup.exe"
+            $installerPath = Join-Path $env:RUNNER_TEMP $name
+            $signature = Get-AuthenticodeSignature -LiteralPath $installerPath
+            if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
+              throw "$architecture installer has an invalid Authenticode signature: $($signature.StatusMessage)"
+            }
+            if ($signature.SignerCertificate.Subject -ne $expectedSignerSubject) {
+              throw "$architecture installer signer is unexpected: $($signature.SignerCertificate.Subject)"
+            }
+          }
+
+      - name: Verify embedded cubby and uninstaller signatures
+        shell: pwsh
+        env:
+          STORE_VERSION: ${{ inputs.version }}
+        run: |
+          foreach ($architecture in @("x64", "arm64")) {
+            $name = "Cubby.Clipboard_$env:STORE_VERSION`_$architecture-Store-setup.exe"
+            $installerPath = Join-Path $env:RUNNER_TEMP $name
+            ./scripts/verify-installer-signature.ps1 `
+              -Installer $installerPath `
+              -ExpectedSubject "CN=Brandon South"
+          }
+
       - name: Set up Microsoft Store Developer CLI
         uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0 # v1.4
 
@@ -152,5 +185,5 @@ jobs:
         run: |
           "### Microsoft Store validation passed" |
             Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
-          "Credentials, product access, both package architectures, and R2 URLs were validated. No submission was changed." |
+          "Credentials, product access, both package architectures, R2 checksums, outer signatures, and embedded cubby/uninstaller signatures were validated. No submission was changed." |
             Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8

--- a/.github/workflows/validate-store-submission.yml
+++ b/.github/workflows/validate-store-submission.yml
@@ -90,6 +90,9 @@ jobs:
             if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
               throw "$architecture installer has an invalid Authenticode signature: $($signature.StatusMessage)"
             }
+            if (-not $signature.SignerCertificate) {
+              throw "$architecture installer has a Valid Authenticode status but no signer certificate."
+            }
             if ($signature.SignerCertificate.Subject -ne $expectedSignerSubject) {
               throw "$architecture installer signer is unexpected: $($signature.SignerCertificate.Subject)"
             }
@@ -105,7 +108,7 @@ jobs:
             $installerPath = Join-Path $env:RUNNER_TEMP $name
             ./scripts/verify-installer-signature.ps1 `
               -Installer $installerPath `
-              -ExpectedSubject "CN=Brandon South"
+              -ExpectedSubject "CN=Brandon South, O=Brandon South, L=Wilmore, S=ky, C=US"
           }
 
       - name: Set up Microsoft Store Developer CLI

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -25,7 +25,8 @@ been validated. The GitHub `release` environment must also define:
 
 The manual **Validate Microsoft Store submission** workflow uses a separate
 `store-validation` environment containing the same five Partner Center values.
-It verifies both R2 installers and checksums, authenticates to Partner Center,
+It verifies both R2 installers, checksums, outer Authenticode signatures, and
+the signature on the packed `cubby.exe` (and `uninstall.exe` when 7-Zip extracts it), authenticates to Partner Center,
 and maps the existing x64 and ARM64 Store packages to their new versioned URLs
 without changing a submission unless `publish` is explicitly selected.
 

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -31,6 +31,9 @@ const [
   supportPageDoc,
   settingsPanelSource,
   settingsLocaleText,
+  publishStoreWorkflow,
+  validateStoreWorkflow,
+  verifyInstallerSignature,
 ] = await Promise.all([
   read('package.json'),
   read('src-tauri/tauri.conf.json'),
@@ -52,6 +55,9 @@ const [
   read('product_pages/support.html'),
   read('frontend/src/components/SettingsPanel.tsx'),
   read('frontend/src/i18n/locales/en.json'),
+  read('.github/workflows/publish-store-packages.yml'),
+  read('.github/workflows/validate-store-submission.yml'),
+  read('scripts/verify-installer-signature.ps1'),
 ]);
 
 const packageVersion = JSON.parse(packageText).version;
@@ -98,6 +104,20 @@ if (!releaseWorkflow.includes('--config src-tauri/tauri.store.conf.json')) {
 
 if (!releaseWorkflow.includes('--features app-store')) {
   throw new Error('Microsoft Store builds must disable Cubby self-update and autostart integration');
+}
+
+// SBS-777: a signed outer Store installer is not enough. Publication and
+// validation must extract and check the packed cubby.exe and uninstall.exe.
+for (const [name, source] of [
+  ['publish-store-packages.yml', publishStoreWorkflow],
+  ['validate-store-submission.yml', validateStoreWorkflow],
+]) {
+  if (!source.includes('verify-installer-signature.ps1')) {
+    throw new Error(`${name} must verify embedded cubby and uninstaller signatures`);
+  }
+}
+if (!verifyInstallerSignature.includes('uninstall.exe')) {
+  throw new Error('verify-installer-signature.ps1 must still inspect uninstall.exe when 7-Zip extracts it');
 }
 
 const csp = tauriConfig.app?.security?.csp;

--- a/scripts/test-verify-installer-signature.ps1
+++ b/scripts/test-verify-installer-signature.ps1
@@ -57,8 +57,8 @@ function New-FakeSignature {
     }
 }
 
-$expectedSubject = "CN=Brandon South"
-$validSubject = "CN=Brandon South, O=Brandon South, L=Wilmore, S=ky, C=US"
+$expectedSubject = "CN=Brandon South, O=Brandon South, L=Wilmore, S=ky, C=US"
+$validSubject = $expectedSubject
 
 Write-Host "Get-RequiredPackedExecutableNames"
 
@@ -98,6 +98,16 @@ Assert-True "Valid status with no certificate is reject-missing-certificate" (
 $spoofedCn = New-FakeSignature -Status "Valid" -Subject "CN=Brandon South Evil, O=Attacker"
 Assert-True "CN that only contains the expected CN as a substring is reject-subject" (
     (Resolve-EmbeddedSignatureDecision -Signature $spoofedCn -ExpectedSubject $expectedSubject) -eq "reject-subject"
+)
+
+$spoofedOrg = New-FakeSignature -Status "Valid" -Subject "CN=Brandon South, O=Attacker"
+Assert-True "same CN with a different O is reject-subject" (
+    (Resolve-EmbeddedSignatureDecision -Signature $spoofedOrg -ExpectedSubject $expectedSubject) -eq "reject-subject"
+)
+
+$cnOnly = New-FakeSignature -Status "Valid" -Subject "CN=Brandon South"
+Assert-True "CN-only subject is reject-subject when the full DN is required" (
+    (Resolve-EmbeddedSignatureDecision -Signature $cnOnly -ExpectedSubject $expectedSubject) -eq "reject-subject"
 )
 
 Write-Host "Assert-PackedFileSignature / Assert-EmbeddedPackageSignatures"

--- a/scripts/test-verify-installer-signature.ps1
+++ b/scripts/test-verify-installer-signature.ps1
@@ -1,0 +1,243 @@
+# Tests the packed-binary signature rule used before a Store publish or
+# backfill.
+#
+# The failure mode this pins is a correctly signed outer installer that still
+# contains an unsigned cubby.exe or uninstall.exe. Store workflows used to
+# treat the outer Authenticode / SHA checks as sufficient. Deliberately not a
+# Pester suite: the runners and this machine disagree about which Pester major
+# version is present, and the rule is a pure function plus a fixture directory.
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$script = Join-Path $PSScriptRoot "verify-installer-signature.ps1"
+if (-not (Test-Path -LiteralPath $script)) {
+    throw "verify-installer-signature.ps1 not found next to this test"
+}
+
+# Load the functions without running the script: dot-sourcing would demand the
+# mandatory -Installer parameter and try to extract a real NSIS package.
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($script, [ref]$null, [ref]$null)
+$functions = $ast.FindAll(
+    { param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] },
+    $true
+)
+foreach ($function in $functions) {
+    . ([scriptblock]::Create($function.Extent.Text))
+}
+
+$failures = New-Object System.Collections.Generic.List[string]
+
+function Assert-True {
+    param([string]$What, [bool]$Condition)
+    if ($Condition) {
+        Write-Host "  ok   $What"
+    }
+    else {
+        Write-Host "  FAIL $What" -ForegroundColor Red
+        $failures.Add($What)
+    }
+}
+
+function New-FakeSignature {
+    param(
+        [string]$Status,
+        [string]$Subject,
+        [string]$StatusMessage = ""
+    )
+
+    $certificate = $null
+    if (-not [string]::IsNullOrWhiteSpace($Subject)) {
+        $certificate = [pscustomobject]@{ Subject = $Subject }
+    }
+    [pscustomobject]@{
+        Status = $Status
+        StatusMessage = $StatusMessage
+        SignerCertificate = $certificate
+    }
+}
+
+$expectedSubject = "CN=Brandon South"
+$validSubject = "CN=Brandon South, O=Brandon South, L=Wilmore, S=ky, C=US"
+
+Write-Host "Get-RequiredPackedExecutableNames"
+
+$required = @(Get-RequiredPackedExecutableNames)
+$optional = @(Get-OptionalPackedExecutableNames)
+Assert-True "requires cubby.exe" ($required -contains "cubby.exe")
+Assert-True "does not require uninstall.exe in the 7-Zip extract" ($required -notcontains "uninstall.exe")
+Assert-True "treats uninstall.exe as optional-if-present" ($optional -contains "uninstall.exe")
+Assert-True "does not require the WebView2 bootstrapper" (
+    @($required + $optional | Where-Object { $_ -like "*WebView*" }).Count -eq 0
+)
+
+Write-Host "Resolve-EmbeddedSignatureDecision"
+
+# The case Store publication used to miss: a Valid outer signature does not
+# change this function's answer. An unsigned packed cubby.exe is still reject.
+$unsignedInner = New-FakeSignature -Status "NotSigned" -Subject "" -StatusMessage "The file is not signed."
+Assert-True "unsigned inner is reject-status even when the caller already accepted the outer package" (
+    (Resolve-EmbeddedSignatureDecision -Signature $unsignedInner -ExpectedSubject $expectedSubject) -eq "reject-status"
+)
+
+$validInner = New-FakeSignature -Status "Valid" -Subject $validSubject
+Assert-True "valid expected subject is accept" (
+    (Resolve-EmbeddedSignatureDecision -Signature $validInner -ExpectedSubject $expectedSubject) -eq "accept"
+)
+
+$wrongSubject = New-FakeSignature -Status "Valid" -Subject "CN=Someone Else"
+Assert-True "unexpected signer is reject-subject" (
+    (Resolve-EmbeddedSignatureDecision -Signature $wrongSubject -ExpectedSubject $expectedSubject) -eq "reject-subject"
+)
+
+$validNoSubject = New-FakeSignature -Status "Valid" -Subject ""
+Assert-True "Valid status with no certificate is reject-status" (
+    (Resolve-EmbeddedSignatureDecision -Signature $validNoSubject -ExpectedSubject $expectedSubject) -eq "reject-status"
+)
+
+Write-Host "Assert-PackedFileSignature / Assert-EmbeddedPackageSignatures"
+
+$scratch = Join-Path ([System.IO.Path]::GetTempPath()) ("cubby-verify-test-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $scratch | Out-Null
+try {
+    $installerName = "Cubby.Clipboard_1.3.1_x64-Store-setup.exe"
+    $installerPath = Join-Path $scratch $installerName
+    Set-Content -LiteralPath $installerPath -Value "outer-installer-bytes"
+    $extractDir = Join-Path $scratch "extracted"
+    New-Item -ItemType Directory -Path $extractDir | Out-Null
+    $cubbyPath = Join-Path $extractDir "cubby.exe"
+    $uninstallPath = Join-Path $extractDir "uninstall.exe"
+    Set-Content -LiteralPath $cubbyPath -Value "unsigned-cubby"
+    Set-Content -LiteralPath $uninstallPath -Value "signed-uninstaller"
+
+    # Signed outer package (the file exists; we never consult its signature
+    # here) with an unsigned packed cubby.exe. This is the SBS-777 miss.
+    $lookup = {
+        param($Path)
+        $leaf = Split-Path -Leaf $Path
+        if ($leaf -eq "cubby.exe") {
+            return New-FakeSignature -Status "NotSigned" -Subject "" -StatusMessage "The file is not signed."
+        }
+        return New-FakeSignature -Status "Valid" -Subject $validSubject
+    }
+
+    $rejectedUnsignedInner = $false
+    $unsignedInnerMessage = ""
+    try {
+        Assert-EmbeddedPackageSignatures `
+            -InstallerPath $installerPath `
+            -ExtractDir $extractDir `
+            -ExpectedSubject $expectedSubject `
+            -GetSignature $lookup
+    }
+    catch {
+        $rejectedUnsignedInner = $true
+        $unsignedInnerMessage = [string]$_.Exception.Message
+    }
+    Assert-True "signed outer + unsigned cubby.exe is rejected" $rejectedUnsignedInner
+    Assert-True "rejection names the installer artifact" ($unsignedInnerMessage -like "*$installerName*")
+    Assert-True "rejection names the packed cubby.exe" ($unsignedInnerMessage -like "*cubby.exe*")
+    Assert-True "rejection does not mention signing credentials" (
+        $unsignedInnerMessage -notlike "*ARTIFACT_SIGNING*" -and
+        $unsignedInnerMessage -notlike "*CLIENT_SECRET*"
+    )
+
+    $bothSigned = {
+        param($Path)
+        New-FakeSignature -Status "Valid" -Subject $validSubject
+    }
+
+    # Missing uninstall.exe must not fail: Tauri WriteUninstaller does not pack it.
+    Remove-Item -LiteralPath $uninstallPath -Force
+    $acceptedWithoutUninstaller = $true
+    try {
+        Assert-EmbeddedPackageSignatures `
+            -InstallerPath $installerPath `
+            -ExtractDir $extractDir `
+            -ExpectedSubject $expectedSubject `
+            -GetSignature $bothSigned
+    }
+    catch {
+        $acceptedWithoutUninstaller = $false
+        Write-Host "  FAIL missing uninstall.exe should be accepted: $($_.Exception.Message)" -ForegroundColor Red
+        $failures.Add("missing uninstall.exe should be accepted")
+    }
+    Assert-True "missing uninstall.exe is accepted when cubby.exe is signed" $acceptedWithoutUninstaller
+
+    Set-Content -LiteralPath $uninstallPath -Value "unsigned-uninstaller"
+    $unsignedUninstaller = {
+        param($Path)
+        $leaf = Split-Path -Leaf $Path
+        if ($leaf -eq "uninstall.exe") {
+            return New-FakeSignature -Status "NotSigned" -Subject "" -StatusMessage "The file is not signed."
+        }
+        return New-FakeSignature -Status "Valid" -Subject $validSubject
+    }
+    $rejectedUnsignedUninstaller = $false
+    $unsignedUninstallerMessage = ""
+    try {
+        Assert-EmbeddedPackageSignatures `
+            -InstallerPath $installerPath `
+            -ExtractDir $extractDir `
+            -ExpectedSubject $expectedSubject `
+            -GetSignature $unsignedUninstaller
+    }
+    catch {
+        $rejectedUnsignedUninstaller = $true
+        $unsignedUninstallerMessage = [string]$_.Exception.Message
+    }
+    Assert-True "extracted unsigned uninstall.exe is rejected" $rejectedUnsignedUninstaller
+    Assert-True "unsigned-uninstaller error names uninstall.exe and the installer" (
+        $unsignedUninstallerMessage -like "*uninstall.exe*" -and
+        $unsignedUninstallerMessage -like "*$installerName*"
+    )
+
+    $accepted = $true
+    try {
+        Assert-EmbeddedPackageSignatures `
+            -InstallerPath $installerPath `
+            -ExtractDir $extractDir `
+            -ExpectedSubject $expectedSubject `
+            -GetSignature $bothSigned
+    }
+    catch {
+        $accepted = $false
+        Write-Host "  FAIL both-signed should accept: $($_.Exception.Message)" -ForegroundColor Red
+        $failures.Add("both-signed should accept")
+    }
+    Assert-True "cubby.exe and a present uninstall.exe signed by the expected subject are accepted" $accepted
+
+    $wrongLookup = {
+        param($Path)
+        New-FakeSignature -Status "Valid" -Subject "CN=Wrong Profile"
+    }
+    $rejectedWrongSubject = $false
+    $wrongSubjectMessage = ""
+    try {
+        Assert-EmbeddedPackageSignatures `
+            -InstallerPath $installerPath `
+            -ExtractDir $extractDir `
+            -ExpectedSubject $expectedSubject `
+            -GetSignature $wrongLookup
+    }
+    catch {
+        $rejectedWrongSubject = $true
+        $wrongSubjectMessage = [string]$_.Exception.Message
+    }
+    Assert-True "unexpected packed signer is rejected" $rejectedWrongSubject
+    Assert-True "wrong-subject error names the installer and packed file" (
+        $wrongSubjectMessage -like "*$installerName*" -and
+        ($wrongSubjectMessage -like "*cubby.exe*" -or $wrongSubjectMessage -like "*uninstall.exe*")
+    )
+}
+finally {
+    Remove-Item -LiteralPath $scratch -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host ""
+    throw "$($failures.Count) embedded-signature assertion(s) failed: $($failures -join ', ')"
+}
+
+Write-Host ""
+Write-Host "embedded installer signatures: all assertions passed"

--- a/scripts/test-verify-installer-signature.ps1
+++ b/scripts/test-verify-installer-signature.ps1
@@ -91,8 +91,13 @@ Assert-True "unexpected signer is reject-subject" (
 )
 
 $validNoSubject = New-FakeSignature -Status "Valid" -Subject ""
-Assert-True "Valid status with no certificate is reject-status" (
-    (Resolve-EmbeddedSignatureDecision -Signature $validNoSubject -ExpectedSubject $expectedSubject) -eq "reject-status"
+Assert-True "Valid status with no certificate is reject-missing-certificate" (
+    (Resolve-EmbeddedSignatureDecision -Signature $validNoSubject -ExpectedSubject $expectedSubject) -eq "reject-missing-certificate"
+)
+
+$spoofedCn = New-FakeSignature -Status "Valid" -Subject "CN=Brandon South Evil, O=Attacker"
+Assert-True "CN that only contains the expected CN as a substring is reject-subject" (
+    (Resolve-EmbeddedSignatureDecision -Signature $spoofedCn -ExpectedSubject $expectedSubject) -eq "reject-subject"
 )
 
 Write-Host "Assert-PackedFileSignature / Assert-EmbeddedPackageSignatures"
@@ -228,6 +233,41 @@ try {
     Assert-True "wrong-subject error names the installer and packed file" (
         $wrongSubjectMessage -like "*$installerName*" -and
         ($wrongSubjectMessage -like "*cubby.exe*" -or $wrongSubjectMessage -like "*uninstall.exe*")
+    )
+
+    $missingCubbyDir = Join-Path $scratch "empty-extract"
+    New-Item -ItemType Directory -Path $missingCubbyDir | Out-Null
+    $missingCubbyMessage = ""
+    try {
+        Find-PackedExecutable `
+            -ExtractDir $missingCubbyDir `
+            -Name "cubby.exe" `
+            -InstallerPath $installerPath `
+            -ExtractExitCode 1
+    }
+    catch {
+        $missingCubbyMessage = [string]$_.Exception.Message
+    }
+    Assert-True "missing cubby.exe names the installer" ($missingCubbyMessage -like "*$installerName*")
+    Assert-True "missing cubby.exe includes the 7-Zip exit code" ($missingCubbyMessage -like "*7-Zip exit code 1*")
+
+    $missingCertLookup = {
+        param($Path)
+        New-FakeSignature -Status "Valid" -Subject ""
+    }
+    $missingCertMessage = ""
+    try {
+        Assert-EmbeddedPackageSignatures `
+            -InstallerPath $installerPath `
+            -ExtractDir $extractDir `
+            -ExpectedSubject $expectedSubject `
+            -GetSignature $missingCertLookup
+    }
+    catch {
+        $missingCertMessage = [string]$_.Exception.Message
+    }
+    Assert-True "Valid packed file with no certificate names the missing certificate" (
+        $missingCertMessage -like "*Valid but has no signer certificate*"
     )
 }
 finally {

--- a/scripts/verify-installer-signature.ps1
+++ b/scripts/verify-installer-signature.ps1
@@ -74,10 +74,13 @@ function Resolve-EmbeddedSignatureDecision {
         $subject = [string]$Signature.SignerCertificate.Subject
     }
     if ([string]::IsNullOrWhiteSpace($subject)) {
-        return "reject-status"
+        return "reject-missing-certificate"
     }
-    if ($ExpectedSubject -and $subject -notlike "*$ExpectedSubject*") {
-        return "reject-subject"
+    if ($ExpectedSubject) {
+        $escaped = [regex]::Escape($ExpectedSubject)
+        if ($subject -notmatch ("^(?i)" + $escaped + "(,|$)")) {
+            return "reject-subject"
+        }
     }
     return "accept"
 }
@@ -86,14 +89,19 @@ function Find-PackedExecutable {
     param(
         [Parameter(Mandatory = $true)][string]$ExtractDir,
         [Parameter(Mandatory = $true)][string]$Name,
-        [Parameter(Mandatory = $true)][string]$InstallerPath
+        [Parameter(Mandatory = $true)][string]$InstallerPath,
+        [int]$ExtractExitCode
     )
 
     $file = Get-ChildItem -LiteralPath $ExtractDir -Filter $Name -Recurse -File |
         Select-Object -First 1
     if (-not $file) {
         $installerName = Split-Path -Leaf $InstallerPath
-        throw "verify-installer-signature: no $Name inside $installerName."
+        $hint = ""
+        if ($PSBoundParameters.ContainsKey("ExtractExitCode")) {
+            $hint = " (7-Zip exit code $ExtractExitCode)"
+        }
+        throw "verify-installer-signature: no $Name inside $installerName.$hint"
     }
     return $file
 }
@@ -119,9 +127,13 @@ function Assert-PackedFileSignature {
         throw "verify-installer-signature: $installerName packed $embeddedName is '$status'.$detail"
     }
 
+    if ($decision -eq "reject-missing-certificate") {
+        throw "verify-installer-signature: $installerName packed $embeddedName is Valid but has no signer certificate."
+    }
+
     $subject = [string]$Signature.SignerCertificate.Subject
     if ($decision -eq "reject-subject") {
-        throw "verify-installer-signature: $installerName packed $embeddedName is signed by '$subject', which does not contain '$ExpectedSubject'."
+        throw "verify-installer-signature: $installerName packed $embeddedName is signed by '$subject', which is not '$ExpectedSubject'."
     }
 
     return $subject
@@ -132,7 +144,8 @@ function Assert-EmbeddedPackageSignatures {
         [Parameter(Mandatory = $true)][string]$InstallerPath,
         [Parameter(Mandatory = $true)][string]$ExtractDir,
         [string]$ExpectedSubject,
-        [scriptblock]$GetSignature
+        [scriptblock]$GetSignature,
+        [int]$ExtractExitCode
     )
 
     if (-not $GetSignature) {
@@ -142,8 +155,18 @@ function Assert-EmbeddedPackageSignatures {
         }
     }
 
+    $findArgs = @{
+        ExtractDir = $ExtractDir
+        Name = $null
+        InstallerPath = $InstallerPath
+    }
+    if ($PSBoundParameters.ContainsKey("ExtractExitCode")) {
+        $findArgs.ExtractExitCode = $ExtractExitCode
+    }
+
     foreach ($name in Get-RequiredPackedExecutableNames) {
-        $file = Find-PackedExecutable -ExtractDir $ExtractDir -Name $name -InstallerPath $InstallerPath
+        $findArgs.Name = $name
+        $file = Find-PackedExecutable @findArgs
         $signature = & $GetSignature $file.FullName
         $subject = Assert-PackedFileSignature `
             -InstallerPath $InstallerPath `
@@ -194,12 +217,15 @@ try {
     Write-Host "verify-installer-signature: extracting $resolved"
     # 7-Zip returns 1 for non-fatal warnings on NSIS containers, so the presence
     # of the required packed executables is the real success condition rather
-    # than the exit code.
+    # than the exit code. Keep the code in the missing-file error so a corrupt
+    # extract is distinguishable from "extracted, but cubby.exe was not inside".
     & $sevenZip x $resolved "-o$extractDir" -y | Out-Null
+    $extractExit = $LASTEXITCODE
     Assert-EmbeddedPackageSignatures `
         -InstallerPath $resolved `
         -ExtractDir $extractDir `
-        -ExpectedSubject $ExpectedSubject
+        -ExpectedSubject $ExpectedSubject `
+        -ExtractExitCode $extractExit
 }
 finally {
     Remove-Item -LiteralPath $extractDir -Recurse -Force -ErrorAction SilentlyContinue

--- a/scripts/verify-installer-signature.ps1
+++ b/scripts/verify-installer-signature.ps1
@@ -1,6 +1,7 @@
 <#
 .SYNOPSIS
-    Verifies that the cubby.exe packed inside a built NSIS installer is signed.
+    Verifies that the cubby.exe packed inside a built NSIS installer is signed,
+    and that uninstall.exe is signed when 7-Zip actually extracts it.
 
 .DESCRIPTION
     Do not check src-tauri/target/<triple>/release/cubby.exe for a signature
@@ -13,7 +14,20 @@
         after each package_type step.
 
     The only trustworthy check is on the bytes users actually receive, so this
-    extracts the installer and verifies the cubby.exe inside it.
+    extracts the installer and verifies the cubby.exe inside it. That is the
+    installed app binary signCommand signs before packing. Store installers
+    also embed a WebView2 bootstrapper; that file is not ours and is not
+    required here.
+
+    Tauri's NSIS uninstaller is produced at install time by WriteUninstaller
+    and signed during makensis via !uninstfinalize. 7-Zip therefore usually
+    cannot extract uninstall.exe from the container. If it is present, this
+    script verifies it the same way as cubby.exe. If it is absent, that is
+    not treated as "unsigned".
+
+    A valid signature on the outer installer does not waive these checks. The
+    Store publish and validate workflows keep the outer Authenticode / SHA
+    checks as separate steps and call this script for the packed binaries.
 
     Extraction uses 7-Zip, which reads the NSIS container. It is preinstalled on
     GitHub's windows runners.
@@ -28,7 +42,133 @@ param(
     [string]$ExpectedSubject
 )
 
+Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
+# cubby.exe is packed with NSIS File and is the binary users run.
+# uninstall.exe is optional in the extract: Tauri writes it at install time.
+# SBS-777: do not treat a signed outer container as enough.
+function Get-RequiredPackedExecutableNames {
+    @("cubby.exe")
+}
+
+function Get-OptionalPackedExecutableNames {
+    @("uninstall.exe")
+}
+
+# Pure decision so a test can pin "Valid outer, NotSigned inner" without 7-Zip
+# or a real certificate. Callers still have to run the outer check themselves.
+function Resolve-EmbeddedSignatureDecision {
+    param(
+        [Parameter(Mandatory = $true)]$Signature,
+        [string]$ExpectedSubject
+    )
+
+    $status = [string]$Signature.Status
+    if ($status -ne "Valid") {
+        return "reject-status"
+    }
+
+    $subject = $null
+    if ($Signature.PSObject.Properties["SignerCertificate"] -and $Signature.SignerCertificate) {
+        $subject = [string]$Signature.SignerCertificate.Subject
+    }
+    if ([string]::IsNullOrWhiteSpace($subject)) {
+        return "reject-status"
+    }
+    if ($ExpectedSubject -and $subject -notlike "*$ExpectedSubject*") {
+        return "reject-subject"
+    }
+    return "accept"
+}
+
+function Find-PackedExecutable {
+    param(
+        [Parameter(Mandatory = $true)][string]$ExtractDir,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$InstallerPath
+    )
+
+    $file = Get-ChildItem -LiteralPath $ExtractDir -Filter $Name -Recurse -File |
+        Select-Object -First 1
+    if (-not $file) {
+        $installerName = Split-Path -Leaf $InstallerPath
+        throw "verify-installer-signature: no $Name inside $installerName."
+    }
+    return $file
+}
+
+function Assert-PackedFileSignature {
+    param(
+        [Parameter(Mandatory = $true)][string]$InstallerPath,
+        [Parameter(Mandatory = $true)][string]$EmbeddedPath,
+        [string]$ExpectedSubject,
+        [Parameter(Mandatory = $true)]$Signature
+    )
+
+    $embeddedName = Split-Path -Leaf $EmbeddedPath
+    $installerName = Split-Path -Leaf $InstallerPath
+    $decision = Resolve-EmbeddedSignatureDecision -Signature $Signature -ExpectedSubject $ExpectedSubject
+    $status = [string]$Signature.Status
+
+    if ($decision -eq "reject-status") {
+        $detail = ""
+        if ($Signature.PSObject.Properties["StatusMessage"] -and $Signature.StatusMessage) {
+            $detail = " $([string]$Signature.StatusMessage)"
+        }
+        throw "verify-installer-signature: $installerName packed $embeddedName is '$status'.$detail"
+    }
+
+    $subject = [string]$Signature.SignerCertificate.Subject
+    if ($decision -eq "reject-subject") {
+        throw "verify-installer-signature: $installerName packed $embeddedName is signed by '$subject', which does not contain '$ExpectedSubject'."
+    }
+
+    return $subject
+}
+
+function Assert-EmbeddedPackageSignatures {
+    param(
+        [Parameter(Mandatory = $true)][string]$InstallerPath,
+        [Parameter(Mandatory = $true)][string]$ExtractDir,
+        [string]$ExpectedSubject,
+        [scriptblock]$GetSignature
+    )
+
+    if (-not $GetSignature) {
+        $GetSignature = {
+            param($Path)
+            Get-AuthenticodeSignature -LiteralPath $Path
+        }
+    }
+
+    foreach ($name in Get-RequiredPackedExecutableNames) {
+        $file = Find-PackedExecutable -ExtractDir $ExtractDir -Name $name -InstallerPath $InstallerPath
+        $signature = & $GetSignature $file.FullName
+        $subject = Assert-PackedFileSignature `
+            -InstallerPath $InstallerPath `
+            -EmbeddedPath $file.FullName `
+            -ExpectedSubject $ExpectedSubject `
+            -Signature $signature
+        Write-Host "verify-installer-signature: packed $name in $(Split-Path -Leaf $InstallerPath) is signed by $subject"
+    }
+
+    foreach ($name in Get-OptionalPackedExecutableNames) {
+        $file = Get-ChildItem -LiteralPath $ExtractDir -Filter $name -Recurse -File |
+            Select-Object -First 1
+        if (-not $file) {
+            Write-Host "verify-installer-signature: no $name inside $(Split-Path -Leaf $InstallerPath); Tauri generates the NSIS uninstaller at install time, so this is expected."
+            continue
+        }
+        $signature = & $GetSignature $file.FullName
+        $subject = Assert-PackedFileSignature `
+            -InstallerPath $InstallerPath `
+            -EmbeddedPath $file.FullName `
+            -ExpectedSubject $ExpectedSubject `
+            -Signature $signature
+        Write-Host "verify-installer-signature: packed $name in $(Split-Path -Leaf $InstallerPath) is signed by $subject"
+    }
+}
 
 if (-not (Test-Path -LiteralPath $Installer)) {
     throw "verify-installer-signature: no installer at $Installer."
@@ -47,31 +187,20 @@ if (-not $sevenZip) {
 }
 
 $resolved = (Resolve-Path -LiteralPath $Installer).Path
-$extractDir = Join-Path ([System.IO.Path]::GetTempPath()) ("cubby-verify-" + [System.IO.Path]::GetFileNameWithoutExtension($resolved))
-if (Test-Path -LiteralPath $extractDir) {
-    Remove-Item -LiteralPath $extractDir -Recurse -Force
+$extractDir = Join-Path ([System.IO.Path]::GetTempPath()) ("cubby-verify-" + [guid]::NewGuid().ToString("N"))
+
+try {
+    New-Item -ItemType Directory -Path $extractDir | Out-Null
+    Write-Host "verify-installer-signature: extracting $resolved"
+    # 7-Zip returns 1 for non-fatal warnings on NSIS containers, so the presence
+    # of the required packed executables is the real success condition rather
+    # than the exit code.
+    & $sevenZip x $resolved "-o$extractDir" -y | Out-Null
+    Assert-EmbeddedPackageSignatures `
+        -InstallerPath $resolved `
+        -ExtractDir $extractDir `
+        -ExpectedSubject $ExpectedSubject
 }
-
-Write-Host "verify-installer-signature: extracting $resolved"
-# 7-Zip returns 1 for non-fatal warnings on NSIS containers, so the presence of
-# cubby.exe below is the real success condition rather than the exit code.
-& $sevenZip x $resolved "-o$extractDir" -y | Out-Null
-
-$app = Get-ChildItem -LiteralPath $extractDir -Filter "cubby.exe" -Recurse -File |
-    Select-Object -First 1
-if (-not $app) {
-    throw "verify-installer-signature: no cubby.exe inside $resolved (7-Zip exit code $LASTEXITCODE)."
+finally {
+    Remove-Item -LiteralPath $extractDir -Recurse -Force -ErrorAction SilentlyContinue
 }
-
-$signature = Get-AuthenticodeSignature -LiteralPath $app.FullName
-if ($signature.Status -ne "Valid") {
-    throw "verify-installer-signature: the packed cubby.exe is '$($signature.Status)' - signCommand did not sign the binary that shipped. $($signature.StatusMessage)"
-}
-
-$subject = $signature.SignerCertificate.Subject
-if ($ExpectedSubject -and $subject -notlike "*$ExpectedSubject*") {
-    throw "verify-installer-signature: the packed cubby.exe is signed by '$subject', which does not contain '$ExpectedSubject'."
-}
-
-Write-Host "verify-installer-signature: packed cubby.exe is signed by $subject"
-Remove-Item -LiteralPath $extractDir -Recurse -Force -ErrorAction SilentlyContinue

--- a/scripts/verify-installer-signature.ps1
+++ b/scripts/verify-installer-signature.ps1
@@ -37,8 +37,9 @@ param(
     [Parameter(Mandatory = $true)]
     [string]$Installer,
 
-    # When set, the signer's certificate subject must contain this string. Guards
-    # against a build that is signed, but by the wrong certificate profile.
+    # When set, the signer's certificate subject must equal this string
+    # (case-insensitive). Prefix or substring matches are not enough: a cert
+    # whose CN is ours but whose O is not must still be rejected.
     [string]$ExpectedSubject
 )
 
@@ -77,8 +78,7 @@ function Resolve-EmbeddedSignatureDecision {
         return "reject-missing-certificate"
     }
     if ($ExpectedSubject) {
-        $escaped = [regex]::Escape($ExpectedSubject)
-        if ($subject -notmatch ("^(?i)" + $escaped + "(,|$)")) {
+        if (-not [string]::Equals($subject, $ExpectedSubject, [System.StringComparison]::OrdinalIgnoreCase)) {
             return "reject-subject"
         }
     }


### PR DESCRIPTION
## Summary

- Store publication and Store-submission validation now run `scripts/verify-installer-signature.ps1` on every selected x64 and arm64 installer. That check is separate from the existing outer Authenticode and SHA-256 steps, so a valid container signature no longer waives an unsigned packed `cubby.exe`.
- The verifier also inspects `uninstall.exe` when 7-Zip actually extracts it. Tauri generates that file at install time with WriteUninstaller and signs it during makensis via uninstfinalize, so a missing extract is expected and is not treated as unsigned.
- `scripts/check-release.mjs` now fails if either Store workflow drops the embedded-signature call. CI runs `scripts/test-verify-installer-signature.ps1`.

A user who hits this now sees: a Store backfill or validation job fail with the installer artifact name and the packed file that was unsigned or signed by the wrong subject, instead of publishing or submitting that package.

## Pattern sweep

Looked at every Store/signing path that could accept an installer.

- release.yml build: already calls the verifier on both NSIS outputs. Unchanged.
- publish-store-packages.yml backfill: outer Authenticode only. Added embedded verifier as its own step.
- validate-store-submission.yml: SHA-256 only. Added outer Authenticode and embedded verifier as separate steps.
- publish-store-installer.ps1: outer Authenticode + timestamp + SHA after upload. Left as the publish-time outer check; backfill now verifies embedded before this script runs.

Did not require every packed exe to be ours. Store installers embed a WebView2 bootstrapper.

## What this change makes more likely

- The backfill and validation jobs now 7-Zip-extract two 50MB+ Store installers. Those jobs get slower and use more runner disk. A future NSIS layout that 7-Zip cannot unpack will fail closed instead of publishing.
- Validation now also rejects a hash-matching installer whose outer Authenticode is invalid or the wrong subject. That is the intended fail-closed direction.

## Quality gates

Required CI job is ci.yml on windows-latest. This box is Linux, so I ran the steps that apply to these files.

1. Formatter: not rerun. No frontend TS/CSS changes.
2. Clippy: not rerun. No Rust changes.
3. Tests that cover this change all passed: test-verify-installer-signature.ps1, test-publish-guard.ps1, check-release.mjs, check-privileged-action-pins.mjs.
4. Fail-without-the-fix: restoring origin/main verify-installer-signature.ps1 made the new test exit 1 (Get-RequiredPackedExecutableNames not recognized). Restoring origin/main Store workflows made check-release.mjs throw: publish-store-packages.yml must verify embedded cubby and uninstaller signatures. Both passed again after restore.

## Test plan

- [x] Fixture rejects unsigned packed cubby.exe
- [x] Missing uninstall.exe accepted; unsigned extracted uninstall.exe rejected
- [x] check-release.mjs fails if Store workflows drop the verifier
- [ ] Wait for Windows CI
- [ ] Do not merge until CI is green


## Left out

Ticket stays open. Pipeline-only change.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject signed Store installers that pack an unsigned `cubby.exe` or `uninstall.exe`
> - Refactors [`verify-installer-signature.ps1`](https://github.com/tsouth89/cubby-clipboard/pull/219/files#diff-0e6f6d05835068091a1973ea64d593038a1fa3c72f47d382028a7b728a300f9f) to extract and validate signatures of embedded `cubby.exe` and `uninstall.exe`, requiring exact (case-insensitive) subject equality instead of a substring match.
> - Adds verification steps to [`publish-store-packages.yml`](https://github.com/tsouth89/cubby-clipboard/pull/219/files#diff-0e29bea99f0c6aea22530676a7dd453c2b81246f935d3682aa8513db6836810c) and [`validate-store-submission.yml`](https://github.com/tsouth89/cubby-clipboard/pull/219/files#diff-9c70cde89b127839d47b2fa6eb7093198c8b32f83c9121c2ba1457d92aea6d0f) that fail the workflow if outer or embedded signatures are invalid, the signer certificate is missing, or the subject does not exactly match the expected distinguished name.
> - Adds a PowerShell test harness in [`test-verify-installer-signature.ps1`](https://github.com/tsouth89/cubby-clipboard/pull/219/files#diff-7767aae5292a66228131172de7f78ac09b75cc0641dbefdcbe8202dfec41666e) and a CI step to run it, covering unsigned binaries, wrong subjects, missing certificates, and optional `uninstall.exe` scenarios.
> - Updates [`check-release.mjs`](https://github.com/tsouth89/cubby-clipboard/pull/219/files#diff-14ac66f5d0a1f9e003460f1b27bce6e68f7665390d99e23d897038130d21cdca) to fail if Store workflows do not call the embedded signature verifier or if the verifier no longer inspects `uninstall.exe`.
> - Behavioral Change: subject matching is now exact equality; previously a partial/substring match was accepted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9c18a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->