### PR TITLE
SBS-809: Authenticate the Win+V helper's localhost UDP channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 ## Unreleased
 
 ### Security
+- The Win+V helper no longer opens the flyout on a bare localhost UDP `activate` datagram; the channel now requires a per-session token, a loopback source, and a rate limit (SBS-809)
 - History source-app filter values are no longer written to the persistent Info log (SBS-773)
 - Pin third-party GitHub Actions in privileged release and Store workflows to immutable commit SHAs, and reject new mutable pins in CI
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,6 +18,15 @@ Cubby release candidates must pass the JavaScript production dependency audit, t
 - Next review: 2026-10-19 (or immediately if SQLx or the lockfile graph changes)
 
 
+## Win+V helper channel
+
+When Win+V replacement is enabled, the helper signals the main process over
+loopback UDP. The datagram must carry a per-session token Cubby generated for
+that helper, arrive from a loopback address, and stay under a short rate limit.
+A packet whose body is only `activate` is ignored. The token is passed as a
+helper argument, so a same-user process that can read Cubby's command line can
+still forge an activation.
+
 ## Privileged GitHub Actions pins
 
 Third-party actions in privileged release, Store, and signing workflows must be pinned to a 40-character commit SHA with a version comment. See docs/RELEASE_CHECKLIST.md for reviewing Dependabot action pin updates.

--- a/docs/SHORTCUT_ACCEPTANCE.md
+++ b/docs/SHORTCUT_ACCEPTANCE.md
@@ -18,10 +18,10 @@ Cubby's shortcut behavior is not complete until this matrix passes on Windows 11
 This default mode is provided by Cubby's bundled Windows shortcut helper. Users do not
 need PowerToys or another remapping application.
 
-The helper intercepts an exact physical `Win+V` chord and forwards it to Cubby's
-privately registered `Win+Alt+V` shortcut. Additional held modifiers do not
-trigger Cubby. If the helper is stopped or crashes, its keyboard hook disappears
-and native Windows behavior is restored.
+The helper intercepts an exact physical `Win+V` chord and signals the main
+Cubby process over the authenticated loopback channel. Additional held modifiers
+do not trigger Cubby. If the helper is stopped or crashes, its keyboard hook
+disappears and native Windows behavior is restored.
 
 Acceptance:
 

--- a/docs/SHORTCUT_BEHAVIOR.md
+++ b/docs/SHORTCUT_BEHAVIOR.md
@@ -18,9 +18,17 @@ process.
 The helper is a second instance of Cubby's own executable launched before the
 normal application startup path. No separate runtime or remapping application is
 required. The helper intercepts only an exact physical `Win+V` chord and signals
-the main Cubby process through a loopback-only activation channel. It ignores its
-own injected events, restores the physical Windows-key state before unrelated
-input continues, and exits independently if Cubby disables replacement mode.
+the main Cubby process through a loopback-only activation channel. The channel
+accepts only a per-session token that Cubby hands the helper it spawned, from a
+loopback source, and only at a human-scale rate. A bare `activate` datagram is
+ignored. The token travels on the helper command line, so a same-user process
+that can read Cubby's arguments can still forge an activation; that is weaker
+than an attacker who can decrypt `storage.key`, but it is no longer an
+unauthenticated display path.
+
+The helper ignores its own injected events, restores the physical Windows-key
+state before unrelated input continues, and exits independently if Cubby
+disables replacement mode.
 
 Cubby monitors the helper and restarts it after an unexpected exit. The helper
 also monitors its parent process, so a Cubby crash cannot leave the hook behind.

--- a/scripts/test-remote-trigger.ps1
+++ b/scripts/test-remote-trigger.ps1
@@ -52,6 +52,9 @@ $backquote = [byte]0xC0
 $keyUp = 0x0002
 $testMarker = [UIntPtr]0x43554254
 $activationHotkey = "Ctrl+Backquote"
