### PR TITLE
SBS-922: Scan large pastes for skip-likely-secrets instead of storing them unexamined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - Search no longer ships full decrypted clip bodies on every keystroke; flyout and History search rows use the same preview-only contract as the list (SBS-912)
 
 ### Fixed
+- Skip-likely-secrets now scans the first 8 KiB of a large paste, so a 9 KiB log or PEM starting with a known token or `-----BEGIN` marker is skipped instead of stored (SBS-922)
 - A failed clip reload no longer looks like a healthy current list: same-filter refresh shows a retry banner, superseded loads are not treated as success, and folder / app / count reloads toast instead of staying silent (SBS-805)
 - Portable first-run can install `storage.key` on FAT/exFAT: CreateHardLinkW is NTFS-only, and the previous hard-link-only install deleted the temp key and panicked (SBS-908)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,7 @@ Third-party actions in privileged release, Store, and signing workflows must be 
 In addition to AES-256-GCM at rest, Cubby skips:
 
 - Clipboard items tagged with Windows `ExcludeClipboardContentFromMonitorProcessing` (default on).
-- Text that matches high-confidence secret heuristics such as private keys, cloud API tokens, and grouped payment-card numbers (off by default, enable in Settings; category logged, never content). This one is opt-in because a wrong guess silently drops a clip the user wanted to keep. Pastes larger than 8 KiB are still scanned: the first 8 KiB is checked so a secret marker at the start of a log or PEM is skipped. Content after that window is not scanned. Text that cannot be decoded as UTF-8 is treated as unscannable and is not stored.
+- Text that matches high-confidence secret heuristics such as private keys, cloud API tokens, and grouped payment-card numbers (off by default, enable in Settings; category logged, never content). This one is opt-in because a wrong guess silently drops a clip the user wanted to keep. Pastes larger than 8 KiB are still scanned: the first 8 KiB is checked so a secret marker at the start of a log or PEM is skipped. Content after that window is not scanned. While this setting is on, text that cannot be decoded as UTF-8 is treated as unscannable and is not stored; with the setting off, that text is stored like any other clip.
 - A one-time seeded ignore list of major password-manager executables, editable in Settings.
 
 Release Info logs persist under the application log directory. The History source-app filter is recorded there as `none` / `blank` / `set`, not as the selected application name.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,7 @@ Third-party actions in privileged release, Store, and signing workflows must be 
 In addition to AES-256-GCM at rest, Cubby skips:
 
 - Clipboard items tagged with Windows `ExcludeClipboardContentFromMonitorProcessing` (default on).
-- Text that matches high-confidence secret heuristics such as private keys, cloud API tokens, and grouped payment-card numbers (off by default, enable in Settings; category logged, never content). This one is opt-in because a wrong guess silently drops a clip the user wanted to keep.
+- Text that matches high-confidence secret heuristics such as private keys, cloud API tokens, and grouped payment-card numbers (off by default, enable in Settings; category logged, never content). This one is opt-in because a wrong guess silently drops a clip the user wanted to keep. Pastes larger than 8 KiB are still scanned: the first 8 KiB is checked so a secret marker at the start of a log or PEM is skipped. Content after that window is not scanned. Text that cannot be decoded as UTF-8 is treated as unscannable and is not stored.
 - A one-time seeded ignore list of major password-manager executables, editable in Settings.
 
 Release Info logs persist under the application log directory. The History source-app filter is recorded there as `none` / `blank` / `set`, not as the selected application name.

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -131,7 +131,7 @@
     "skipSensitive": "Skip passwords and sensitive copies",
     "skipSensitiveDesc": "When an app such as a password manager marks a copy as sensitive, Cubby won't save it (Windows' own clipboard history does the same). Turn this off to capture everything, including passwords.",
     "skipLikelySecrets": "Skip likely secrets in text",
