### PR TITLE
SBS-779: Compile every shipped Windows feature and architecture in pre-merge CI

### DIFF
--- a/.github/scripts/check-shipped-windows-ci.mjs
+++ b/.github/scripts/check-shipped-windows-ci.mjs
@@ -162,16 +162,20 @@ function jobProblems(job) {
   if (!/\bmkdir\s+dist\b/.test(body) && !/New-Item[^\n]*\bdist\b/.test(body)) {
     problems.push('job must create dist so tauri generate_context can see frontendDist');
   }
-  if (!/--manifest-path\s+src-tauri\/Cargo\.toml/.test(body)) {
+  const checkLines = body
+    .split('\n')
+    .filter((line) => /cargo\s+check\b/.test(line))
+    .join('\n');
+  if (!/--manifest-path\s+src-tauri\/Cargo\.toml/.test(checkLines)) {
     problems.push('cargo check must use --manifest-path src-tauri/Cargo.toml');
   }
-  if (!/--target\s+\$\{\{\s*matrix\.target\s*\}\}/.test(body)) {
+  if (!/--target\s+\$\{\{\s*matrix\.target\s*\}\}/.test(checkLines)) {
     problems.push('cargo check must pass --target ${{ matrix.target }}');
   }
-  if (!/--all-targets/.test(body)) {
+  if (!/--all-targets/.test(checkLines)) {
     problems.push('cargo check must pass --all-targets so feature-gated bins and tests compile');
   }
-  if (!/\$\{\{\s*matrix\.extra_args\s*\}\}/.test(body)) {
+  if (!/\$\{\{\s*matrix\.extra_args\s*\}\}/.test(checkLines)) {
     problems.push('cargo check must apply matrix.extra_args so app-store is not a host-only flag');
   }
   const cacheKey = firstMatch(job.lines, /^\s+key:\s*(.+)$/);

--- a/.github/scripts/check-shipped-windows-ci.mjs
+++ b/.github/scripts/check-shipped-windows-ci.mjs
@@ -80,7 +80,7 @@ export function parseIncludeMaps(jobLines) {
       break;
     }
     const itemStart = line.match(/^(\s+)-\s+([A-Za-z0-9_]+):\s*(.*)$/);
-    if (itemStart && itemStart[1].length === includeIndent + 2) {
+    if (itemStart && itemStart[1].length > includeIndent) {
       if (current) {
         items.push(current);
       }
@@ -159,6 +159,9 @@ function jobProblems(job) {
   if (/cargo\s+build\b/.test(body) || /tauri\s+build\b/.test(body)) {
     problems.push('pre-merge matrix must cargo check, not bundle');
   }
+  if (!/\bmkdir\s+dist\b/.test(body) && !/New-Item[^\n]*\bdist\b/.test(body)) {
+    problems.push('job must create dist so tauri generate_context can see frontendDist');
+  }
   if (!/--manifest-path\s+src-tauri\/Cargo\.toml/.test(body)) {
     problems.push('cargo check must use --manifest-path src-tauri/Cargo.toml');
   }
@@ -183,7 +186,12 @@ function jobProblems(job) {
 
 export function evaluateShippedWindowsCi(text) {
   const jobs = parseTopLevelJobs(text);
-  const checkJobs = jobs.filter((job) => job.lines.some((line) => !line.trim().startsWith('#') && line.includes('cargo check')));
+  // Only the shipped-Windows matrix: a host lint job that happens to run
+  // `cargo check` must not be required to look like this matrix.
+  const checkJobs = jobs.filter((job) => {
+    const body = job.lines.filter((line) => !line.trim().startsWith('#')).join('\n');
+    return /cargo\s+check\b/.test(body) && /matrix\.target/.test(body);
+  });
   const matched = [];
   const jobLevelProblems = [];
 

--- a/.github/scripts/check-shipped-windows-ci.mjs
+++ b/.github/scripts/check-shipped-windows-ci.mjs
@@ -1,0 +1,270 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const CI_WORKFLOW = '.github/workflows/ci.yml';
+
+/** SBS-779: every shipped Windows feature/arch pair must cargo-check in pre-merge CI. */
+export const REQUIRED_LEGS = [
+  { arch: 'x64', target: 'x86_64-pc-windows-msvc', features: 'default' },
+  { arch: 'x64', target: 'x86_64-pc-windows-msvc', features: 'app-store' },
+  { arch: 'arm64', target: 'aarch64-pc-windows-msvc', features: 'default' },
+  { arch: 'arm64', target: 'aarch64-pc-windows-msvc', features: 'app-store' },
+];
+
+function stripQuote(value) {
+  const trimmed = (value ?? '').trim();
+  if (
+    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+    (trimmed.startsWith('"') && trimmed.endsWith('"'))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function lineIndent(line) {
+  const match = line.match(/^(\s*)/);
+  return match ? match[1].length : 0;
+}
+
+/**
+ * Split a workflow into top-level jobs. Unknown / unparseable YAML is an
+ * empty list so the caller can fail closed instead of treating "no jobs"
+ * as "all legs present".
+ */
+export function parseTopLevelJobs(text) {
+  const lines = text.split(/\r?\n/);
+  const jobsHeader = lines.findIndex((line) => line === 'jobs:');
+  if (jobsHeader < 0) {
+    return [];
+  }
+
+  const jobs = [];
+  let current = null;
+  for (let index = jobsHeader + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    const jobMatch = line.match(/^  ([A-Za-z0-9_-]+):\s*$/);
+    if (jobMatch) {
+      if (current) {
+        jobs.push(current);
+      }
+      current = { id: jobMatch[1], startLine: index + 1, lines: [] };
+      continue;
+    }
+    if (current) {
+      current.lines.push(line);
+    }
+  }
+  if (current) {
+    jobs.push(current);
+  }
+  return jobs;
+}
+
+export function parseIncludeMaps(jobLines) {
+  const includeIdx = jobLines.findIndex((line) => /^\s+include:\s*$/.test(line));
+  if (includeIdx < 0) {
+    return [];
+  }
+  const includeIndent = lineIndent(jobLines[includeIdx]);
+  const items = [];
+  let current = null;
+  for (let index = includeIdx + 1; index < jobLines.length; index += 1) {
+    const line = jobLines[index];
+    if (!line.trim() || line.trim().startsWith('#')) {
+      continue;
+    }
+    const indent = lineIndent(line);
+    if (indent <= includeIndent) {
+      break;
+    }
+    const itemStart = line.match(/^(\s+)-\s+([A-Za-z0-9_]+):\s*(.*)$/);
+    if (itemStart && itemStart[1].length === includeIndent + 2) {
+      if (current) {
+        items.push(current);
+      }
+      current = { [itemStart[2]]: stripQuote(itemStart[3]) };
+      continue;
+    }
+    const kv = line.match(/^\s+([A-Za-z0-9_]+):\s*(.*)$/);
+    if (kv && current) {
+      current[kv[1]] = stripQuote(kv[2]);
+    }
+  }
+  if (current) {
+    items.push(current);
+  }
+  return items;
+}
+
+function firstMatch(lines, pattern) {
+  for (const line of lines) {
+    if (line.trim().startsWith('#')) {
+      continue;
+    }
+    const match = line.match(pattern);
+    if (match) {
+      return match[1] ?? match[0];
+    }
+  }
+  return '';
+}
+
+function classifyLeg(item) {
+  const arch = item.arch ?? '';
+  const target = item.target ?? '';
+  const features = item.features ?? '';
+  const extraArgs = item.extra_args ?? '';
+  const issues = [];
+
+  if (!arch) {
+    issues.push('matrix row is missing arch');
+  }
+  if (!target) {
+    issues.push('matrix row is missing target');
+  }
+  if (features !== 'default' && features !== 'app-store') {
+    issues.push(`matrix row features must be default or app-store (got ${features || 'empty'})`);
+  }
+  if (features === 'default' && extraArgs.includes('app-store')) {
+    issues.push('default leg must not pass --features app-store');
+  }
+  if (features === 'app-store' && !extraArgs.includes('--features app-store')) {
+    issues.push('app-store leg must pass --features app-store via extra_args');
+  }
+
+  return { arch, target, features, extraArgs, issues, ok: issues.length === 0 };
+}
+
+function jobProblems(job) {
+  const body = job.lines.filter((line) => !line.trim().startsWith('#')).join('\n');
+  const problems = [];
+  const name = firstMatch(job.lines, /^\s+name:\s*(.+)$/);
+  if (!/\$\{\{\s*matrix\.arch\s*\}\}/.test(name) || !/\$\{\{\s*matrix\.features\s*\}\}/.test(name)) {
+    problems.push('job name must include matrix.arch and matrix.features');
+  }
+  if (!/runs-on:\s*windows-latest/.test(body)) {
+    problems.push('job must run on windows-latest');
+  }
+  if (!/fail-fast:\s*false/.test(body)) {
+    problems.push('matrix fail-fast must be false so one leg cannot hide another');
+  }
+  if (!/timeout-minutes:\s*\d+/.test(body)) {
+    problems.push('job must set timeout-minutes so a wedged check cannot run for hours');
+  }
+  if (!/cargo\s+check\b/.test(body)) {
+    problems.push('job must run cargo check');
+  }
+  if (/cargo\s+build\b/.test(body) || /tauri\s+build\b/.test(body)) {
+    problems.push('pre-merge matrix must cargo check, not bundle');
+  }
+  if (!/--manifest-path\s+src-tauri\/Cargo\.toml/.test(body)) {
+    problems.push('cargo check must use --manifest-path src-tauri/Cargo.toml');
+  }
+  if (!/--target\s+\$\{\{\s*matrix\.target\s*\}\}/.test(body)) {
+    problems.push('cargo check must pass --target ${{ matrix.target }}');
+  }
+  if (!/--all-targets/.test(body)) {
+    problems.push('cargo check must pass --all-targets so feature-gated bins and tests compile');
+  }
+  if (!/\$\{\{\s*matrix\.extra_args\s*\}\}/.test(body)) {
+    problems.push('cargo check must apply matrix.extra_args so app-store is not a host-only flag');
+  }
+  const cacheKey = firstMatch(job.lines, /^\s+key:\s*(.+)$/);
+  if (!/matrix\.target/.test(cacheKey) || !/matrix\.features/.test(cacheKey)) {
+    problems.push('cache key must include matrix.target and matrix.features');
+  }
+  if (/dtolnay\/rust-toolchain/.test(body) && !/targets:\s*\$\{\{\s*matrix\.target\s*\}\}/.test(body)) {
+    problems.push('rust-toolchain must install matrix.target');
+  }
+  return problems;
+}
+
+export function evaluateShippedWindowsCi(text) {
+  const jobs = parseTopLevelJobs(text);
+  const checkJobs = jobs.filter((job) => job.lines.some((line) => !line.trim().startsWith('#') && line.includes('cargo check')));
+  const matched = [];
+  const jobLevelProblems = [];
+
+  if (checkJobs.length === 0) {
+    return {
+      ok: false,
+      reason: 'no CI job runs cargo check',
+      missing: REQUIRED_LEGS,
+      matched,
+      jobLevelProblems: ['no CI job runs cargo check'],
+    };
+  }
+
+  for (const job of checkJobs) {
+    const problems = jobProblems(job);
+    if (problems.length > 0) {
+      jobLevelProblems.push(...problems.map((problem) => `${job.id}: ${problem}`));
+    }
+    const includes = parseIncludeMaps(job.lines);
+    if (includes.length === 0) {
+      jobLevelProblems.push(`${job.id}: cargo check job has no matrix include rows`);
+      continue;
+    }
+    for (const item of includes) {
+      matched.push({ job: job.id, ...classifyLeg(item) });
+    }
+  }
+
+  const missing = REQUIRED_LEGS.filter(
+    (required) =>
+      !matched.some(
+        (leg) =>
+          leg.ok &&
+          leg.arch === required.arch &&
+          leg.target === required.target &&
+          leg.features === required.features,
+      ),
+  );
+  const badLegs = matched.filter((leg) => !leg.ok);
+
+  return {
+    ok: missing.length === 0 && badLegs.length === 0 && jobLevelProblems.length === 0,
+    missing,
+    matched,
+    badLegs,
+    jobLevelProblems,
+    reason:
+      missing.length > 0
+        ? `missing shipped legs: ${missing.map((leg) => `${leg.arch} ${leg.features}`).join(', ')}`
+        : badLegs.length > 0
+          ? `invalid matrix rows: ${badLegs.map((leg) => leg.issues.join('; ')).join(' | ')}`
+          : jobLevelProblems[0] ?? '',
+  };
+}
+
+export async function checkShippedWindowsCi(rootDir) {
+  const text = await readFile(path.join(rootDir, CI_WORKFLOW), 'utf8');
+  return evaluateShippedWindowsCi(text);
+}
+
+function repoRootFromHere() {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const root = process.argv[2] ? path.resolve(process.argv[2]) : repoRootFromHere();
+  const result = await checkShippedWindowsCi(root);
+  if (!result.ok) {
+    for (const problem of result.jobLevelProblems) {
+      console.error(problem);
+    }
+    for (const leg of result.badLegs) {
+      console.error(`${leg.arch} ${leg.features}: ${leg.issues.join('; ')}`);
+    }
+    for (const leg of result.missing) {
+      console.error(`missing ${leg.arch} ${leg.features} (${leg.target})`);
+    }
+    console.error(`Shipped Windows CI check failed: ${result.reason}`);
+    process.exit(1);
+  }
+  console.log(
+    `Shipped Windows CI check passed: ${result.matched.length} cargo-check legs cover x64/ARM64 default and app-store.`,
+  );
+}

--- a/.github/scripts/check-shipped-windows-ci.test.mjs
+++ b/.github/scripts/check-shipped-windows-ci.test.mjs
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import {
+  CI_WORKFLOW,
+  REQUIRED_LEGS,
+  checkShippedWindowsCi,
+  evaluateShippedWindowsCi,
+  parseIncludeMaps,
+  parseTopLevelJobs,
+} from './check-shipped-windows-ci.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const VALID_JOB = `name: CI
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - run: cargo test --manifest-path src-tauri/Cargo.toml --all-targets
+  check-shipped-windows:
+    name: Check \${{ matrix.arch }} \${{ matrix.features }}
+    runs-on: windows-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            target: x86_64-pc-windows-msvc
+            features: default
+            extra_args: ''
+          - arch: x64
+            target: x86_64-pc-windows-msvc
+            features: app-store
+            extra_args: --features app-store
+          - arch: arm64
+            target: aarch64-pc-windows-msvc
+            features: default
+            extra_args: ''
+          - arch: arm64
+            target: aarch64-pc-windows-msvc
+            features: app-store
+            extra_args: --features app-store
+    steps:
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: \${{ matrix.target }}
+      - uses: actions/cache@v6
+        with:
+          key: \${{ runner.os }}-cargo-check-\${{ matrix.target }}-\${{ matrix.features }}-lock
+      - run: cargo check --manifest-path src-tauri/Cargo.toml --target \${{ matrix.target }} --all-targets \${{ matrix.extra_args }}
+`;
+
+test('parser splits top-level jobs and ignores deeper keys', () => {
+  const jobs = parseTopLevelJobs(VALID_JOB);
+  assert.deepEqual(
+    jobs.map((job) => job.id),
+    ['test', 'check-shipped-windows'],
+  );
+});
+
+test('parser reads matrix include maps including empty extra_args', () => {
+  const jobs = parseTopLevelJobs(VALID_JOB);
+  const checkJob = jobs.find((job) => job.id === 'check-shipped-windows');
+  const includes = parseIncludeMaps(checkJob.lines);
+  assert.equal(includes.length, 4);
+  assert.equal(includes[0].features, 'default');
+  assert.equal(includes[0].extra_args, '');
+  assert.equal(includes[1].extra_args, '--features app-store');
+});
+
+/** Pins SBS-779: host-only cargo test is not coverage of shipped Store/ARM64 configs. */
+test('a workflow that only cargo-tests the host default is missing every shipped leg', () => {
+  const result = evaluateShippedWindowsCi(`name: CI
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - run: cargo test --manifest-path src-tauri/Cargo.toml --all-targets
+`);
+  assert.equal(result.ok, false);
+  assert.equal(result.missing.length, REQUIRED_LEGS.length);
+  assert.match(result.reason, /no CI job runs cargo check/);
+});
+
+/** Pins SBS-779: dropping one architecture/feature pair must fail closed, not count as covered. */
+test('a matrix missing ARM64 app-store is not complete', () => {
+  const result = evaluateShippedWindowsCi(VALID_JOB.replace(
+    `          - arch: arm64
+            target: aarch64-pc-windows-msvc
+            features: app-store
+            extra_args: --features app-store
+`,
+    '',
+  ));
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.missing, [
+    { arch: 'arm64', target: 'aarch64-pc-windows-msvc', features: 'app-store' },
+  ]);
+});
+
+test('an app-store row that does not pass --features app-store is invalid, not a hit', () => {
+  const result = evaluateShippedWindowsCi(VALID_JOB.replace(
+    'extra_args: --features app-store',
+    "extra_args: ''",
+  ));
+  assert.equal(result.ok, false);
+  assert.ok(result.badLegs.some((leg) => leg.features === 'app-store'));
+});
+
+test('fail-fast true is rejected so one broken target cannot hide another', () => {
+  const result = evaluateShippedWindowsCi(VALID_JOB.replace('fail-fast: false', 'fail-fast: true'));
+  assert.equal(result.ok, false);
+  assert.ok(result.jobLevelProblems.some((problem) => problem.includes('fail-fast')));
+});
+
+test('a cargo build / tauri build matrix is rejected as too expensive', () => {
+  const result = evaluateShippedWindowsCi(
+    VALID_JOB.replace('cargo check --manifest-path', 'cargo build --manifest-path'),
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.reason + ' ' + result.jobLevelProblems.join(';'), /no CI job runs cargo check|not bundle/);
+});
+
+test('a cache key that omits target is rejected so matrix legs cannot clobber each other', () => {
+  const result = evaluateShippedWindowsCi(
+    VALID_JOB.replace(
+      'key: ${{ runner.os }}-cargo-check-${{ matrix.target }}-${{ matrix.features }}-lock',
+      'key: ${{ runner.os }}-cargo-${{ hashFiles(\'src-tauri/Cargo.lock\') }}',
+    ),
+  );
+  assert.equal(result.ok, false);
+  assert.ok(result.jobLevelProblems.some((problem) => problem.includes('cache key')));
+});
+
+test('an unnamed matrix job is rejected so failures are not an opaque Check (matrix)', () => {
+  const result = evaluateShippedWindowsCi(
+    VALID_JOB.replace('name: Check ${{ matrix.arch }} ${{ matrix.features }}', 'name: Check Windows'),
+  );
+  assert.equal(result.ok, false);
+  assert.ok(result.jobLevelProblems.some((problem) => problem.includes('job name')));
+});
+
+test('a valid four-leg cargo check matrix passes', () => {
+  const result = evaluateShippedWindowsCi(VALID_JOB);
+  assert.equal(result.ok, true, result.reason || result.jobLevelProblems.join('; '));
+  assert.equal(result.missing.length, 0);
+  assert.equal(result.matched.length, 4);
+});
+
+test('unparseable workflow fails closed instead of reporting full coverage', () => {
+  const result = evaluateShippedWindowsCi('name: CI\n');
+  assert.equal(result.ok, false);
+  assert.equal(result.missing.length, REQUIRED_LEGS.length);
+});
+
+/** Pins SBS-779: shipped pre-merge CI must cargo-check all four Windows configs. */
+test('shipped ci.yml cargo-checks x64/ARM64 default and app-store', async () => {
+  const result = await checkShippedWindowsCi(repoRoot);
+  assert.equal(
+    result.ok,
+    true,
+    [result.reason, ...result.jobLevelProblems].filter(Boolean).join('\n'),
+  );
+  assert.equal(result.matched.length, REQUIRED_LEGS.length);
+});
+
+/** Pins SBS-779 wiring: the required CI job must invoke this checker. */
+test('ci.yml runs the shipped-Windows checker and its tests', async () => {
+  const source = await readFile(path.join(repoRoot, CI_WORKFLOW), 'utf8');
+  assert.match(source, /check-shipped-windows-ci\.mjs/);
+  assert.match(source, /check-shipped-windows-ci\.test\.mjs/);
+});
+
+test('checker fails a temp repo whose ci.yml still only tests the host default', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'sbs-779-'));
+  await mkdir(path.join(root, '.github', 'workflows'), { recursive: true });
+  await writeFile(
+    path.join(root, CI_WORKFLOW),
+    `name: CI
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - run: cargo test --manifest-path src-tauri/Cargo.toml --all-targets
+`,
+  );
+  const result = await checkShippedWindowsCi(root);
+  assert.equal(result.ok, false);
+  assert.equal(result.missing.length, REQUIRED_LEGS.length);
+});

--- a/.github/scripts/check-shipped-windows-ci.test.mjs
+++ b/.github/scripts/check-shipped-windows-ci.test.mjs
@@ -54,6 +54,7 @@ jobs:
       - uses: actions/cache@v6
         with:
           key: \${{ runner.os }}-cargo-check-\${{ matrix.target }}-\${{ matrix.features }}-lock
+      - run: mkdir dist
       - run: cargo check --manifest-path src-tauri/Cargo.toml --target \${{ matrix.target }} --all-targets \${{ matrix.extra_args }}
 `;
 
@@ -125,7 +126,62 @@ test('a cargo build / tauri build matrix is rejected as too expensive', () => {
     VALID_JOB.replace('cargo check --manifest-path', 'cargo build --manifest-path'),
   );
   assert.equal(result.ok, false);
-  assert.match(result.reason + ' ' + result.jobLevelProblems.join(';'), /no CI job runs cargo check|not bundle/);
+  assert.match(result.reason, /no CI job runs cargo check/);
+});
+
+test('a cargo check job that also cargo-builds is rejected as too expensive', () => {
+  const result = evaluateShippedWindowsCi(
+    VALID_JOB.replace(
+      '- run: cargo check --manifest-path src-tauri/Cargo.toml --target ${{ matrix.target }} --all-targets ${{ matrix.extra_args }}',
+      `- run: cargo check --manifest-path src-tauri/Cargo.toml --target \${{ matrix.target }} --all-targets \${{ matrix.extra_args }}
+      - run: cargo build --manifest-path src-tauri/Cargo.toml --target \${{ matrix.target }}`,
+    ),
+  );
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.jobLevelProblems.some((problem) => problem.includes('not bundle')),
+    result.jobLevelProblems.join('; '),
+  );
+});
+
+test('an extra ubuntu cargo check job is not treated as the shipped-Windows matrix', () => {
+  const result = evaluateShippedWindowsCi(`${VALID_JOB}
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo check --manifest-path src-tauri/Cargo.toml
+`);
+  assert.equal(result.ok, true, result.reason || result.jobLevelProblems.join('; '));
+  assert.equal(result.matched.length, 4);
+});
+
+test('include rows indented more than two spaces still parse', () => {
+  const result = evaluateShippedWindowsCi(
+    VALID_JOB.replaceAll(
+      '          - arch:',
+      '            - arch:',
+    ).replaceAll(
+      '            target:',
+      '              target:',
+    ).replaceAll(
+      '            features:',
+      '              features:',
+    ).replaceAll(
+      '            extra_args:',
+      '              extra_args:',
+    ),
+  );
+  assert.equal(result.ok, true, result.reason || result.jobLevelProblems.join('; '));
+  assert.equal(result.matched.length, 4);
+});
+
+test('a matrix that never creates dist is rejected', () => {
+  const result = evaluateShippedWindowsCi(VALID_JOB.replace('      - run: mkdir dist\n', ''));
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.jobLevelProblems.some((problem) => problem.includes('create dist')),
+    result.jobLevelProblems.join('; '),
+  );
 });
 
 test('a cache key that omits target is rejected so matrix legs cannot clobber each other', () => {

--- a/.github/scripts/check-shipped-windows-ci.test.mjs
+++ b/.github/scripts/check-shipped-windows-ci.test.mjs
@@ -184,6 +184,21 @@ test('a matrix that never creates dist is rejected', () => {
   );
 });
 
+test('cargo check flags are not satisfied by a different cargo invocation in the same job', () => {
+  const result = evaluateShippedWindowsCi(
+    VALID_JOB.replace(
+      '- run: cargo check --manifest-path src-tauri/Cargo.toml --target ${{ matrix.target }} --all-targets ${{ matrix.extra_args }}',
+      `- run: cargo check --manifest-path src-tauri/Cargo.toml --target \${{ matrix.target }} \${{ matrix.extra_args }}
+      - run: cargo test --all-targets`,
+    ),
+  );
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.jobLevelProblems.some((problem) => problem.includes('--all-targets')),
+    result.jobLevelProblems.join('; '),
+  );
+});
+
 test('a cache key that omits target is rejected so matrix legs cannot clobber each other', () => {
   const result = evaluateShippedWindowsCi(
     VALID_JOB.replace(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,4 +145,8 @@ jobs:
             ${{ runner.os }}-cargo-check-${{ matrix.target }}-${{ matrix.features }}-
             ${{ runner.os }}-cargo-check-${{ matrix.target }}-
 
+      # tauri::generate_context! requires frontendDist ("../dist") to exist.
+      # The test job creates it via pnpm build; this matrix only cargo-checks.
+      - run: mkdir dist
+
       - run: cargo check --manifest-path src-tauri/Cargo.toml --target ${{ matrix.target }} --all-targets ${{ matrix.extra_args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,9 @@ jobs:
       - run: pnpm run build
       - run: node .github/scripts/check-site.mjs
       - run: node .github/scripts/check-privileged-action-pins.mjs
+      - run: node .github/scripts/check-shipped-windows-ci.mjs
       - run: pnpm run test
-      - run: node --test product_pages/worker.test.mjs product_pages/analytics.test.mjs .github/scripts/check-privileged-action-pins.test.mjs
+      - run: node --test product_pages/worker.test.mjs product_pages/analytics.test.mjs .github/scripts/check-privileged-action-pins.test.mjs .github/scripts/check-shipped-windows-ci.test.mjs
       - run: pnpm audit --prod
       # The rule that decides whether a live download URL may be overwritten.
       - name: Publish-guard rules
@@ -95,3 +96,53 @@ jobs:
       - run: cargo fmt --manifest-path src-tauri/Cargo.toml --check
       - run: cargo test --manifest-path src-tauri/Cargo.toml --all-targets
       - run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+
+  # SBS-779: compile every shipped Windows feature/arch pair on the PR, not
+  # only at tag/release. cargo check is enough to catch cfg(feature =
+  # "app-store") and target-specific breakage; the existing `test` job still
+  # owns host x64 tests, clippy, and fmt.
+  check-shipped-windows:
+    name: Check ${{ matrix.arch }} ${{ matrix.features }}
+    runs-on: windows-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            target: x86_64-pc-windows-msvc
+            features: default
+            extra_args: ''
+          - arch: x64
+            target: x86_64-pc-windows-msvc
+            features: app-store
+            extra_args: --features app-store
+          - arch: arm64
+            target: aarch64-pc-windows-msvc
+            features: default
+            extra_args: ''
+          - arch: arm64
+            target: aarch64-pc-windows-msvc
+            features: app-store
+            extra_args: --features app-store
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      # Per-target, per-feature cache so the four legs and the `test` job
+      # cannot clobber each other's src-tauri/target.
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: ${{ runner.os }}-cargo-check-${{ matrix.target }}-${{ matrix.features }}-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-check-${{ matrix.target }}-${{ matrix.features }}-
+            ${{ runner.os }}-cargo-check-${{ matrix.target }}-
+
+      - run: cargo check --manifest-path src-tauri/Cargo.toml --target ${{ matrix.target }} --all-targets ${{ matrix.extra_args }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - History source-app filter values are no longer written to the persistent Info log (SBS-773)
 - Pin third-party GitHub Actions in privileged release and Store workflows to immutable commit SHAs, and reject new mutable pins in CI
 
+### Changed
+- Pre-merge CI now cargo-checks x64 and ARM64 default and Microsoft Store feature builds, so those configurations fail on the pull request instead of at release (SBS-779)
+
 ### Fixed
 - Backup export, backup import, and Ditto import now only write or read a path chosen in the file dialog, so a compromised Settings page cannot send history to an arbitrary location (SBS-808)
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -157,3 +157,20 @@ When Dependabot opens an actions pin update:
    `node --test .github/scripts/check-privileged-action-pins.test.mjs`.
 5. Merge the pin update. Do not retarget the `uses:` ref back to a floating
    tag such as `@v3` or `@stable`.
+
+## Pre-merge Windows compile matrix (SBS-779)
+
+Pull-request CI cargo-checks four shipped configurations on `windows-latest`:
+
+- x64 default
+- x64 `app-store`
+- ARM64 default
+- ARM64 `app-store`
+
+That is a `cargo check --all-targets` per leg, not a bundle. Release still owns
+NSIS packaging, signing, and the Store installer. `.github/scripts/check-shipped-windows-ci.mjs`
+fails the required CI job if a leg is removed or renamed into an opaque matrix.
+
+A configuration-specific compile break should now fail the PR (`Check <arch> <features>`)
+instead of the first tag/release build that exercises that pair.
+


### PR DESCRIPTION
## Summary

- Pre-merge CI now cargo-checks the four shipped Windows configurations on windows-latest: x64 default, x64 app-store, ARM64 default, and ARM64 app-store.
- Each matrix leg is named Check <arch> <features>, uses cargo check --all-targets (not a bundle), and caches src-tauri/target per target+feature.
- A policy checker fails the required test job if a leg is removed, left unnamed, switched to a bundle, or given a cache key that omits target/features.

A contributor who breaks cfg(feature = "app-store") or an ARM64-only compile now sees a red Check arm64 app-store (or sibling) on the PR, instead of the first tag/release build that exercises that pair.

## Test plan

- [x] node --test .github/scripts/check-shipped-windows-ci.test.mjs -- 14/14 pass
- [x] Fail-without-fix: revert only the check-shipped-windows job; shipped ci.yml test fails with "no CI job runs cargo check". Restore -- passes.
- [x] node scripts/check-release.mjs -- Cubby Clipboard v1.3.1 release metadata is consistent.
- [x] node .github/scripts/check-privileged-action-pins.mjs -- 14 SHA-pinned third-party actions
- [x] node .github/scripts/check-shipped-windows-ci.mjs -- 4 cargo-check legs
- [x] Required CI node --test set (site + pin + shipped-Windows) -- 47/47 pass
- [ ] GitHub Actions Check x64 default / Check x64 app-store / Check arm64 default / Check arm64 app-store on this PR (Windows runners; cannot cargo-check windows crate targets on this Linux box)
- [ ] Confirm the existing test job still runs host x64 cargo test + clippy + fmt

## Sweep

app-store compile paths live in lib.rs and settings_commands.rs. release.yml still bundles x64/ARM64 plus app-store. check-release.mjs still requires that flag. No other pre-merge workflow covered these four pairs.

## What this makes more likely

Four extra Windows cargo check jobs per PR. ARM64 cross-compile on an x64 runner can fail for SDK reasons; fail-fast is false. Cache entries grow. A real app-store or ARM64 compile error now blocks merge.

## Gaps

Linux box could not run Windows cargo test or clippy. Frontend unchanged. rust-toolchain in CI stays on stable. Release packaging unchanged. Linear issue stays open.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pre-merge CI cargo check for all shipped Windows architectures and features
> - Adds a new `check-shipped-windows` CI job in [ci.yml](.github/workflows/ci.yml) that runs `cargo check` (not a full build) for x64 and ARM64 targets with both `default` and `app-store` features on `windows-latest`.
> - Adds [check-shipped-windows-ci.mjs](.github/scripts/check-shipped-windows-ci.mjs), a Node.js script that validates the CI workflow file contains a compliant Windows matrix, checking job structure, cache keys, flags, and required legs.
> - The checker script is run as part of the existing test job and fails CI if the required matrix is missing or misconfigured, preventing accidental removal of coverage.
> - Adds a test suite in [check-shipped-windows-ci.test.mjs](.github/scripts/check-shipped-windows-ci.test.mjs) covering parsing, leg classification, and integration against the real `ci.yml`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c6825e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->