### PR TITLE
Say that Store submission is live, and that a tag has no checkpoint

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -79,7 +79,7 @@ That script enforces:
 
 Also confirm:
 
-- All three version fields match: `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`.
+- All four version fields match: `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and the `cubby` stanza in `src-tauri/Cargo.lock`. `release:check` covers the first three; the lockfile is caught only by `cargo tree --locked` in `audit-rust.ps1`, so a bump that forgets it fails the required `test` job rather than `release:check`. See AGENTS.md for the exact command.
 - Both x64 and arm64 NSIS installers build and are attached to the same draft release.
 
 ## Packaged-install smoke (manual VM)
@@ -162,7 +162,7 @@ payload. A Settings/About surface for this status is still optional.
   means a `src/bin` target lost its `required-features = ["dev-harness"]` gate;
   a `NotSigned` result means `signCommand` did not run.
 - Do not enable Winget publishing until `SouthForgeAI.CubbyClipboard` is reserved and the installer identity is final.
-- Do not submit to Microsoft Store until Partner Center identity, signing, privacy text, and clean upgrade/uninstall behavior are verified.
+- Store submission is automatic on a `v*` tag, so verify Partner Center identity, signing, privacy text, and clean upgrade/uninstall behavior *before* tagging, not before submitting. There is no manual submit step left to hold back.
 - Keep GPL-3.0 source, `NOTICE.md`, and PastePaw attribution available with every release.
 
 ## Privileged GitHub Action pins (SBS-778)

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -15,11 +15,18 @@ Tag releases upload and verify both signed installers automatically. To backfill
 an existing GitHub release, run the `Publish Microsoft Store packages` workflow
 with its version tag.
 
-Microsoft Store submission is disabled until Partner Center onboarding has
-been validated. The GitHub `release` environment must also define:
+> **Microsoft Store submission is live.** `MICROSOFT_STORE_SUBMISSION_ENABLED`
+> is `true` in the `release` environment as of v1.3.2. Pushing a `v*` tag runs
+> `msstore submission update` **and** `msstore submission publish`, so the tag
+> alone sends a build to Store certification with no further confirmation.
+> There is no draft step to stop at. Check this variable before tagging if you
+> only meant to cut a GitHub release.
+
+The GitHub `release` environment must define:
 
 - variable `PARTNER_CENTER_PRODUCT_ID`;
-- variable `MICROSOFT_STORE_SUBMISSION_ENABLED` (`false` during onboarding);
+- variable `MICROSOFT_STORE_SUBMISSION_ENABLED` (`true` once onboarding is
+  validated; set it to `false` to tag without touching the Store);
 - secrets `PARTNER_CENTER_TENANT_ID`, `PARTNER_CENTER_SELLER_ID`,
   `PARTNER_CENTER_CLIENT_ID`, and `PARTNER_CENTER_CLIENT_SECRET`.
 
@@ -30,13 +37,29 @@ the signature on the packed `cubby.exe` (and `uninstall.exe` when 7-Zip extracts
 and maps the existing x64 and ARM64 Store packages to their new versioned URLs
 without changing a submission unless `publish` is explicitly selected.
 
-After a validation-only run passes, set
-`MICROSOFT_STORE_SUBMISSION_ENABLED=true`. Future tag releases wait for both
-architecture uploads, update both package URLs together, and create one Store
-submission before the GitHub release is published. Reruns skip existing R2
+That validation-only run is what gated turning the flag on; it is now on. Tag
+releases wait for both architecture uploads, update both package URLs together,
+and create one Store submission before the GitHub release is published. Reruns skip existing R2
 objects only when their bytes match; a different build must use a new version
 instead of replacing an existing versioned URL, even while the GitHub release
 is still a draft.
+
+## Two ways to run the Release workflow
+
+Pick deliberately. They are not the same thing.
+
+| | `workflow_dispatch` (test build) | push a `v*` tag |
+|---|---|---|
+| Tag | `draft-<sha>` | `v<version>`, must match all four version files |
+| GitHub release | draft prerelease, stays draft | published automatically at the end |
+| Release notes | a fixed "test build" line | awk-extracted from the `## v<version>` CHANGELOG section, which fails the build if missing |
+| `latest.json` | not assembled | assembled, so installed users auto-update |
+| Microsoft Store | skipped | submitted **and** published when the flag is on |
+| Cleanup | deletes previous test-build drafts on the next dispatch | none; a leftover test draft has to be deleted by hand |
+
+Use dispatch for anything you intend to install and try. Use a tag only when
+you mean to ship, because the tag path has no checkpoint between "build" and
+"the public has it".
 
 ## Automated gate
 


### PR DESCRIPTION
Docs only.

Two things the checklist got wrong, both found while cutting v1.3.2:

1. It said Microsoft Store submission was disabled pending onboarding, and that `MICROSOFT_STORE_SUBMISSION_ENABLED` should be `false`. It is `true` in the `release` environment, so the v1.3.2 tag submitted and published to Store certification. Trusting the doc over the environment would tell you a tag is Store-safe.

2. Nothing described the difference between `workflow_dispatch` and a `v*` tag. Dispatch makes a draft test build that stays draft. A tag publishes the release, assembles `latest.json` so installed users auto-update, and submits to the Store, with no checkpoint in between. That was only discoverable by reading `release.yml`.

No code or workflow changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update release checklist to reflect that Store submission is live on v* tag push
> - Updates [RELEASE_CHECKLIST.md](https://github.com/tsouth89/cubby-clipboard/pull/226/files#diff-01a313e7e929db25ac2e0b129ffdc941def6ada896f29c12dfc1f38fee77a321) to document that `MICROSOFT_STORE_SUBMISSION_ENABLED` is `true` in the release environment as of v1.3.2, meaning pushing a v* tag automatically triggers Store submission with no manual step.
> - Adds a section contrasting `workflow_dispatch` (test build) vs v* tag push (public release), covering differences in GitHub release state, release notes, `latest.json`, Store behavior, and draft cleanup.
> - Expands version consistency checks to four files, explicitly including the `cubby` stanza in `src-tauri/Cargo.lock`.
> - Risk: the checklist now warns that all Partner Center and signing verifications must be completed before tagging, since Store submission is automatic and cannot be skipped post-tag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 969f266.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->