### PR TITLE
Release v1.3.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,8 @@ one of them fails the pull request rather than the release:
 1. `package.json` → `"version": "x.y.z"`
 2. `src-tauri/Cargo.toml` → `version = "x.y.z"`
 3. `src-tauri/tauri.conf.json` → `"version": "x.y.z"`
-4. `src-tauri/Cargo.lock` → run `cargo update -p cubby` and commit the hunk.
+4. `src-tauri/Cargo.lock` → run `cargo update -p cubby --manifest-path src-tauri/Cargo.toml`
+   from the repository root and commit the hunk.
    `scripts/audit-rust.ps1` runs `cargo tree --locked`, which refuses to rewrite
    the lockfile, so a stale `cubby` stanza fails the required `test` job.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,9 +162,15 @@ pnpm run test
 
 ## Version Bumping
 
-Update version in **both**:
-1. `src-tauri/Cargo.toml` → `version = "x.y.z"`
-2. `src-tauri/tauri.conf.json` → `"version": "x.y.z"`
+Update the version in **all four** places. `pnpm run release:check` enforces the
+first three and CI's `--locked` cargo commands enforce the fourth, so missing any
+one of them fails the pull request rather than the release:
+1. `package.json` → `"version": "x.y.z"`
+2. `src-tauri/Cargo.toml` → `version = "x.y.z"`
+3. `src-tauri/tauri.conf.json` → `"version": "x.y.z"`
+4. `src-tauri/Cargo.lock` → run `cargo update -p cubby` and commit the hunk.
+   `scripts/audit-rust.ps1` runs `cargo tree --locked`, which refuses to rewrite
+   the lockfile, so a stale `cubby` stanza fails the required `test` job.
 
 Before writing the CHANGELOG entry, **always** review all commits since the previous tag:
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable Cubby Clipboard changes are documented here. PastePaw entries below Cubby's first beta are retained as upstream history and attribution.
 
-## Unreleased
+## v1.3.2
 
 ### Security
 - The Win+V helper no longer opens the flyout on a bare localhost UDP `activate` datagram; the channel now requires a per-session token, a loopback source, and a rate limit (SBS-809)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,37 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 
 ### Security
 - The Win+V helper no longer opens the flyout on a bare localhost UDP `activate` datagram; the channel now requires a per-session token, a loopback source, and a rate limit (SBS-809)
+- History list requests no longer ship full decrypted clip text to a window that asked only for previews (SBS-829)
+- Release builds no longer stream Rust logs into the WebView, which had been putting process names, clip identifiers, and filter values in renderer memory (SBS-837)
+- Backup export, backup import, and Ditto import now only write or read a path chosen in the file dialog, so a compromised Settings page cannot send history to an arbitrary location (SBS-808)
 - History source-app filter values are no longer written to the persistent Info log (SBS-773)
-- Pin third-party GitHub Actions in privileged release and Store workflows to immutable commit SHAs, and reject new mutable pins in CI
+- A signed Microsoft Store installer that packs an unsigned `cubby.exe` is now rejected instead of published (SBS-777)
+- Pin third-party GitHub Actions in privileged release and Store workflows to immutable commit SHAs, and reject new mutable pins in CI (SBS-778)
 
 ### Changed
+- Portable mode keeps its promises: logs stay in the folder you carry instead of `%LOCALAPPDATA%`, the installed-channel updater stays out of portable builds, and a `storage.key` this Windows account cannot read is explained at startup instead of failing silently (SBS-774, SBS-775, SBS-776)
+- Startup now records what its storage migrations changed, so a run that edited history says so
 - Pre-merge CI now cargo-checks x64 and ARM64 default and Microsoft Store feature builds, so those configurations fail on the pull request instead of at release (SBS-779)
 
 ### Fixed
-- Screenshot notes now show on the History row, not only in the preview pane (SBS-807)
-- The image window no longer offers Copy image after the original has expired (SBS-807)
-- Backup export, backup import, and Ditto import now only write or read a path chosen in the file dialog, so a compromised Settings page cannot send history to an arbitrary location (SBS-808)
+- Revive an expired screenshot original when that same image is copied again, including a consecutive duplicate that used to be skipped, so Paste and Copy work immediately and recognized text stays (SBS-769)
+- Keep the previous original when a recapture cannot write the full image, instead of losing both (SBS-836)
 - Refuse an encrypted backup export when any live clip field cannot be fully decrypted, and leave an existing destination file unchanged (SBS-772)
 - Refresh the rolling history backup during long-running sessions, so a machine that stays up past a day still gets a current `cubby.db.bak` without quitting Cubby (SBS-771)
-- Revive an expired screenshot original when that same image is copied again, including a consecutive duplicate that used to be skipped, so Paste and Copy work immediately and recognized text stays (SBS-769)
+- Skip an unreadable clip instead of letting it break history listing and search entirely (SBS-830)
+- Restore the forget-on-clear retry marker when the clip lookup fails, so a password manager clearing the clipboard still removes that clip (SBS-831)
+- Screenshot notes now show on the History row, not only in the preview pane (SBS-807)
+- The image window no longer offers Copy image after the original has expired (SBS-807)
+- Keep clip edits, history files, and captures from mixing together or vanishing
+- Stop a failed paste and a failed history reload from reporting success
+- Keep History preview details in sync after a save and after a reveal
+- Keep hidden clips blank in search results, and finish folder and duplicate cleanup
+- Keep the flyout visible while Settings is open, and honor the toggle and always-on-top preferences
+- Let the flyout follow the system theme, and let type-to-search accept IME input
+- Reset the history scroll position when the source or date filter changes
+- Keep the folder dialog open when creating a folder fails, so the name is not lost
+- Relay a remote-session copy so it reaches every session, not only the one that owns the clipboard
+- Say plainly in the docs and product pages that copied files are not kept, that secret heuristics ship off by default, and unblock the Settings links that went nowhere (SBS-832)
 
 ## v1.3.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cubby-clipboard",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A native-feeling clipboard history replacement for Windows 11",
   "license": "GPL-3.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "cubby"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubby"
-version = "1.3.1"
+version = "1.3.2"
 description = "A native-feeling clipboard history replacement for Windows 11"
 authors = ["SouthForge AI", "PastePaw contributors"]
 license = "GPL-3.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "Cubby Clipboard",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "identifier": "ai.southforge.cubbyclipboard",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump for the twelve pull requests merged since v1.3.1.

- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json` all move to 1.3.2 together; `release:check` fails if any one lags.
- `## Unreleased` becomes `## v1.3.2`. The release workflow awk-extracts that exact heading for the release notes and fails the build if it is missing.

`pnpm run release:check` passes locally. No code changes.

Cut for a signed draft test build off the resulting main.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release v1.3.2
> Bumps the version to 1.3.2 across [package.json](https://github.com/tsouth89/cubby-clipboard/pull/223/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), [Cargo.toml](https://github.com/tsouth89/cubby-clipboard/pull/223/files#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39), [tauri.conf.json](https://github.com/tsouth89/cubby-clipboard/pull/223/files#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7), and [Cargo.lock](https://github.com/tsouth89/cubby-clipboard/pull/223/files#diff-91fed938c12ef6620ac89e4130fe1f2b92c58b68083fc6bbc71c3e0f381a25cd). Also updates [AGENTS.md](https://github.com/tsouth89/cubby-clipboard/pull/223/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) to document that version bumps must be applied in all four places, and updates [CHANGELOG.md](https://github.com/tsouth89/cubby-clipboard/pull/223/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) with security, behavior, and bug fix notes for this release.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0446bf5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->