### PR TITLE
SBS-807: Show image-row notes and disable Copy image after expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - Pre-merge CI now cargo-checks x64 and ARM64 default and Microsoft Store feature builds, so those configurations fail on the pull request instead of at release (SBS-779)
 
 ### Fixed
+- Screenshot notes now show on the History row, not only in the preview pane (SBS-807)
+- The image window no longer offers Copy image after the original has expired (SBS-807)
 - Backup export, backup import, and Ditto import now only write or read a path chosen in the file dialog, so a compromised Settings page cannot send history to an arbitrary location (SBS-808)
 
 ## v1.3.1

--- a/frontend/src/components/ClipCard.tsx
+++ b/frontend/src/components/ClipCard.tsx
@@ -24,6 +24,7 @@ import {
   parseImageMetadata,
   sourceLabel,
 } from '../utils/clipDisplay';
+import { shouldRenderClipRowNote } from '../utils/clipRowPresentation';
 
 interface ClipCardProps {
   clip: ClipboardItem;
@@ -53,6 +54,19 @@ interface ClipCardProps {
   /** Toggle multi-selection. The event carries the modifiers, so the caller can
    *  tell a plain toggle from a shift-extend. */
   onToggleSelect?: (event: React.MouseEvent) => void;
+}
+
+function ClipRowNote({ notes }: { notes: string }) {
+  return (
+    <p
+      data-el="clip-note"
+      className="mt-1 flex min-w-0 items-center gap-1 text-[11px] text-primary/85"
+      title={notes}
+    >
+      <StickyNote size={10} className="shrink-0" />
+      <span className="truncate">{notes}</span>
+    </p>
+  );
 }
 
 export const ClipCard = memo(function ClipCard({
@@ -307,6 +321,10 @@ export const ClipCard = memo(function ClipCard({
                   {imageDetails.join(' · ')}
                 </p>
               ) : null}
+              {shouldRenderClipRowNote(clip.notes, {
+                hidden: isHidden,
+                clipType: clip.clip_type,
+              }) && <ClipRowNote notes={clip.notes ?? ''} />}
               <p className="mt-1.5 truncate text-[11px] text-muted-foreground">
                 {label}
                 {age && <span className="px-1.5 text-muted-foreground/40">•</span>}
@@ -325,19 +343,10 @@ export const ClipCard = memo(function ClipCard({
             >
               {preview.slice(0, PREVIEW_CHAR_LIMIT)}
             </p>
-            {/* Explicit emptiness check: a note of "0" is a real note, and a
-                truthiness test would drop it while search and the title still
-                treated it as present. */}
-            {clip.notes != null && clip.notes !== '' && (
-              <p
-                data-el="clip-note"
-                className="mt-1 flex min-w-0 items-center gap-1 text-[11px] text-primary/85"
-                title={clip.notes}
-              >
-                <StickyNote size={10} className="shrink-0" />
-                <span className="truncate">{clip.notes}</span>
-              </p>
-            )}
+            {shouldRenderClipRowNote(clip.notes, {
+              hidden: isHidden,
+              clipType: clip.clip_type,
+            }) && <ClipRowNote notes={clip.notes ?? ''} />}
             <div className="mt-1.5 flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
               {clip.is_pinned && (
                 <>

--- a/frontend/src/utils/clipRowPresentation.test.ts
+++ b/frontend/src/utils/clipRowPresentation.test.ts
@@ -48,4 +48,19 @@ describe('fullImageCopyState', () => {
     expect(canCopyFullImage(fullImageCopyState(undefined))).toBe(false);
     expect(fullImageCopyTitle('unknown')).toBe('Copy image is unavailable until the image loads');
   });
+
+  it('stops telling the user to wait once the details fetch has failed', () => {
+    const state = fullImageCopyState(undefined, true);
+    expect(state).toBe('failed');
+    expect(canCopyFullImage(state)).toBe(false);
+    expect(fullImageCopyTitle(state)).not.toBe('Copy image is unavailable until the image loads');
+    expect(fullImageCopyTitle(state)).toBe(
+      'Copy image is unavailable; this image could not be loaded'
+    );
+  });
+
+  it('keeps a known expiry flag authoritative even if a later fetch failed', () => {
+    expect(fullImageCopyState(true, true)).toBe('expired');
+    expect(fullImageCopyState(false, true)).toBe('ready');
+  });
 });

--- a/frontend/src/utils/clipRowPresentation.test.ts
+++ b/frontend/src/utils/clipRowPresentation.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canCopyFullImage,
+  fullImageCopyState,
+  fullImageCopyTitle,
+  shouldRenderClipRowNote,
+} from './clipRowPresentation';
+
+describe('shouldRenderClipRowNote', () => {
+  it('shows a screenshot note the same as a text note (SBS-807)', () => {
+    const note = 'meeting whiteboard';
+    expect(shouldRenderClipRowNote(note, { hidden: false, clipType: 'image' })).toBe(true);
+    expect(shouldRenderClipRowNote(note, { hidden: false, clipType: 'text' })).toBe(true);
+  });
+
+  it('treats a note of "0" as present, not empty', () => {
+    expect(shouldRenderClipRowNote('0', { hidden: false, clipType: 'image' })).toBe(true);
+  });
+
+  it('hides an empty or missing note on every clip type', () => {
+    for (const clipType of ['image', 'text']) {
+      expect(shouldRenderClipRowNote(null, { hidden: false, clipType })).toBe(false);
+      expect(shouldRenderClipRowNote('', { hidden: false, clipType })).toBe(false);
+      expect(shouldRenderClipRowNote(undefined, { hidden: false, clipType })).toBe(false);
+    }
+  });
+
+  it('keeps notes off a still-hidden row until reveal', () => {
+    expect(shouldRenderClipRowNote('secret', { hidden: true, clipType: 'image' })).toBe(false);
+  });
+});
+
+describe('fullImageCopyState', () => {
+  it('disables Copy image once the full bitmap has expired (SBS-807)', () => {
+    expect(fullImageCopyState(true)).toBe('expired');
+    expect(canCopyFullImage(fullImageCopyState(true))).toBe(false);
+    expect(fullImageCopyTitle('expired')).toBe('Full image expired; only the thumbnail remains');
+  });
+
+  it('enables Copy image only when the original is known to be present', () => {
+    expect(fullImageCopyState(false)).toBe('ready');
+    expect(canCopyFullImage(fullImageCopyState(false))).toBe(true);
+  });
+
+  it('treats a missing expiry flag as unknown, not ready', () => {
+    expect(fullImageCopyState(undefined)).toBe('unknown');
+    expect(fullImageCopyState(null)).toBe('unknown');
+    expect(canCopyFullImage(fullImageCopyState(undefined))).toBe(false);
+    expect(fullImageCopyTitle('unknown')).toBe('Copy image is unavailable until the image loads');
+  });
+});

--- a/frontend/src/utils/clipRowPresentation.ts
+++ b/frontend/src/utils/clipRowPresentation.ts
@@ -31,13 +31,19 @@ export function shouldRenderClipRowNote(
  * - `ready`: full bitmap is present
  * - `expired`: header already says the original is gone; offering Copy image
  *   then failing is the SBS-807 bug. History's preview already disables Copy.
- * - `unknown`: details have not loaded (or failed). That is not "ready" —
- *   enabling the button would collapse "not asked yet" into "copy works".
+ * - `unknown`: details have not loaded yet. That is not "ready" — enabling the
+ *   button would collapse "not asked yet" into "copy works".
+ * - `failed`: the details fetch already rejected. Telling the user to wait for
+ *   a load that will never arrive is worse than saying it failed, so this is a
+ *   separate state from `unknown`.
  */
-export type FullImageCopyState = 'ready' | 'expired' | 'unknown';
+export type FullImageCopyState = 'ready' | 'expired' | 'unknown' | 'failed';
 
-export function fullImageCopyState(imageExpired: boolean | null | undefined): FullImageCopyState {
-  if (imageExpired == null) return 'unknown';
+export function fullImageCopyState(
+  imageExpired: boolean | null | undefined,
+  loadFailed = false
+): FullImageCopyState {
+  if (imageExpired == null) return loadFailed ? 'failed' : 'unknown';
   return imageExpired ? 'expired' : 'ready';
 }
 
@@ -47,6 +53,7 @@ export function canCopyFullImage(state: FullImageCopyState): boolean {
 
 export function fullImageCopyTitle(state: FullImageCopyState): string {
   if (state === 'expired') return 'Full image expired; only the thumbnail remains';
+  if (state === 'failed') return 'Copy image is unavailable; this image could not be loaded';
   if (state === 'unknown') return 'Copy image is unavailable until the image loads';
   return 'Copy image';
 }

--- a/frontend/src/utils/clipRowPresentation.ts
+++ b/frontend/src/utils/clipRowPresentation.ts
@@ -1,0 +1,52 @@
+/**
+ * Row-level presentation decisions shared by ClipCard and the image window.
+ * Extracted so SBS-807's two History bugs fail in unit tests instead of only
+ * in a rendered tree (there is no component-test harness yet).
+ */
+
+/**
+ * Whether a clip row should show its note.
+ *
+ * `clipType` is required at the call site so an image row cannot "forget" to
+ * ask. It must not hide the note: the old ClipCard only rendered notes in the
+ * text branch, so screenshot notes were searchable and visible in the History
+ * preview but missing on the row itself (SBS-807).
+ *
+ * A note of `"0"` is a real note. Hidden rows keep notes off the card until
+ * reveal — the hidden payload blanks them.
+ */
+export function shouldRenderClipRowNote(
+  notes: string | null | undefined,
+  options: { hidden: boolean; clipType: string }
+): boolean {
+  if (options.hidden) return false;
+  if (notes == null || notes === '') return false;
+  void options.clipType;
+  return true;
+}
+
+/**
+ * Copy-image availability for the dedicated image window.
+ *
+ * - `ready`: full bitmap is present
+ * - `expired`: header already says the original is gone; offering Copy image
+ *   then failing is the SBS-807 bug. History's preview already disables Copy.
+ * - `unknown`: details have not loaded (or failed). That is not "ready" —
+ *   enabling the button would collapse "not asked yet" into "copy works".
+ */
+export type FullImageCopyState = 'ready' | 'expired' | 'unknown';
+
+export function fullImageCopyState(imageExpired: boolean | null | undefined): FullImageCopyState {
+  if (imageExpired == null) return 'unknown';
+  return imageExpired ? 'expired' : 'ready';
+}
+
+export function canCopyFullImage(state: FullImageCopyState): boolean {
+  return state === 'ready';
+}
+
+export function fullImageCopyTitle(state: FullImageCopyState): string {
+  if (state === 'expired') return 'Full image expired; only the thumbnail remains';
+  if (state === 'unknown') return 'Copy image is unavailable until the image loads';
+  return 'Copy image';
+}

--- a/frontend/src/windows/ImageWindow.tsx
+++ b/frontend/src/windows/ImageWindow.tsx
@@ -6,6 +6,11 @@ import { Toaster, toast } from 'sonner';
 import { ClipDetails } from '../components/ClipPreview';
 import { ImageTextViewer } from '../components/ImageTextViewer';
 import { imageSrcFromContent } from '../utils/clipDisplay';
+import {
+  canCopyFullImage,
+  fullImageCopyState,
+  fullImageCopyTitle,
+} from '../utils/clipRowPresentation';
 import { useSystemAccent } from '../hooks/useSystemAccent';
 import { useTheme } from '../hooks/useTheme';
 import { Settings } from '../types';
@@ -68,8 +73,11 @@ export function ImageWindow() {
     }
   }, []);
 
+  const copyState = fullImageCopyState(details?.image_expired);
+  const copyImageEnabled = canCopyFullImage(copyState);
+
   const handleCopyImage = useCallback(async () => {
-    if (!clipId) return;
+    if (!clipId || !canCopyFullImage(fullImageCopyState(details?.image_expired))) return;
     try {
       await invoke('copy_clip', { id: clipId, plainText: false });
       toast.success('Copied');
@@ -77,7 +85,7 @@ export function ImageWindow() {
       console.error('Failed to copy the image:', copyError);
       toast.error('Failed to copy');
     }
-  }, [clipId]);
+  }, [clipId, details?.image_expired]);
 
   const handleCopyAllText = useCallback(async () => {
     if (!clipId) return;
@@ -101,7 +109,7 @@ export function ImageWindow() {
 
   const imageSrc = details ? imageSrcFromContent(details.content) : null;
   const actionClass =
-    'inline-flex items-center gap-1.5 rounded-md border border-white/[0.09] bg-white/[0.05] px-2.5 py-1.5 text-[11px] font-medium text-foreground transition-colors hover:bg-white/[0.1]';
+    'inline-flex items-center gap-1.5 rounded-md border border-white/[0.09] bg-white/[0.05] px-2.5 py-1.5 text-[11px] font-medium text-foreground transition-colors hover:bg-white/[0.1] disabled:opacity-40';
 
   return (
     <div className="flex h-screen select-none flex-col bg-background text-foreground">
@@ -122,7 +130,14 @@ export function ImageWindow() {
           )}
         </div>
         <div className="flex items-center gap-1.5" onMouseDown={(event) => event.stopPropagation()}>
-          <button type="button" className={actionClass} onClick={handleCopyImage}>
+          <button
+            type="button"
+            className={actionClass}
+            onClick={handleCopyImage}
+            disabled={!copyImageEnabled}
+            title={fullImageCopyTitle(copyState)}
+            aria-label={fullImageCopyTitle(copyState)}
+          >
             <Copy size={13} />
             Copy image
           </button>

--- a/frontend/src/windows/ImageWindow.tsx
+++ b/frontend/src/windows/ImageWindow.tsx
@@ -73,7 +73,8 @@ export function ImageWindow() {
     }
   }, []);
 
-  const copyState = fullImageCopyState(details?.image_expired);
+  const loadFailed = error != null;
+  const copyState = fullImageCopyState(details?.image_expired, loadFailed);
   const copyImageEnabled = canCopyFullImage(copyState);
 
   const handleCopyImage = useCallback(async () => {
@@ -109,7 +110,7 @@ export function ImageWindow() {
 
   const imageSrc = details ? imageSrcFromContent(details.content) : null;
   const actionClass =
-    'inline-flex items-center gap-1.5 rounded-md border border-white/[0.09] bg-white/[0.05] px-2.5 py-1.5 text-[11px] font-medium text-foreground transition-colors hover:bg-white/[0.1] disabled:opacity-40';
+    'inline-flex items-center gap-1.5 rounded-md border border-white/[0.09] bg-white/[0.05] px-2.5 py-1.5 text-[11px] font-medium text-foreground transition-colors enabled:hover:bg-white/[0.1] disabled:opacity-40';
 
   return (
     <div className="flex h-screen select-none flex-col bg-background text-foreground">


### PR DESCRIPTION
## Summary

Two of the three SBS-807 History presentation bugs, the ones that are not GitHub 186.

- Screenshot notes now render on the History/flyout image row, not only on text rows and in the preview pane.
- The dedicated image window disables Copy image once image_expired is true (and while details have not loaded). History preview already did this; the image window did not.

Bulk-copy OCR (SBS-807 item 1 / GitHub 186) is out of this PR. That path needs a backend batch read of recognized text; the list row only has has_ocr_text. Claiming the public issue from Linear would duplicate the open GitHub ticket.

## A user who hits this now sees

- An image clip with a note: the same clip-note line that text rows already showed, between the thumbnail details and the source/age line.
- An expired screenshot opened in the image window: Copy image is disabled, titled "Full image expired; only the thumbnail remains". Clicking it is a no-op. Copy all text (OCR) is unchanged.

## Sweep

Searched frontend/src tsx for Copy image, clip-note, and image_expired.

- ClipCard.tsx: note block was only in the non-image branch; now both branches use shouldRenderClipRowNote.
- ImageWindow.tsx: the only Copy image button. Now disabled via fullImageCopyState.
- ClipPreview.tsx around line 520: disabled={isImage && expired} already. Left as-is; this PR matches that behavior in the image window.
- HistoryWindow.tsx / App.tsx: copy handlers already toast and return on expired images. Not the armed-button bug.

## Fail-without-fix

Reverted only shouldRenderClipRowNote (image type returns false) and fullImageCopyState (always ready), then ran the new file:

```
 FAIL  src/utils/clipRowPresentation.test.ts > shouldRenderClipRowNote > shows a screenshot note the same as a text note (SBS-807)
AssertionError: expected false to be true

 FAIL  src/utils/clipRowPresentation.test.ts > shouldRenderClipRowNote > treats a note of "0" as present, not empty
AssertionError: expected false to be true

 FAIL  src/utils/clipRowPresentation.test.ts > fullImageCopyState > disables Copy image once the full bitmap has expired (SBS-807)
AssertionError: expected ready to be expired

 FAIL  src/utils/clipRowPresentation.test.ts > fullImageCopyState > treats a missing expiry flag as unknown, not ready
AssertionError: expected ready to be unknown

 Test Files  1 failed (1)
      Tests  4 failed | 3 passed (7)
```

Restored the helper; 7 passed.


## Quality gates

Frontend only on this Linux box. vitest 106 passed. prettier clean. tsc clean. vite build clean. release check pass. Cargo not re-run (no Rust change).

## What this makes more likely

Copy image stays disabled while details are unknown. If details fail to load, the button does not offer a click that toasts failure. The pane already says the image could not load.

## What I did not do

- Bulk Copy of image OCR (GitHub 186 / SBS-807 item 1).
- Component tests (no Testing Library harness; GitHub 146).
- Cargo suite (no Rust change).
- Windows click-through of the image window.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show notes on image History rows and disable Copy image after expiry
> - Adds note rendering to image clip rows in [`ClipCard`](https://github.com/tsouth89/cubby-clipboard/pull/222/files#diff-e12583bcb063ccbdbf8ed369f1bb6c91e9d00f4d7ad63d8f972e9807d2e9c7ed) using a new `ClipRowNote` component, matching existing behavior for text clips. Notes are hidden when the clip is hidden.
> - Adds `fullImageCopyState`, `canCopyFullImage`, and `fullImageCopyTitle` helpers in [`clipRowPresentation.ts`](https://github.com/tsouth89/cubby-clipboard/pull/222/files#diff-90760e0ed7656fcd62827a86cc8dd4e166e5ae330d7aa545bf5044b392daca61) to track whether the full bitmap is ready, expired, unknown, or failed.
> - Updates the Copy image button in [`ImageWindow`](https://github.com/tsouth89/cubby-clipboard/pull/222/files#diff-3923a15b496f7df6c7e94281a8a46dd20678eae8b36b3f60d8bb68dc17ccfe73) to disable and show a state-specific title when the image is expired, still loading, or failed to load.
> - Behavioral Change: Copy image now silently bails out if triggered while not in the `ready` state, and the button is visually disabled in those cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d07e87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->