-    "skipLikelySecretsDesc": "Don't save text that looks like API tokens, private keys, or payment card numbers. Off by default. Turn it on if you'd rather keep these out of your history (the matching is conservative, but it can skip a clip you meant to keep).",
+    "skipLikelySecretsDesc": "Don't save text that looks like API tokens, private keys, or payment card numbers. Off by default. Turn it on if you'd rather keep these out of your history (the matching is conservative, but it can skip a clip you meant to keep). Large pastes are still checked: Cubby scans the first 8 KB, which is enough to catch those markers at the start of a log or key.",
     "forgetOnClipboardClear": "Forget copies the app clears",
     "forgetOnClipboardClearDesc": "If something clears the clipboard soon after a copy (common for password manager browser extensions), remove that last item from history. Only password-shaped items are removed; notes, links, and pinned items stay.",
     "ignoredAppsDesc": "Don't capture clipboard from these apps. Major password managers are added once by default; remove any you want Cubby to capture.",

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -1470,6 +1470,34 @@ fn should_skip_sensitive_capture(
     skip_sensitive && sensitive && !remote_client
 }
 
+/// Outcome of the skip-likely-secrets capture gate.
+///
+/// `Unscannable` is its own state: failing to decode the paste is not the
+/// same as "not a secret", so capture refuses to store it (SBS-922).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LikelySecretDecision {
+    Store,
+    Skip(crate::secrets::SecretKind),
+    Unscannable,
+}
+
+fn likely_secret_decision(
+    skip_likely_secrets: bool,
+    clip_type: &str,
+    clip_content: &[u8],
+) -> LikelySecretDecision {
+    if !skip_likely_secrets || clip_type != "text" {
+        return LikelySecretDecision::Store;
+    }
+    match std::str::from_utf8(clip_content) {
+        Ok(text) => match crate::secrets::classify_secret(text) {
+            Some(kind) => LikelySecretDecision::Skip(kind),
+            None => LikelySecretDecision::Store,
+        },
+        Err(_) => LikelySecretDecision::Unscannable,
+    }
+}
+
 /// `CF_UNICODETEXT` payload bytes: UTF-16LE, NUL-terminated as Win32 requires.
 #[cfg(target_os = "windows")]
 fn utf16_clipboard_bytes(text: &str) -> Vec<u8> {
@@ -1898,14 +1926,18 @@ async fn process_clipboard_snapshot(
         return;
     }
 
-    if settings.skip_likely_secrets && clip_type == "text" {
-        if let Ok(text) = std::str::from_utf8(&clip_content) {
-            if let Some(kind) = crate::secrets::classify_secret(text) {
-                // Category only — never log the matched clipboard bytes.
-                log::info!("CLIPBOARD: Skipping likely secret ({})", kind.as_str());
-                discard_clear_target();
-                return;
-            }
+    match likely_secret_decision(settings.skip_likely_secrets, clip_type, &clip_content) {
+        LikelySecretDecision::Store => {}
+        LikelySecretDecision::Skip(kind) => {
+            // Category only — never log the matched clipboard bytes.
+            log::info!("CLIPBOARD: Skipping likely secret ({})", kind.as_str());
+            discard_clear_target();
+            return;
+        }
+        LikelySecretDecision::Unscannable => {
+            log::info!("CLIPBOARD: Skipping text that could not be scanned for secrets");
+            discard_clear_target();
+            return;
         }
     }
 
@@ -3051,9 +3083,10 @@ mod tests {
     use super::{
         build_clip_hash_material, calculate_hash, capture_state_name, capture_text,
         clear_ignore_hash_if_matches, clipboard_retry_delay, ignore_marker_applies,
-        is_remote_client_owner, is_remote_client_process, next_listener_backoff, relayed_clip_hash,
-        rgba_to_cf_dib, set_ignore_hash, should_forget_recent_capture, should_relay_capture,
-        should_skip_sensitive_capture, CapturedContent, CapturedFormat, CAPTURE_STATE_LISTENING,
+        is_remote_client_owner, is_remote_client_process, likely_secret_decision,
+        next_listener_backoff, relayed_clip_hash, rgba_to_cf_dib, set_ignore_hash,
+        should_forget_recent_capture, should_relay_capture, should_skip_sensitive_capture,
+        CapturedContent, CapturedFormat, LikelySecretDecision, CAPTURE_STATE_LISTENING,
         CAPTURE_STATE_RESTARTING, CAPTURE_STATE_STOPPED, CLIPBOARD_CLEAR_FORGET_WINDOW,
         IGNORE_HASH, IGNORE_HASH_TTL,
     };
@@ -3372,6 +3405,57 @@ mod tests {
         assert!(!should_skip_sensitive_capture(true, false, false));
         assert!(!should_skip_sensitive_capture(false, true, false));
         assert!(!should_skip_sensitive_capture(false, true, true));
+    }
+
+    /// SBS-922: Skip likely secrets must refuse a 9 KiB paste that starts
+    /// with a known marker, not store it because the whole blob is over 8 KiB.
+    #[test]
+    fn skip_likely_secrets_refuses_a_9kib_prefix_secret() {
+        let padding = "x".repeat(9 * 1024);
+        let github = format!("ghp_{} {padding}", "abcdefghijklmnopqrstuvwxyz0123456789");
+        let aws = format!("AKIA{}{} {padding}", "IOSFODNN7", "EXAMPLE");
+        let pem = format!(
+            "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA\n-----END RSA PRIVATE KEY-----\n{padding}"
+        );
+        assert!(matches!(
+            likely_secret_decision(true, "text", github.as_bytes()),
+            LikelySecretDecision::Skip(crate::secrets::SecretKind::GitHubToken)
+        ));
+        assert!(matches!(
+            likely_secret_decision(true, "text", aws.as_bytes()),
+            LikelySecretDecision::Skip(crate::secrets::SecretKind::AwsAccessKey)
+        ));
+        assert!(matches!(
+            likely_secret_decision(true, "text", pem.as_bytes()),
+            LikelySecretDecision::Skip(crate::secrets::SecretKind::PrivateKey)
+        ));
+        assert_eq!(
+            likely_secret_decision(true, "text", padding.as_bytes()),
+            LikelySecretDecision::Store
+        );
+        // Setting off, or a non-text clip, still stores.
+        assert_eq!(
+            likely_secret_decision(false, "text", github.as_bytes()),
+            LikelySecretDecision::Store
+        );
+        assert_eq!(
+            likely_secret_decision(true, "image", github.as_bytes()),
+            LikelySecretDecision::Store
+        );
+    }
+
+    /// A scan error is not "not a secret". Invalid UTF-8 text cannot be
+    /// classified, so capture skips storage when the setting is on.
+    #[test]
+    fn skip_likely_secrets_treats_undecodable_text_as_unscannable() {
+        assert_eq!(
+            likely_secret_decision(true, "text", &[0xff, 0xfe, 0xfd]),
+            LikelySecretDecision::Unscannable
+        );
+        assert_eq!(
+            likely_secret_decision(false, "text", &[0xff, 0xfe, 0xfd]),
+            LikelySecretDecision::Store
+        );
     }
 
     #[test]

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -114,7 +114,12 @@ pub fn classify_secret(text: &str) -> Option<SecretKind> {
 /// user's note is not.
 pub fn looks_like_credential(text: &str) -> bool {
     let trimmed = text.trim();
-    if classify_secret(trimmed).is_some() {
+    // Deliberately not the windowed scan `classify_secret` does. Forget-on-clear
+    // deletes a clip the user can never get back, so it only counts a match on a
+    // paste small enough to have been read whole. A 9 KiB log or key tutorial
+    // that merely mentions `ghp_` in its first 8 KiB stays in history; the
+    // skip-likely-secrets setting still windows it (SBS-922).
+    if trimmed.len() <= SECRET_SCAN_PREFIX_BYTES && classify_secret(trimmed).is_some() {
         return true;
     }
 
@@ -428,7 +433,12 @@ mod tests {
         assert_eq!(classify_secret(&aws), Some(SecretKind::AwsAccessKey));
         assert_eq!(classify_secret(&pem), Some(SecretKind::PrivateKey));
         assert_eq!(classify_secret(&padding), None);
-        assert!(looks_like_credential(&github));
+        // Forget-on-clear keeps its old oversized-note rule: it deletes, so it
+        // only trusts a paste it read whole.
+        assert!(!looks_like_credential(&github));
+        let small_github = format!("ghp_{}", "abcdefghijklmnopqrstuvwxyz0123456789");
+        assert!(small_github.len() <= SECRET_SCAN_PREFIX_BYTES);
+        assert!(looks_like_credential(&small_github));
     }
 
     /// The documented bound: a marker that first appears after the prefix

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -56,15 +56,24 @@ impl SecretKind {
     }
 }
 
+/// Largest prefix classified on an oversized paste. Walking a multi-megabyte
+/// log is skipped for CPU, but the window is large enough for token, PEM, and
+/// card prefixes so a 9 KiB blob starting with `ghp_`, `AKIA`, or
+/// `-----BEGIN` is still skipped (SBS-922).
+pub const SECRET_SCAN_PREFIX_BYTES: usize = 8_192;
+
 /// Returns a secret category when `text` matches a high-confidence pattern.
 /// Empty / whitespace-only input never matches.
+///
+/// Pastes longer than [`SECRET_SCAN_PREFIX_BYTES`] are still scanned: only
+/// the leading window is classified. A marker that first appears after that
+/// window is not seen.
 pub fn classify_secret(text: &str) -> Option<SecretKind> {
     let trimmed = text.trim();
-    if trimmed.is_empty() || trimmed.len() > 8_192 {
-        // Extremely long pastes are almost never a single secret; skip scanning
-        // so we don't burn CPU on multi-megabyte logs.
+    if trimmed.is_empty() {
         return None;
     }
+    let trimmed = secret_scan_window(trimmed);
 
     if looks_like_private_key(trimmed) {
         return Some(SecretKind::PrivateKey);
@@ -129,6 +138,17 @@ pub fn looks_like_credential(text: &str) -> bool {
         .filter(|present| *present)
         .count()
         >= 3
+}
+
+fn secret_scan_window(text: &str) -> &str {
+    if text.len() <= SECRET_SCAN_PREFIX_BYTES {
+        return text;
+    }
+    let mut end = SECRET_SCAN_PREFIX_BYTES;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    &text[..end]
 }
 
 fn looks_like_private_key(text: &str) -> bool {
@@ -389,5 +409,35 @@ mod tests {
     #[test]
     fn secret_kind_labels_are_stable_for_logs() {
         assert_eq!(SecretKind::GitHubToken.as_str(), "github_token");
+    }
+
+    /// SBS-922: a paste over 8 KiB used to skip the scan entirely, so a
+    /// 9 KiB log starting with a known marker was stored.
+    #[test]
+    fn scans_prefix_of_pastes_larger_than_8_kib() {
+        let padding = "x".repeat(9 * 1024);
+        let github = format!("ghp_{} {padding}", "abcdefghijklmnopqrstuvwxyz0123456789");
+        let aws = format!("AKIA{}{} {padding}", "IOSFODNN7", "EXAMPLE");
+        let pem = format!(
+            "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA\n-----END RSA PRIVATE KEY-----\n{padding}"
+        );
+        assert!(github.len() > SECRET_SCAN_PREFIX_BYTES);
+        assert!(aws.len() > SECRET_SCAN_PREFIX_BYTES);
+        assert!(pem.len() > SECRET_SCAN_PREFIX_BYTES);
+        assert_eq!(classify_secret(&github), Some(SecretKind::GitHubToken));
+        assert_eq!(classify_secret(&aws), Some(SecretKind::AwsAccessKey));
+        assert_eq!(classify_secret(&pem), Some(SecretKind::PrivateKey));
+        assert_eq!(classify_secret(&padding), None);
+        assert!(looks_like_credential(&github));
+    }
+
+    /// The documented bound: a marker that first appears after the prefix
+    /// window is not classified. Catching that would mean scanning the whole
+    /// paste, which this function deliberately does not do.
+    #[test]
+    fn does_not_scan_past_the_documented_prefix_window() {
+        let padding = "x".repeat(SECRET_SCAN_PREFIX_BYTES + 8);
+        let github = format!("{padding} ghp_{}", "abcdefghijklmnopqrstuvwxyz0123456789");
+        assert_eq!(classify_secret(&github), None);
     }
 }


### PR DESCRIPTION
## Summary

- `classify_secret` used to return `None` as soon as the trimmed paste was longer than 8192 bytes, before any token / PEM / card check. Capture then stored the clip.
- Oversized pastes are now classified on a documented 8 KiB prefix window. A 9 KiB log or PEM starting with `ghp_`, `AKIA`, or `-----BEGIN` is skipped.
- Capture treats a UTF-8 decode failure as `Unscannable`, not as not-a-secret, and refuses to store that text when the setting is on.

A user who has Skip likely secrets on and pastes a 9 KiB blob starting with a known secret marker now does not get it stored.

## Test plan

- [x] `scans_prefix_of_pastes_larger_than_8_kib`
- [x] `does_not_scan_past_the_documented_prefix_window`
- [x] `skip_likely_secrets_refuses_a_9kib_prefix_secret`
- [x] `skip_likely_secrets_treats_undecodable_text_as_unscannable`
- [ ] Windows CI `test` job (required gate)
- [ ] Windows build: setting on, paste a 9 KiB log starting with `ghp_`, clip is not in history

## Quality gate

Required CI job is ci.yml test on windows-latest.

cargo fmt check: pass. release-check: pass.
Full crate cargo test and clippy need GTK headers this Linux box does not have.

## Fail without the fix

Reverted only classify_secret to the old 8192 early-return. scans_prefix_of_pastes_larger_than_8_kib failed: left None, right Some(GitHubToken). Restored the scan; 10 passed.

## Pattern sweep

rg for 8_192 / 8192 / skip scanning: the only secret-policy size-cap early-return was classify_secret. OCR and backup size caps are decode/bundle safety, not capture policy. looks_like_credential 8-128 still runs after classify_secret; a 9 KiB prefix secret now matches first.

## What this makes more likely

More large pastes will be skipped, including false positives if the first 8 KiB contains an AKIA shape or PEM header. forget-on-clear can now drop those prefix-secret blobs. Invalid UTF-8 text is no longer stored when the setting is on. Relay is still not gated by secret heuristics.

## Gaps

Markers after the 8 KiB window are not scanned (documented and tested). A JWT larger than 8 KiB will not match. No live Windows clipboard integration test. Did not change the shipped default (SBS-811 stays separate). Did not merge. Issue left In Progress.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scan the first 8 KiB of large pastes for skip-likely-secrets instead of storing them unexamined
> - `classify_secret` in [secrets.rs](https://github.com/tsouth89/cubby-clipboard/pull/228/files#diff-146b42413a5a996a396d692f778a3b9c6bd57c21fcfc2f71abf39d753a2201b3) previously skipped classification for inputs over 8 KiB; it now scans the first `SECRET_SCAN_PREFIX_BYTES` (8,192) of the trimmed input, so pastes like 9 KiB logs or PEMs that begin with a known secret marker are detected and skipped.
> - A new `likely_secret_decision` helper in [clipboard.rs](https://github.com/tsouth89/cubby-clipboard/pull/228/files#diff-8b53e1d4014cd55d2bf889ca51d824e6f3c4f2e3775e5b8a5d2670c416a3b984) returns `Store`, `Skip(kind)`, or `Unscannable`, replacing the inline skip-likely-secrets check in `process_clipboard_snapshot`.
> - `looks_like_credential` still requires the full content to fit within 8 KiB so the forget-on-clear heuristic is unaffected by windowed scanning.
> - Behavioral Change: when skip-likely-secrets is enabled, text pastes that cannot be decoded as UTF-8 are now refused and not stored rather than passed through.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ebb4d16.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->