+$tokenBytes = New-Object byte[] 16
+[System.Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($tokenBytes)
+$activationToken = -join ($tokenBytes | ForEach-Object { $_.ToString("x2") })
 $listener = [System.Net.Sockets.UdpClient]::new(0)
 $listener.Client.ReceiveTimeout = 3000
 $activationPort = ([System.Net.IPEndPoint]$listener.Client.LocalEndPoint).Port
@@ -90,6 +93,7 @@ try {
             "--timeout-seconds", $TimeoutSeconds,
             "--accept-injected-test-events",
             "--activation-port", $activationPort,
+            "--activation-token", $activationToken,
             "--activation-hotkey", $activationHotkey
         ) `
         -WindowStyle Hidden `
@@ -116,8 +120,8 @@ try {
     $remoteEndpoint = [System.Net.IPEndPoint]::new([System.Net.IPAddress]::Any, 0)
     $message = $listener.Receive([ref]$remoteEndpoint)
     $messageText = [System.Text.Encoding]::UTF8.GetString($message)
-    if ($messageText -ne "activate") {
-        throw "Expected direct activation message, received '$messageText'"
+    if ($messageText -ne "activate $activationToken") {
+        throw "Expected authorized activation message, received '$messageText'"
     }
 
     Start-Sleep -Milliseconds 150

--- a/src-tauri/src/bin/win_v_helper.rs
+++ b/src-tauri/src/bin/win_v_helper.rs
@@ -538,10 +538,15 @@ mod windows_helper {
                     return LRESULT(1);
                 }
                 match activate_cubby(None, false) {
-                    Ok(()) => emit("configured_hotkey", Some("activated Cubby directly")),
-                    Err(error) => emit("activation_failed", Some(&error)),
+                    Ok(()) => {
+                        emit("configured_hotkey", Some("activated Cubby directly"));
+                        return LRESULT(1);
+                    }
+                    Err(error) => {
+                        emit("activation_failed", Some(&error));
+                        return unsafe { CallNextHookEx(None, code, wparam, lparam) };
+                    }
                 }
-                return LRESULT(1);
             }
         }
 
@@ -625,6 +630,24 @@ mod windows_helper {
         win_v_activation::token_from_args(args.iter().map(String::as_str))
     }
 
+    /// UDP activation needs a well-formed token before the hook is installed.
+    /// Otherwise Win+V is swallowed with nowhere authenticated to send it.
+    /// Port 0 is the shortcut-injection fallback and does not use the token.
+    fn activation_token_for_port(
+        port: u16,
+        token: Option<String>,
+    ) -> Result<Option<String>, String> {
+        if port == 0 {
+            return Ok(None);
+        }
+        token
+            .ok_or_else(|| {
+                "Win+V helper requires a well-formed --activation-token when --activation-port is set"
+                    .to_string()
+            })
+            .map(Some)
+    }
+
     fn parse_activation_hotkey() -> Option<TriggerChord> {
         let args: Vec<String> = env::args().collect();
         args.windows(2)
@@ -656,8 +679,9 @@ mod windows_helper {
     pub fn run() -> Result<(), String> {
         let timeout_seconds = parse_timeout_seconds();
         let parent_pid = parse_parent_pid();
-        ACTIVATION_PORT.store(parse_activation_port().unwrap_or(0), Ordering::SeqCst);
-        if let Some(token) = parse_activation_token() {
+        let activation_port = parse_activation_port().unwrap_or(0);
+        ACTIVATION_PORT.store(activation_port, Ordering::SeqCst);
+        if let Some(token) = activation_token_for_port(activation_port, parse_activation_token())? {
             let _ = ACTIVATION_TOKEN.set(token);
         }
         ACCEPT_TEST_INPUT.store(
@@ -716,7 +740,8 @@ mod windows_helper {
     #[cfg(test)]
     mod tests {
         use super::{
-            is_supported_remote_process, parse_hotkey, Decision, RemapState, TriggerChord,
+            activation_token_for_port, is_supported_remote_process, parse_hotkey, Decision,
+            RemapState, TriggerChord,
         };
         use windows::Win32::UI::Input::KeyboardAndMouse::{VK_E, VK_LWIN, VK_V};
 
@@ -832,6 +857,26 @@ mod windows_helper {
             assert_eq!(parse_hotkey("Ctrl+Shift+A+B"), None); // two main keys
             assert_eq!(parse_hotkey("Ctrl+Nonsense"), None); // unknown key
             assert_eq!(parse_hotkey(""), None);
+        }
+
+        #[test]
+        fn udp_port_without_a_token_fails_before_the_hook_is_installed() {
+            let err = activation_token_for_port(9_001, None).expect_err("missing token");
+            assert!(
+                err.contains("--activation-token"),
+                "startup must name the missing flag so a manual launch is diagnosable: {err}"
+            );
+        }
+
+        #[test]
+        fn udp_port_with_a_token_keeps_it() {
+            let token = activation_token_for_port(9_001, Some("abc".into())).expect("token");
+            assert_eq!(token.as_deref(), Some("abc"));
+        }
+
+        #[test]
+        fn shortcut_fallback_does_not_require_a_token() {
+            assert_eq!(activation_token_for_port(0, None).expect("port 0"), None);
         }
 
         #[test]

--- a/src-tauri/src/bin/win_v_helper.rs
+++ b/src-tauri/src/bin/win_v_helper.rs
@@ -1,5 +1,6 @@
 #[cfg(target_os = "windows")]
 mod windows_helper {
+    use cubby::win_v_activation;
     use serde::Serialize;
     use std::env;
     use std::net::UdpSocket;
@@ -31,6 +32,7 @@ mod windows_helper {
     static HOOK_THREAD_ID: AtomicU32 = AtomicU32::new(0);
     static ACCEPT_TEST_INPUT: AtomicBool = AtomicBool::new(false);
     static ACTIVATION_PORT: AtomicU16 = AtomicU16::new(0);
+    static ACTIVATION_TOKEN: OnceLock<String> = OnceLock::new();
     /// The user's configured Cubby hotkey, parsed into a physical chord. When a
     /// remote client is focused this chord is caught here, below the remote
     /// client's key forwarding, so the same hotkey that opens Cubby locally also
@@ -387,12 +389,19 @@ mod windows_helper {
                 .map_err(|error| format!("shortcut fallback injection failed: {error:?}"));
         }
 
+        let token = ACTIVATION_TOKEN.get().ok_or_else(|| {
+            "activation token missing; refusing to send an unauthenticated datagram".to_string()
+        })?;
+        let payload = win_v_activation::encode_activate(token).ok_or_else(|| {
+            "activation token is malformed; refusing to send an unauthenticated datagram"
+                .to_string()
+        })?;
         let socket = UdpSocket::bind(("127.0.0.1", 0))
             .map_err(|error| format!("could not create activation socket: {error}"))?;
         let sent = socket
-            .send_to(b"activate", ("127.0.0.1", activation_port))
+            .send_to(&payload, ("127.0.0.1", activation_port))
             .map_err(|error| format!("could not signal Cubby: {error}"))?;
-        if sent != b"activate".len() {
+        if sent != payload.len() {
             return Err(format!("activation message was truncated to {sent} bytes"));
         }
         Ok(())
@@ -611,6 +620,11 @@ mod windows_helper {
             .and_then(|pair| pair[1].parse::<u16>().ok())
     }
 
+    fn parse_activation_token() -> Option<String> {
+        let args: Vec<String> = env::args().collect();
+        win_v_activation::token_from_args(args.iter().map(String::as_str))
+    }
+
     fn parse_activation_hotkey() -> Option<TriggerChord> {
         let args: Vec<String> = env::args().collect();
         args.windows(2)
@@ -643,6 +657,9 @@ mod windows_helper {
         let timeout_seconds = parse_timeout_seconds();
         let parent_pid = parse_parent_pid();
         ACTIVATION_PORT.store(parse_activation_port().unwrap_or(0), Ordering::SeqCst);
+        if let Some(token) = parse_activation_token() {
+            let _ = ACTIVATION_TOKEN.set(token);
+        }
         ACCEPT_TEST_INPUT.store(
             env::args().any(|arg| arg == "--accept-injected-test-events"),
             Ordering::SeqCst,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,6 +81,7 @@ mod secrets;
 mod settings_commands;
 mod settings_manager;
 mod shortcuts;
+pub mod win_v_activation;
 mod win_v_replacement;
 
 use database::Database;

--- a/src-tauri/src/win_v_activation.rs
+++ b/src-tauri/src/win_v_activation.rs
@@ -11,7 +11,6 @@ use std::time::{Duration, Instant};
 /// same-user process that can read Cubby's arguments can still forge a
 /// packet. That is a weaker attacker than one who can decrypt `storage.key`,
 /// but it is no longer "any datagram whose body is activate".
-
 pub const TOKEN_BYTE_LEN: usize = 16;
 pub const TOKEN_HEX_LEN: usize = TOKEN_BYTE_LEN * 2;
 pub const ACTIVATE_PREFIX: &[u8] = b"activate ";

--- a/src-tauri/src/win_v_activation.rs
+++ b/src-tauri/src/win_v_activation.rs
@@ -1,0 +1,281 @@
+use std::collections::VecDeque;
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+/// Shared Win+V helper <-> main-process datagram (SBS-809).
+///
+/// The helper used to send the literal body `activate` to a loopback UDP port.
+/// Any local process that could guess or scan that port could open the flyout.
+/// The channel now requires a per-session token, a loopback source, and a
+/// rate limit. The token is passed to the helper on its command line; a
+/// same-user process that can read Cubby's arguments can still forge a
+/// packet. That is a weaker attacker than one who can decrypt `storage.key`,
+/// but it is no longer "any datagram whose body is activate".
+
+pub const TOKEN_BYTE_LEN: usize = 16;
+pub const TOKEN_HEX_LEN: usize = TOKEN_BYTE_LEN * 2;
+pub const ACTIVATE_PREFIX: &[u8] = b"activate ";
+pub const ACTIVATE_MESSAGE_LEN: usize = ACTIVATE_PREFIX.len() + TOKEN_HEX_LEN;
+/// Recv buffer is larger than a valid message so a trailing suffix is visible
+/// and rejected instead of silently truncating into a match.
+pub const RECV_BUFFER_LEN: usize = ACTIVATE_MESSAGE_LEN + 16;
+
+const RATE_WINDOW: Duration = Duration::from_secs(1);
+const RATE_MAX_ACCEPTS: usize = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivationDecision {
+    Accept,
+    /// Missing token, wrong token, or the legacy bare `activate` body.
+    RejectUnauthenticated,
+    RejectOrigin,
+    RejectRateLimited,
+}
+
+pub struct ActivationRateLimit {
+    stamps: VecDeque<Instant>,
+}
+
+impl Default for ActivationRateLimit {
+    fn default() -> Self {
+        Self {
+            stamps: VecDeque::with_capacity(RATE_MAX_ACCEPTS),
+        }
+    }
+}
+
+impl ActivationRateLimit {
+    pub fn allow(&mut self, now: Instant) -> bool {
+        while let Some(front) = self.stamps.front() {
+            if now.duration_since(*front) >= RATE_WINDOW {
+                self.stamps.pop_front();
+            } else {
+                break;
+            }
+        }
+        if self.stamps.len() >= RATE_MAX_ACCEPTS {
+            return false;
+        }
+        self.stamps.push_back(now);
+        true
+    }
+}
+
+pub fn generate_token() -> Result<String, String> {
+    let mut bytes = [0_u8; TOKEN_BYTE_LEN];
+    getrandom::fill(&mut bytes)
+        .map_err(|error| format!("Could not generate the Cubby shortcut token: {error}"))?;
+    Ok(hex_encode(&bytes))
+}
+
+pub fn is_well_formed_token(token: &str) -> bool {
+    token.len() == TOKEN_HEX_LEN
+        && token
+            .bytes()
+            .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+pub fn encode_activate(token: &str) -> Option<Vec<u8>> {
+    if !is_well_formed_token(token) {
+        return None;
+    }
+    let mut message = Vec::with_capacity(ACTIVATE_MESSAGE_LEN);
+    message.extend_from_slice(ACTIVATE_PREFIX);
+    message.extend_from_slice(token.as_bytes());
+    Some(message)
+}
+
+pub fn token_from_args<'a, I>(args: I) -> Option<String>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let args: Vec<&str> = args.into_iter().collect();
+    args.windows(2)
+        .find(|pair| pair[0] == "--activation-token")
+        .map(|pair| pair[1].to_string())
+        .filter(|token| is_well_formed_token(token))
+}
+
+pub fn token_matches(payload: &[u8], token: &str) -> bool {
+    let Some(expected) = encode_activate(token) else {
+        return false;
+    };
+    constant_time_eq(payload, &expected)
+}
+
+pub fn decide_activation(
+    payload: &[u8],
+    source: SocketAddr,
+    token: &str,
+    rate: &mut ActivationRateLimit,
+    now: Instant,
+) -> ActivationDecision {
+    if !source.ip().is_loopback() {
+        return ActivationDecision::RejectOrigin;
+    }
+    if !token_matches(payload, token) {
+        return ActivationDecision::RejectUnauthenticated;
+    }
+    if !rate.allow(now) {
+        return ActivationDecision::RejectRateLimited;
+    }
+    ActivationDecision::Accept
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut diff = 0_u8;
+    for (a, b) in left.iter().zip(right.iter()) {
+        diff |= a ^ b;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    const TOKEN: &str = "0123456789abcdef0123456789abcdef";
+
+    fn loopback() -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9)
+    }
+
+    fn remote() -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 9)
+    }
+
+    /// SBS-809: a scanner that only knows the old body must not open the flyout.
+    #[test]
+    fn bare_activate_datagram_is_rejected() {
+        let mut rate = ActivationRateLimit::default();
+        assert_eq!(
+            decide_activation(b"activate", loopback(), TOKEN, &mut rate, Instant::now()),
+            ActivationDecision::RejectUnauthenticated
+        );
+    }
+
+    #[test]
+    fn matching_token_from_loopback_is_accepted() {
+        let mut rate = ActivationRateLimit::default();
+        let payload = encode_activate(TOKEN).expect("fixture token");
+        assert_eq!(
+            decide_activation(&payload, loopback(), TOKEN, &mut rate, Instant::now()),
+            ActivationDecision::Accept
+        );
+    }
+
+    #[test]
+    fn wrong_token_is_rejected() {
+        let mut rate = ActivationRateLimit::default();
+        let other = "fedcba9876543210fedcba9876543210";
+        let payload = encode_activate(other).expect("fixture token");
+        assert_eq!(
+            decide_activation(&payload, loopback(), TOKEN, &mut rate, Instant::now()),
+            ActivationDecision::RejectUnauthenticated
+        );
+    }
+
+    #[test]
+    fn trailing_suffix_is_rejected() {
+        let mut rate = ActivationRateLimit::default();
+        let mut payload = encode_activate(TOKEN).expect("fixture token");
+        payload.push(b'x');
+        assert_eq!(
+            decide_activation(&payload, loopback(), TOKEN, &mut rate, Instant::now()),
+            ActivationDecision::RejectUnauthenticated
+        );
+    }
+
+    #[test]
+    fn empty_or_malformed_token_never_matches() {
+        assert!(encode_activate("").is_none());
+        assert!(encode_activate("activate").is_none());
+        assert!(encode_activate(&"A".repeat(TOKEN_HEX_LEN)).is_none());
+        assert!(!token_matches(b"activate ", ""));
+    }
+
+    #[test]
+    fn non_loopback_source_is_rejected_even_with_a_valid_token() {
+        let mut rate = ActivationRateLimit::default();
+        let payload = encode_activate(TOKEN).expect("fixture token");
+        assert_eq!(
+            decide_activation(&payload, remote(), TOKEN, &mut rate, Instant::now()),
+            ActivationDecision::RejectOrigin
+        );
+    }
+
+    /// A flood of authorized packets must not keep toggling the flyout.
+    #[test]
+    fn rate_limit_rejects_a_flood_then_recovers() {
+        let mut rate = ActivationRateLimit::default();
+        let payload = encode_activate(TOKEN).expect("fixture token");
+        let start = Instant::now();
+        for offset_ms in 0..10 {
+            assert_eq!(
+                decide_activation(
+                    &payload,
+                    loopback(),
+                    TOKEN,
+                    &mut rate,
+                    start + Duration::from_millis(offset_ms),
+                ),
+                ActivationDecision::Accept,
+                "accept #{offset_ms}"
+            );
+        }
+        assert_eq!(
+            decide_activation(
+                &payload,
+                loopback(),
+                TOKEN,
+                &mut rate,
+                start + Duration::from_millis(11),
+            ),
+            ActivationDecision::RejectRateLimited
+        );
+        assert_eq!(
+            decide_activation(
+                &payload,
+                loopback(),
+                TOKEN,
+                &mut rate,
+                start + Duration::from_secs(1),
+            ),
+            ActivationDecision::Accept
+        );
+    }
+
+    #[test]
+    fn generate_token_is_32_lowercase_hex_and_unique() {
+        let first = generate_token().expect("entropy");
+        let second = generate_token().expect("entropy");
+        assert!(is_well_formed_token(&first));
+        assert!(is_well_formed_token(&second));
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn token_from_args_requires_a_well_formed_value() {
+        assert_eq!(
+            token_from_args(["--activation-token", TOKEN]),
+            Some(TOKEN.to_string())
+        );
+        assert_eq!(token_from_args(["--activation-token", "activate"]), None);
+        assert_eq!(token_from_args(["--activation-port", "1234"]), None);
+        assert_eq!(token_from_args(["--activation-token"]), None);
+    }
+}

--- a/src-tauri/src/win_v_replacement.rs
+++ b/src-tauri/src/win_v_replacement.rs
@@ -24,6 +24,7 @@ struct Inner {
     state: Mutex<HelperState>,
     watchdog_started: AtomicBool,
     activation_port: u16,
+    activation_token: String,
 }
 
 impl Drop for Inner {
@@ -40,21 +41,46 @@ pub struct WinVReplacementManager {
 
 impl WinVReplacementManager {
     pub fn new(app: AppHandle) -> Result<Self, String> {
+        // Fail closed if we cannot mint a token: an unauthenticated bind is
+        // the SBS-809 bug. Do not bind first and "add a token later".
+        let activation_token = crate::win_v_activation::generate_token()?;
         let socket = UdpSocket::bind(("127.0.0.1", 0))
             .map_err(|error| format!("Could not create the Cubby shortcut channel: {error}"))?;
         let activation_port = socket
             .local_addr()
             .map_err(|error| format!("Could not inspect the Cubby shortcut channel: {error}"))?
             .port();
+        let listener_token = activation_token.clone();
         std::thread::spawn(move || {
-            let mut buffer = [0_u8; 32];
+            let mut buffer = [0_u8; crate::win_v_activation::RECV_BUFFER_LEN];
+            let mut rate = crate::win_v_activation::ActivationRateLimit::default();
             loop {
                 match socket.recv_from(&mut buffer) {
-                    Ok((length, _)) if &buffer[..length] == b"activate" => {
-                        log::debug!("WIN_V: Received direct shortcut activation");
-                        crate::shortcuts::toggle_main_window(&app);
+                    Ok((length, source)) => {
+                        match crate::win_v_activation::decide_activation(
+                            &buffer[..length],
+                            source,
+                            &listener_token,
+                            &mut rate,
+                            std::time::Instant::now(),
+                        ) {
+                            crate::win_v_activation::ActivationDecision::Accept => {
+                                log::debug!("WIN_V: Received authorized shortcut activation");
+                                crate::shortcuts::toggle_main_window(&app);
+                            }
+                            crate::win_v_activation::ActivationDecision::RejectUnauthenticated => {
+                                log::debug!("WIN_V: Ignored unauthenticated shortcut activation");
+                            }
+                            crate::win_v_activation::ActivationDecision::RejectOrigin => {
+                                log::debug!(
+                                    "WIN_V: Ignored shortcut activation from outside loopback"
+                                );
+                            }
+                            crate::win_v_activation::ActivationDecision::RejectRateLimited => {
+                                log::debug!("WIN_V: Ignored shortcut activation (rate limited)");
+                            }
+                        }
                     }
-                    Ok(_) => {}
                     Err(error) => {
                         log::error!("WIN_V: Shortcut activation listener failed: {error}");
                         return;
@@ -68,6 +94,7 @@ impl WinVReplacementManager {
                 state: Mutex::new(HelperState::default()),
                 watchdog_started: AtomicBool::new(false),
                 activation_port,
+                activation_token,
             }),
         })
     }
@@ -93,7 +120,11 @@ impl WinVReplacementManager {
             stop_child(&mut state.child);
         }
 
-        ensure_child_running(&mut state, self.inner.activation_port)?;
+        ensure_child_running(
+            &mut state,
+            self.inner.activation_port,
+            &self.inner.activation_token,
+        )?;
         drop(state);
         self.start_watchdog();
         Ok(())
@@ -140,14 +171,20 @@ fn watchdog_loop(inner: Weak<Inner>) {
 
         if exited {
             state.child = None;
-            if let Err(error) = ensure_child_running(&mut state, inner.activation_port) {
+            if let Err(error) =
+                ensure_child_running(&mut state, inner.activation_port, &inner.activation_token)
+            {
                 log::error!("WIN_V: Helper restart failed: {error}");
             }
         }
     }
 }
 
-fn ensure_child_running(state: &mut HelperState, activation_port: u16) -> Result<(), String> {
+fn ensure_child_running(
+    state: &mut HelperState,
+    activation_port: u16,
+    activation_token: &str,
+) -> Result<(), String> {
     if let Some(child) = state.child.as_mut() {
         match child.try_wait() {
             Ok(None) => return Ok(()),
@@ -164,6 +201,8 @@ fn ensure_child_running(state: &mut HelperState, activation_port: u16) -> Result
         .arg(std::process::id().to_string())
         .arg("--activation-port")
         .arg(activation_port.to_string())
+        .arg("--activation-token")
+        .arg(activation_token)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
@@ -187,11 +226,9 @@ fn ensure_child_running(state: &mut HelperState, activation_port: u16) -> Result
         return Err(format!("Win+V helper exited during startup with {status}"));
     }
 
-    log::info!(
-        "WIN_V: Replacement helper started (pid {}, direct activation port {})",
-        child.id(),
-        activation_port
-    );
+    // Do not log the port or the token. The port was previously printed at
+    // Info and made the unauthenticated channel easier to find (SBS-809).
+    log::info!("WIN_V: Replacement helper started (pid {})", child.id());
     state.child = Some(child);
     Ok(())
 }


### PR DESCRIPTION
## Linear

[SBS-809](https://linear.app/southboundsoftware/issue/SBS-809/winv-helper-accepts-unauthenticated-localhost-udp-to-show-the-flyout) — Win+V helper accepts unauthenticated localhost UDP to show the flyout

## User-visible outcome

A user who presses Win+V still sees the flyout toggle. A local process that only sends the old activate datagram to the loopback port does not open the flyout. A user who never enables Win+V replacement sees no change.

## What changed

- New shared protocol in src-tauri/src/win_v_activation.rs. The helper and the main process both use it.
- On bind, Cubby mints a 16-byte token before opening the UDP socket. If entropy fails, replacement does not start (fail-closed).
- The helper is started with --activation-token. It refuses to send a datagram if the token is missing or malformed.
- The listener accepts a packet only when all three hold: loopback source, exact activate-plus-token body (constant-time compare), and under 10 accepts per second.
- Info logs no longer print the activation port.

## Sweep

rg for bare activate send_to and UdpSocket under src-tauri and scripts (excluding target).

- win_v_replacement.rs listener: was any body activate; now decide_activation
- win_v_helper.rs notify_cubby: was bare activate; now encode_activate(token) or refuse
- scripts/test-remote-trigger.ps1: now generates a token and expects activate plus token
- scripts/test-win-v-helper.ps1: no activation-port, key-injection fallback; left unchanged
- No other UdpSocket activation path

## Tests

Doc comments name the failure mode they pin. They live in src-tauri/src/win_v_activation.rs.

1. bare_activate_datagram_is_rejected — SBS-809 scanner that only knows the old body must not open the flyout
2. matching_token_from_loopback_is_accepted
3. wrong_token_is_rejected
4. trailing_suffix_is_rejected
5. empty_or_malformed_token_never_matches
6. non_loopback_source_is_rejected_even_with_a_valid_token
7. rate_limit_rejects_a_flood_then_recovers
8. generate_token_is_32_lowercase_hex_and_unique
9. token_from_args_requires_a_well_formed_value

### Fail-without-fix (rule 6)

Temporarily restored the old payload==activate accept in decide_activation, then ran bare_activate_datagram_is_rejected:

    assertion left == right failed
      left: Accept
     right: RejectUnauthenticated
    test tests::bare_activate_datagram_is_rejected ... FAILED

Restored the token check; the same test then passed.

This box is Linux. The cubby crate does not compile here (windows crate / HWND APIs). The nine tests were run by compiling win_v_activation.rs as its own crate with the same getrandom 0.3 the app already uses: 9 passed.

## Quality gate (rule 1)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate the Win+V helper's localhost UDP activation channel with a per-session token
> - Introduces a new [`win_v_activation`](https://github.com/tsouth89/cubby-clipboard/pull/220/files#diff-65cc0848986ff23d5302c331d6622b8b1fa964de794e420007434219c29e26ea) module implementing token generation (32-char hex), constant-time token matching, loopback-origin enforcement, and a rate limit (10 accepts per 1-second window).
> - The main process generates a per-session token at startup and passes it to the helper via `--activation-token`; the listener rejects any datagram that doesn't match `activate <token>` or originates outside loopback.
> - The helper in [`win_v_helper.rs`](https://github.com/tsouth89/cubby-clipboard/pull/220/files#diff-ac135015d7157820c718fb38ce196712beb72374446b85386bde61c738b155f5) now sends `activate <token>` instead of bare `activate`, and refuses to send if the token is missing or malformed.
> - On UDP activation failure, the helper emits `activation_failed` and delegates to `CallNextHookEx` instead of swallowing the Win+V event.
> - Risk: helpers started without `--activation-token` on a non-zero port will fail to launch, and bare `activate` datagrams are silently dropped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f2defe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->