### PR TITLE
Keep HTML/RTF when Unicode text is empty instead of diagnosing a lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - Skip-likely-secrets now scans the first 8 KiB of a large paste, so a 9 KiB log or PEM starting with a known token or `-----BEGIN` marker is skipped instead of stored (SBS-922)
 - A failed clip reload no longer looks like a healthy current list: same-filter refresh shows a retry banner, superseded loads are not treated as success, and folder / app / count reloads toast instead of staying silent (SBS-805)
 - Portable first-run can install `storage.key` on FAT/exFAT: CreateHardLinkW is NTFS-only, and the previous hard-link-only install deleted the temp key and panicked (SBS-908)
+- Empty Unicode text is no longer diagnosed as a clipboard lock, so a copy that still has HTML or RTF is stored instead of dropped (SBS-924)
 
 ## v1.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - Search no longer ships full decrypted clip bodies on every keystroke; flyout and History search rows use the same preview-only contract as the list (SBS-912)
 
 ### Fixed
+- Empty Unicode text is no longer diagnosed as a clipboard lock, so a copy that still has HTML or RTF is stored instead of dropped; an advertised picture still retries before that HTML wrapper is stored (SBS-924)
 - Recover an interrupted settings.json replace from the leftover temp instead of treating it as a first-run 30-day retention (SBS-935)
 - Record startup quarantine and rolling-backup restore in the on-disk log, instead of discarding those lines before the logger exists (SBS-929)
 - Skip-likely-secrets now scans the first 8 KiB of a large paste, so a 9 KiB log or PEM starting with a known token or `-----BEGIN` marker is skipped instead of stored (SBS-922)
 - A failed clip reload no longer looks like a healthy current list: same-filter refresh shows a retry banner, superseded loads are not treated as success, and folder / app / count reloads toast instead of staying silent (SBS-805)
 - Portable first-run can install `storage.key` on FAT/exFAT: CreateHardLinkW is NTFS-only, and the previous hard-link-only install deleted the temp key and panicked (SBS-908)
-- Empty Unicode text is no longer diagnosed as a clipboard lock, so a copy that still has HTML or RTF is stored instead of dropped; an advertised picture still retries before that HTML wrapper is stored (SBS-924)
 
 ## v1.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - Skip-likely-secrets now scans the first 8 KiB of a large paste, so a 9 KiB log or PEM starting with a known token or `-----BEGIN` marker is skipped instead of stored (SBS-922)
 - A failed clip reload no longer looks like a healthy current list: same-filter refresh shows a retry banner, superseded loads are not treated as success, and folder / app / count reloads toast instead of staying silent (SBS-805)
 - Portable first-run can install `storage.key` on FAT/exFAT: CreateHardLinkW is NTFS-only, and the previous hard-link-only install deleted the temp key and panicked (SBS-908)
-- Empty Unicode text is no longer diagnosed as a clipboard lock, so a copy that still has HTML or RTF is stored instead of dropped (SBS-924)
+- Empty Unicode text is no longer diagnosed as a clipboard lock, so a copy that still has HTML or RTF is stored instead of dropped; an advertised picture still retries before that HTML wrapper is stored (SBS-924)
 
 ## v1.3.2
 

--- a/docs/CLIPBOARD_RELIABILITY.md
+++ b/docs/CLIPBOARD_RELIABILITY.md
@@ -32,11 +32,23 @@ The first compatibility baseline covers:
 - PNG and Windows bitmap variants
 - Multiple simultaneous formats representing the same copied item
 
-An empty `CF_UNICODETEXT` payload is not a lock. If HTML or RTF is present,
-that copy is stored (searchable text is derived from the rich payload). Empty
-text plus only private/custom formats is an unsupported copy: mark it handled
-without restarting the listener or recording a lock miss. A clipboard that
+An empty `CF_UNICODETEXT` payload is not a lock. When Unicode text is empty or
+missing, the order is: a readable image first (an Office copy of a picture has
+empty text, an HTML wrapper, RTF, and a bitmap), then HTML or RTF with content,
+whose searchable text is derived from the rich payload. Empty text plus only
+private/custom formats is an unsupported copy: mark it handled without
+restarting the listener or recording a lock miss.
+
+Advertised text that has not rendered yet is not empty text. While attempts
+remain it is contention, so a delayed `CF_UNICODETEXT` is not replaced by an
+HTML-derived stand-in that would then be stored for good. A clipboard that
 cannot be opened is still diagnosed as contention.
+
+Searchable text derived from HTML skips comments (including Office conditional
+blocks and the Word settings XML inside them) and non-content elements, and
+uses the `StartFragment`/`EndFragment` selection when the source marked one.
+From RTF it skips `\pict`, the font, colour, and style tables, and other
+ignorable destinations, and turns `\par`, `\line`, and `\tab` into spaces.
 
 File clipboard payloads are intentionally ignored. Windows file copies are
 references to external paths rather than durable clipboard content, so Cubby

--- a/docs/CLIPBOARD_RELIABILITY.md
+++ b/docs/CLIPBOARD_RELIABILITY.md
@@ -32,6 +32,12 @@ The first compatibility baseline covers:
 - PNG and Windows bitmap variants
 - Multiple simultaneous formats representing the same copied item
 
+An empty `CF_UNICODETEXT` payload is not a lock. If HTML or RTF is present,
+that copy is stored (searchable text is derived from the rich payload). Empty
+text plus only private/custom formats is an unsupported copy: mark it handled
+without restarting the listener or recording a lock miss. A clipboard that
+cannot be opened is still diagnosed as contention.
+
 File clipboard payloads are intentionally ignored. Windows file copies are
 references to external paths rather than durable clipboard content, so Cubby
 does not present them as stored history.

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -696,19 +696,24 @@ fn capture_one_bound_sequence(
     let materialized = materialize_with_sequence_guard(
         sequence,
         read_sequence,
-        |attempt| {
-            let content = materialize_clipboard_content_once(attempt);
-            if content.is_none() && attempt + 1 < 10 {
-                std::thread::sleep(clipboard_retry_delay(attempt));
+        |attempt| match materialize_clipboard_content_once(attempt) {
+            MaterializeOnce::Captured(content, formats) => {
+                Some(MaterializeAttempt::Captured(content, formats))
             }
-            content
+            MaterializeOnce::DeterminateMiss => Some(MaterializeAttempt::DeterminateMiss),
+            MaterializeOnce::Transient => {
+                if attempt + 1 < 10 {
+                    std::thread::sleep(clipboard_retry_delay(attempt));
+                }
+                None
+            }
         },
         10,
     )?;
 
     persist_if_sequence_holds(sequence, read_sequence(), ())?;
 
-    if let Some((content, formats)) = materialized {
+    if let Some(MaterializeAttempt::Captured(content, formats)) = materialized {
         note_clipboard_event(sequence);
         let snapshot = ClipboardSnapshot {
             sequence,
@@ -722,6 +727,27 @@ fn capture_one_bound_sequence(
             .send(ClipboardListenerEvent::Content(snapshot))
             .map(|_| CaptureAttempt::Handled)
             .map_err(|_| BoundCaptureFailure::ConsumerGone);
+    }
+
+    if matches!(materialized, Some(MaterializeAttempt::DeterminateMiss)) {
+        // Opened the clipboard and read empty/missing text with no HTML/RTF
+        // and no image. That is not a lock, even when CF_UNICODETEXT is still
+        // advertised (SBS-924).
+        if clipboard_is_cleared() {
+            persist_if_sequence_holds(sequence, read_sequence(), ())?;
+            note_clipboard_event(sequence);
+            return event_tx
+                .send(ClipboardListenerEvent::Cleared { sequence })
+                .map(|_| CaptureAttempt::Handled)
+                .map_err(|_| BoundCaptureFailure::ConsumerGone);
+        }
+        persist_if_sequence_holds(sequence, read_sequence(), ())?;
+        note_clipboard_event(sequence);
+        log::debug!(
+            "CLIPBOARD: Sequence {} contained no supported text or image payload",
+            sequence
+        );
+        return Ok(CaptureAttempt::Handled);
     }
 
     if has_file_payload && has_image_payload {
@@ -794,6 +820,10 @@ fn capture_one_bound_sequence(
 /// True when the clipboard advertises a format `materialize_clipboard_content_once`
 /// can read (text or an image). Used to tell "unsupported payload"
 /// (mark handled) apart from "supported but contended" (defer and retry).
+///
+/// Advertised `CF_UNICODETEXT` is not enough after a determinate empty-text
+/// read: that payload is empty, not locked (SBS-924). Callers that already
+/// opened the clipboard and read empty text must not use this as a lock signal.
 #[cfg(target_os = "windows")]
 fn clipboard_has_supported_format() -> bool {
     use windows::core::PCWSTR;
@@ -948,7 +978,7 @@ fn clipboard_is_cleared() -> bool {
                 return false;
             }
             // Empty plain text must not count as a clear if HTML/RTF still hold
-            // content (materialize can miss those when get_text is empty).
+            // content. Those copies are stored as rich clips (SBS-924).
             if let Ok(html) = ctx.get_html() {
                 if !html.is_empty() {
                     return false;
@@ -1136,9 +1166,11 @@ fn run_native_listener(_event_tx: tokio::sync::mpsc::UnboundedSender<ClipboardLi
 /// One materialize attempt. `attempt` is 0-based so the last try can do a
 /// slower image decode. The sequence-bound capture path checks the clipboard
 /// sequence around each call instead of sleeping across a sequence change.
-fn materialize_clipboard_content_once(
-    attempt: u32,
-) -> Option<(CapturedContent, Vec<CapturedFormat>)> {
+///
+/// Empty Unicode text is a determinate miss, not a retryable lock: if HTML or
+/// RTF has content we store that clip; otherwise the caller marks the sequence
+/// handled (or cleared) without restarting the listener (SBS-924).
+fn materialize_clipboard_content_once(attempt: u32) -> MaterializeOnce {
     const ATTEMPTS: u32 = 10;
     let last_attempt = attempt + 1 == ATTEMPTS;
 
@@ -1148,44 +1180,131 @@ fn materialize_clipboard_content_once(
     // immediately; retry the image for the complete bounded window.
     if clipboard_has_image_format() && clipboard_has_file_payload_format() {
         if let Ok(image) = read_clipboard_image_fast(last_attempt) {
-            return Some((captured_image(image), Vec::new()));
+            return MaterializeOnce::Captured(captured_image(image), Vec::new());
         }
         // The caller records this hybrid update as handled on the last miss.
         // Do not fall through to text, where the path could be captured as a
         // text clip.
-        return None;
+        return MaterializeOnce::Transient;
     }
 
     if let Ok(ctx) = ClipboardContext::new() {
-        if let Ok(text) = ctx.get_text() {
-            if let Some(content) = capture_text(text) {
-                let mut formats = Vec::new();
-                if let Ok(html) = ctx.get_html() {
-                    if !html.is_empty() {
-                        formats.push(CapturedFormat {
-                            name: "html",
-                            content: html.into_bytes(),
-                        });
-                    }
-                }
-                if let Ok(rtf) = ctx.get_rich_text() {
-                    if !rtf.is_empty() {
-                        formats.push(CapturedFormat {
-                            name: "rtf",
-                            content: rtf.into_bytes(),
-                        });
-                    }
-                }
-                return Some((content, formats));
+        let text = ctx.get_text().ok();
+        let html = ctx.get_html().ok();
+        let rtf = ctx.get_rich_text().ok();
+        let text_read = observed_payload(&text, clipboard_has_unicode_text_format());
+        let html_read = observed_payload(&html, clipboard_has_html_format());
+        let rtf_read = observed_payload(&rtf, clipboard_has_rtf_format());
+        if let Some(rich) =
+            crate::clipboard_miss::rich_capture_from_payloads(text_read, html_read, rtf_read)
+        {
+            if let Some(content) = capture_text(rich.searchable_text) {
+                return MaterializeOnce::Captured(
+                    content,
+                    captured_rich_formats(rich.html, rich.rtf),
+                );
             }
         }
+
+        if let Ok(image) = read_clipboard_image_fast(last_attempt) {
+            return MaterializeOnce::Captured(captured_image(image), Vec::new());
+        }
+        // We opened the clipboard and read it. Empty text is not a lock; an
+        // advertised image or delayed HTML/RTF that did not decode yet still is.
+        if clipboard_has_image_format()
+            || matches!(text_read, crate::clipboard_miss::PayloadRead::Unknown)
+            || matches!(html_read, crate::clipboard_miss::PayloadRead::Unknown)
+            || matches!(rtf_read, crate::clipboard_miss::PayloadRead::Unknown)
+        {
+            return MaterializeOnce::Transient;
+        }
+        return MaterializeOnce::DeterminateMiss;
     }
 
     if let Ok(image) = read_clipboard_image_fast(last_attempt) {
-        return Some((captured_image(image), Vec::new()));
+        return MaterializeOnce::Captured(captured_image(image), Vec::new());
     }
+    MaterializeOnce::Transient
+}
 
-    None
+fn observed_payload(
+    value: &Option<String>,
+    advertised: bool,
+) -> crate::clipboard_miss::PayloadRead<'_> {
+    match value {
+        Some(body) => crate::clipboard_miss::PayloadRead::Present(body),
+        None if advertised => crate::clipboard_miss::PayloadRead::Unknown,
+        None => crate::clipboard_miss::PayloadRead::Missing,
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn clipboard_has_unicode_text_format() -> bool {
+    const CF_UNICODETEXT: u32 = 13;
+    unsafe { windows::Win32::System::DataExchange::IsClipboardFormatAvailable(CF_UNICODETEXT) }
+        .is_ok()
+}
+
+#[cfg(not(target_os = "windows"))]
+fn clipboard_has_unicode_text_format() -> bool {
+    false
+}
+
+#[cfg(target_os = "windows")]
+fn clipboard_has_html_format() -> bool {
+    let format = register_clipboard_format("HTML Format");
+    format != 0
+        && unsafe { windows::Win32::System::DataExchange::IsClipboardFormatAvailable(format) }
+            .is_ok()
+}
+
+#[cfg(not(target_os = "windows"))]
+fn clipboard_has_html_format() -> bool {
+    false
+}
+
+#[cfg(target_os = "windows")]
+fn clipboard_has_rtf_format() -> bool {
+    let format = register_clipboard_format("Rich Text Format");
+    format != 0
+        && unsafe { windows::Win32::System::DataExchange::IsClipboardFormatAvailable(format) }
+            .is_ok()
+}
+
+#[cfg(not(target_os = "windows"))]
+fn clipboard_has_rtf_format() -> bool {
+    false
+}
+
+fn captured_rich_formats(html: Option<String>, rtf: Option<String>) -> Vec<CapturedFormat> {
+    let mut formats = Vec::new();
+    if let Some(html) = html {
+        formats.push(CapturedFormat {
+            name: "html",
+            content: html.into_bytes(),
+        });
+    }
+    if let Some(rtf) = rtf {
+        formats.push(CapturedFormat {
+            name: "rtf",
+            content: rtf.into_bytes(),
+        });
+    }
+    formats
+}
+
+/// Outcome of one materialize attempt. Transient misses retry; a determinate
+/// miss (opened, empty/missing text, no HTML/RTF, no image) must not.
+enum MaterializeOnce {
+    Captured(CapturedContent, Vec<CapturedFormat>),
+    DeterminateMiss,
+    Transient,
+}
+
+/// Stop retrying once we know the copy is captured or is a determinate miss.
+enum MaterializeAttempt {
+    Captured(CapturedContent, Vec<CapturedFormat>),
+    DeterminateMiss,
 }
 
 fn captured_image(image: ClipboardImageRead) -> CapturedContent {

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -1195,30 +1195,48 @@ fn materialize_clipboard_content_once(attempt: u32) -> MaterializeOnce {
         let text_read = observed_payload(&text, clipboard_has_unicode_text_format());
         let html_read = observed_payload(&html, clipboard_has_html_format());
         let rtf_read = observed_payload(&rtf, clipboard_has_rtf_format());
-        if let Some(rich) =
-            crate::clipboard_miss::rich_capture_from_payloads(text_read, html_read, rtf_read)
-        {
-            if let Some(content) = capture_text(rich.searchable_text) {
-                return MaterializeOnce::Captured(
-                    content,
-                    captured_rich_formats(rich.html, rich.rtf),
-                );
-            }
-        }
 
-        if let Ok(image) = read_clipboard_image_fast(last_attempt) {
-            return MaterializeOnce::Captured(captured_image(image), Vec::new());
-        }
-        // We opened the clipboard and read it. Empty text is not a lock; an
-        // advertised image or delayed HTML/RTF that did not decode yet still is.
-        if clipboard_has_image_format()
-            || matches!(text_read, crate::clipboard_miss::PayloadRead::Unknown)
-            || matches!(html_read, crate::clipboard_miss::PayloadRead::Unknown)
-            || matches!(rtf_read, crate::clipboard_miss::PayloadRead::Unknown)
-        {
-            return MaterializeOnce::Transient;
-        }
-        return MaterializeOnce::DeterminateMiss;
+        // Only decode when the Unicode body cannot carry the copy on its own.
+        // A non-empty text clip never needs the bitmap, and decoding one on
+        // every attempt would pay for pixels nobody stores.
+        let image = if matches!(
+            text_read,
+            crate::clipboard_miss::PayloadRead::Present(body) if !body.is_empty()
+        ) {
+            None
+        } else {
+            read_clipboard_image_fast(last_attempt).ok()
+        };
+
+        let decision = crate::clipboard_miss::decide_capture(crate::clipboard_miss::AttemptFacts {
+            text: text_read,
+            html: html_read,
+            rtf: rtf_read,
+            image_advertised: clipboard_has_image_format(),
+            image_readable: image.is_some(),
+            last_attempt,
+        });
+        return match decision {
+            crate::clipboard_miss::CaptureDecision::Image => match image {
+                Some(image) => MaterializeOnce::Captured(captured_image(image), Vec::new()),
+                None => MaterializeOnce::Transient,
+            },
+            crate::clipboard_miss::CaptureDecision::Rich(rich) => {
+                match capture_text(rich.searchable_text) {
+                    Some(content) => MaterializeOnce::Captured(
+                        content,
+                        captured_rich_formats(rich.html, rich.rtf),
+                    ),
+                    // The body strips to nothing after all. Nothing here will
+                    // change on a retry, so do not restart the listener.
+                    None => MaterializeOnce::DeterminateMiss,
+                }
+            }
+            crate::clipboard_miss::CaptureDecision::DeterminateMiss => {
+                MaterializeOnce::DeterminateMiss
+            }
+            crate::clipboard_miss::CaptureDecision::Transient => MaterializeOnce::Transient,
+        };
     }
 
     if let Ok(image) = read_clipboard_image_fast(last_attempt) {

--- a/src-tauri/src/clipboard_miss.rs
+++ b/src-tauri/src/clipboard_miss.rs
@@ -70,8 +70,11 @@ pub(crate) enum CaptureDecision {
 /// 3. A readable image beats an HTML/RTF-derived body. A Word, PowerPoint, or
 ///    Outlook copy of a picture has empty Unicode text, an HTML wrapper, RTF,
 ///    and a bitmap; storing the wrapper would lose the picture entirely.
-/// 4. Otherwise HTML or RTF with content is the clip.
-/// 5. An advertised-but-unread image, or unread HTML/RTF, is still contention.
+/// 4. An advertised-but-unread image still retries before HTML/RTF, except on
+///    the last attempt. The first fast PNG read often misses, and accepting
+///    the wrapper then stops later attempts from ever seeing the bitmap.
+/// 5. Otherwise HTML or RTF with content is the clip.
+/// 6. Unread HTML/RTF, or a last-attempt unread image, is still contention.
 pub(crate) fn decide_capture(facts: AttemptFacts<'_>) -> CaptureDecision {
     let html = nonempty_present(facts.html);
     let rtf = nonempty_present(facts.rtf);
@@ -92,6 +95,10 @@ pub(crate) fn decide_capture(facts: AttemptFacts<'_>) -> CaptureDecision {
 
     if facts.image_readable {
         return CaptureDecision::Image;
+    }
+
+    if facts.image_advertised && !facts.last_attempt {
+        return CaptureDecision::Transient;
     }
 
     if let Some(rich) = rich_capture_from_payloads(facts.text, facts.html, facts.rtf) {
@@ -309,6 +316,8 @@ pub(crate) fn plain_text_from_rtf(rtf: &str) -> String {
     let mut depth: usize = 0;
     // Depth of the outermost group being skipped, if any.
     let mut skipping_from: Option<usize> = None;
+    // `\ucN` fallback length after `\u`; RTF default is one ANSI byte.
+    let mut ansi_fallback_bytes: usize = 1;
     let mut i = 0;
     while i < bytes.len() {
         match bytes[i] {
@@ -360,20 +369,50 @@ pub(crate) fn plain_text_from_rtf(rtf: &str) -> String {
                             i += 1;
                         }
                         let word = &rtf[start..i];
+                        let mut param: Option<i32> = None;
                         if i < bytes.len() && (bytes[i] == b'-' || bytes[i].is_ascii_digit()) {
+                            let param_start = i;
                             if bytes[i] == b'-' {
                                 i += 1;
                             }
                             while i < bytes.len() && bytes[i].is_ascii_digit() {
                                 i += 1;
                             }
+                            param = rtf[param_start..i].parse().ok();
+                        }
+                        if word == "bin" {
+                            // `\binN` is followed immediately by N raw bytes.
+                            // Those bytes are not RTF tokens: a 0x7D in a
+                            // Word `\pict\bin` payload would otherwise close
+                            // the skip and leak the rest into clip text.
+                            let skip = param.unwrap_or(0).max(0) as usize;
+                            i = (i + skip).min(bytes.len());
+                            continue;
                         }
                         // One trailing space is the control-word delimiter, not
-                        // content.
+                        // content. Not for `\bin`, whose payload starts here.
                         if i < bytes.len() && bytes[i] == b' ' {
                             i += 1;
                         }
-                        if RTF_NON_CONTENT_DESTINATIONS.contains(&word) {
+                        if word == "uc" {
+                            if let Some(count) = param {
+                                ansi_fallback_bytes = count.max(0) as usize;
+                            }
+                        } else if word == "u" {
+                            if skipping_from.is_none() {
+                                if let Some(code) = param {
+                                    let unsigned = if code < 0 {
+                                        code.wrapping_add(65536)
+                                    } else {
+                                        code
+                                    } as u32;
+                                    if let Some(ch) = char::from_u32(unsigned) {
+                                        out.push(ch);
+                                    }
+                                }
+                            }
+                            i = (i + ansi_fallback_bytes).min(bytes.len());
+                        } else if RTF_NON_CONTENT_DESTINATIONS.contains(&word) {
                             skipping_from.get_or_insert(depth);
                         } else if skipping_from.is_none()
                             && matches!(word, "par" | "line" | "tab" | "cell" | "row" | "sect")
@@ -612,6 +651,32 @@ mod tests {
         );
     }
 
+    /// Office picture copies advertise PNG/DIB plus an HTML wrapper. The first
+    /// fast image read often misses; accepting the wrapper then marks the
+    /// sequence handled and the bitmap never reaches history.
+    #[test]
+    fn unread_advertised_image_retries_before_accepting_html() {
+        let attempt = AttemptFacts {
+            text: PayloadRead::Present(""),
+            html: PayloadRead::Present("<img src=\"file:///C:/Temp/image001.png\">"),
+            rtf: PayloadRead::Present(r"{\rtf1{\pict\pngblip 89504e47}}"),
+            image_advertised: true,
+            image_readable: false,
+            last_attempt: false,
+        };
+        assert_eq!(decide_capture(attempt), CaptureDecision::Transient);
+
+        let last = AttemptFacts {
+            last_attempt: true,
+            ..attempt
+        };
+        let decision = decide_capture(last);
+        assert!(
+            matches!(decision, CaptureDecision::Rich(_)),
+            "last attempt should keep the wrapper rather than miss: {decision:?}"
+        );
+    }
+
     #[test]
     fn nonempty_unicode_text_keeps_html_and_rtf_companions() {
         let captured = rich_capture_from_payloads(
@@ -719,5 +784,28 @@ mod tests {
         assert!(!text.contains("89504e47"), "picture hex leaked: {text}");
         assert!(!text.contains("Calibri"), "font table leaked: {text}");
         assert!(!text.contains("Riched20"), "generator leaked: {text}");
+    }
+
+    /// `\binN` payload is raw bytes, not RTF. A `}` in those bytes must not
+    /// end the `\pict` skip and leak the rest into searchable text.
+    #[test]
+    fn rtf_bin_payload_is_not_parsed_as_rtf() {
+        let mut rtf = String::from(r"{\rtf1{\pict\bin");
+        let payload = b"abc}SECRET";
+        rtf.push_str(&payload.len().to_string());
+        rtf.push_str(std::str::from_utf8(payload).unwrap());
+        rtf.push_str("} the copied phrase}");
+        let text = plain_text_from_rtf(&rtf);
+        assert_eq!(text, "the copied phrase");
+        assert!(
+            !text.contains("SECRET"),
+            "binary after a payload '}}' leaked: {text}"
+        );
+    }
+
+    /// Word writes non-ASCII as `\uN` plus an ANSI fallback, often `?`.
+    #[test]
+    fn rtf_unicode_control_word_emits_the_codepoint() {
+        assert_eq!(plain_text_from_rtf(r"{\rtf1\u12354?}"), "あ");
     }
 }

--- a/src-tauri/src/clipboard_miss.rs
+++ b/src-tauri/src/clipboard_miss.rs
@@ -1,0 +1,485 @@
+//! Classify a clipboard miss when Unicode text is empty or absent.
+//!
+//! SBS-924: an empty `CF_UNICODETEXT` payload is not a clipboard lock. Capture
+//! still keeps HTML/RTF when they have content. Empty text plus only private
+//! formats is unsupported (handled), not contention. A clipboard we never
+//! opened stays its own state: a real lock.
+//!
+//! This module has no crate dependencies so `rustc --test` can run it on a
+//! Linux box that cannot compile the Windows crate.
+
+/// What we learned about one clipboard format after trying to read it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PayloadRead<'a> {
+    /// Successfully read. `""` is a real empty payload, not a lock.
+    Present(&'a str),
+    /// Format was not available, or `get_*` returned an error.
+    Missing,
+    /// We never observed this format (clipboard never opened, or not asked).
+    Unknown,
+}
+
+/// What to do with HTML/RTF after reading Unicode text (which may be empty).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RichCapture {
+    pub searchable_text: String,
+    pub html: Option<String>,
+    pub rtf: Option<String>,
+}
+
+/// After materialize has no content, why — and what the capture path should do.
+///
+/// Three states, not two: empty text is not a lock, and a missing format is
+/// not empty text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MissAction {
+    /// HTML or RTF has content. Store that clip; do not diagnose a lock.
+    CaptureRich,
+    /// Placeholder-only empty clipboard. Password-manager auto-clear.
+    Cleared,
+    /// Empty or missing text, no rich payload, no image. Private/custom only
+    /// or nothing we store. Mark handled; do not restart the listener.
+    Unsupported,
+    /// Could not open the clipboard, or a supported payload stayed unreadable.
+    Contended,
+}
+
+/// Build a storable clip from observed text/HTML/RTF.
+///
+/// Non-empty Unicode text wins as the searchable body (existing path). Empty
+/// or missing Unicode text still yields a clip when HTML or RTF has content;
+/// the searchable body is derived from the rich payload so History has
+/// something to show and search.
+pub(crate) fn rich_capture_from_payloads(
+    text: PayloadRead<'_>,
+    html: PayloadRead<'_>,
+    rtf: PayloadRead<'_>,
+) -> Option<RichCapture> {
+    let html = nonempty_present(html);
+    let rtf = nonempty_present(rtf);
+
+    if let PayloadRead::Present(body) = text {
+        if !body.is_empty() {
+            return Some(RichCapture {
+                searchable_text: body.to_string(),
+                html: html.map(str::to_string),
+                rtf: rtf.map(str::to_string),
+            });
+        }
+    }
+
+    if html.is_none() && rtf.is_none() {
+        return None;
+    }
+
+    let searchable_text = html
+        .map(plain_text_from_html)
+        .filter(|body| !body.is_empty())
+        .or_else(|| rtf.map(plain_text_from_rtf).filter(|body| !body.is_empty()))
+        .unwrap_or_else(|| {
+            if html.is_some() {
+                "[HTML]".to_string()
+            } else {
+                "[RTF]".to_string()
+            }
+        });
+
+    Some(RichCapture {
+        searchable_text,
+        html: html.map(str::to_string),
+        rtf: rtf.map(str::to_string),
+    })
+}
+
+/// Decide the post-miss action from observed facts.
+///
+/// `only_placeholder_text_formats` is `None` when we could not enumerate
+/// formats (unknown). That must not become a clear (would delete the previous
+/// capture) or a lock (the SBS-924 false diagnosis).
+pub(crate) fn classify_miss(
+    text: PayloadRead<'_>,
+    html: PayloadRead<'_>,
+    rtf: PayloadRead<'_>,
+    image_advertised: bool,
+    only_placeholder_text_formats: Option<bool>,
+    clipboard_opened: bool,
+) -> MissAction {
+    if rich_capture_from_payloads(text, html, rtf).is_some() {
+        // Non-empty text, or empty/missing text with HTML/RTF. Neither is a lock.
+        return MissAction::CaptureRich;
+    }
+
+    // Advertised but unread text/HTML/RTF is delayed render or a lost read,
+    // not "empty" and not "missing".
+    if matches!(text, PayloadRead::Unknown)
+        || matches!(html, PayloadRead::Unknown)
+        || matches!(rtf, PayloadRead::Unknown)
+    {
+        return MissAction::Contended;
+    }
+
+    if !clipboard_opened
+        || matches!(text, PayloadRead::Unknown)
+            && matches!(html, PayloadRead::Unknown)
+            && matches!(rtf, PayloadRead::Unknown)
+    {
+        return MissAction::Contended;
+    }
+
+    if image_advertised {
+        return MissAction::Contended;
+    }
+
+    match only_placeholder_text_formats {
+        Some(true) => MissAction::Cleared,
+        Some(false) => MissAction::Unsupported,
+        None => match text {
+            // Known empty text, formats unknown: do not clear (might still
+            // hold a private format) and do not lock (we already read).
+            PayloadRead::Present("") => MissAction::Unsupported,
+            PayloadRead::Present(_) => MissAction::Unsupported,
+            PayloadRead::Missing => MissAction::Unsupported,
+            PayloadRead::Unknown => MissAction::Contended,
+        },
+    }
+}
+
+fn nonempty_present(read: PayloadRead<'_>) -> Option<&str> {
+    match read {
+        PayloadRead::Present(body) if !body.is_empty() => Some(body),
+        _ => None,
+    }
+}
+
+/// Best-effort visible text from a CF_HTML document (header already stripped).
+pub(crate) fn plain_text_from_html(html: &str) -> String {
+    let mut out = String::new();
+    let mut in_tag = false;
+    let mut tag = String::new();
+    for ch in html.chars() {
+        match ch {
+            '<' => {
+                in_tag = true;
+                tag.clear();
+            }
+            '>' if in_tag => {
+                in_tag = false;
+                let name = tag
+                    .trim_start_matches('/')
+                    .split(|c: char| c.is_ascii_whitespace() || c == '/')
+                    .next()
+                    .unwrap_or("");
+                if matches!(
+                    name.to_ascii_lowercase().as_str(),
+                    "p" | "div" | "br" | "tr" | "li" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
+                ) {
+                    if !out.ends_with(' ') && !out.is_empty() {
+                        out.push(' ');
+                    }
+                }
+            }
+            _ if in_tag => tag.push(ch),
+            _ => out.push(ch),
+        }
+    }
+    decode_basic_entities(&out)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Best-effort visible text from a simple RTF payload.
+pub(crate) fn plain_text_from_rtf(rtf: &str) -> String {
+    let bytes = rtf.as_bytes();
+    let mut out = String::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => {
+                i += 1;
+                if i >= bytes.len() {
+                    break;
+                }
+                match bytes[i] {
+                    b'\\' | b'{' | b'}' => {
+                        out.push(bytes[i] as char);
+                        i += 1;
+                    }
+                    b'\'' => {
+                        if i + 2 < bytes.len() {
+                            if let Ok(value) = u8::from_str_radix(&rtf[i + 1..i + 3], 16) {
+                                if value >= 32 {
+                                    out.push(value as char);
+                                }
+                            }
+                            i += 3;
+                        } else {
+                            i += 1;
+                        }
+                    }
+                    b'\n' | b'\r' => i += 1,
+                    c if c.is_ascii_alphabetic() => {
+                        i += 1;
+                        while i < bytes.len() && bytes[i].is_ascii_alphabetic() {
+                            i += 1;
+                        }
+                        if i < bytes.len() && (bytes[i] == b'-' || bytes[i].is_ascii_digit()) {
+                            if bytes[i] == b'-' {
+                                i += 1;
+                            }
+                            while i < bytes.len() && bytes[i].is_ascii_digit() {
+                                i += 1;
+                            }
+                        }
+                        if i < bytes.len() && bytes[i] == b' ' {
+                            i += 1;
+                        }
+                    }
+                    _ => i += 1,
+                }
+            }
+            b'{' | b'}' | b'\n' | b'\r' => i += 1,
+            c => {
+                out.push(c as char);
+                i += 1;
+            }
+        }
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn decode_basic_entities(input: &str) -> String {
+    input
+        .replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        classify_miss, plain_text_from_html, plain_text_from_rtf, rich_capture_from_payloads,
+        MissAction, PayloadRead,
+    };
+
+    /// SBS-924: empty CF_UNICODETEXT plus live HTML is a rich capture, not a lock.
+    #[test]
+    fn empty_text_plus_html_is_captured_not_locked() {
+        let html = "<b>Office format only</b>";
+        let captured = rich_capture_from_payloads(
+            PayloadRead::Present(""),
+            PayloadRead::Present(html),
+            PayloadRead::Missing,
+        )
+        .expect("empty Unicode text must not drop HTML");
+        assert_eq!(captured.searchable_text, "Office format only");
+        assert_eq!(captured.html.as_deref(), Some(html));
+        assert_eq!(captured.rtf, None);
+        assert_eq!(
+            classify_miss(
+                PayloadRead::Present(""),
+                PayloadRead::Present(html),
+                PayloadRead::Missing,
+                false,
+                Some(false),
+                true,
+            ),
+            MissAction::CaptureRich
+        );
+    }
+
+    /// SBS-924: empty text plus a private/custom format is handled, not a lock.
+    #[test]
+    fn empty_text_plus_private_format_is_unsupported_not_locked() {
+        assert!(rich_capture_from_payloads(
+            PayloadRead::Present(""),
+            PayloadRead::Missing,
+            PayloadRead::Missing,
+        )
+        .is_none());
+        assert_eq!(
+            classify_miss(
+                PayloadRead::Present(""),
+                PayloadRead::Missing,
+                PayloadRead::Missing,
+                false,
+                Some(false),
+                true,
+            ),
+            MissAction::Unsupported
+        );
+    }
+
+    /// SBS-924: placeholder-only empty clipboard is a clear, not a lock.
+    #[test]
+    fn truly_empty_clipboard_is_cleared_not_locked() {
+        assert_eq!(
+            classify_miss(
+                PayloadRead::Present(""),
+                PayloadRead::Missing,
+                PayloadRead::Missing,
+                false,
+                Some(true),
+                true,
+            ),
+            MissAction::Cleared
+        );
+    }
+
+    /// A clipboard we never opened is still a lock, even if text *might* be empty.
+    #[test]
+    fn unopened_clipboard_is_still_a_lock() {
+        assert_eq!(
+            classify_miss(
+                PayloadRead::Unknown,
+                PayloadRead::Unknown,
+                PayloadRead::Unknown,
+                false,
+                None,
+                false,
+            ),
+            MissAction::Contended
+        );
+    }
+
+    #[test]
+    fn empty_text_plus_rtf_is_captured() {
+        let rtf = r"{\rtf1\ansi Hello from Word}";
+        let captured = rich_capture_from_payloads(
+            PayloadRead::Present(""),
+            PayloadRead::Missing,
+            PayloadRead::Present(rtf),
+        )
+        .expect("empty Unicode text must not drop RTF");
+        assert_eq!(captured.searchable_text, "Hello from Word");
+        assert_eq!(captured.rtf.as_deref(), Some(rtf));
+    }
+
+    #[test]
+    fn missing_text_is_not_collapsed_into_empty_text() {
+        // get_text Err is Missing, not Present(""). HTML still wins.
+        let captured = rich_capture_from_payloads(
+            PayloadRead::Missing,
+            PayloadRead::Present("<p>still here</p>"),
+            PayloadRead::Missing,
+        )
+        .expect("a missing Unicode format must not drop HTML");
+        assert_eq!(captured.searchable_text, "still here");
+
+        // Missing text, no rich, no image, private formats: unsupported, not lock.
+        assert_eq!(
+            classify_miss(
+                PayloadRead::Missing,
+                PayloadRead::Missing,
+                PayloadRead::Missing,
+                false,
+                Some(false),
+                true,
+            ),
+            MissAction::Unsupported
+        );
+    }
+
+    #[test]
+    fn unread_advertised_unicode_text_is_contention() {
+        assert_eq!(
+            classify_miss(
+                PayloadRead::Unknown,
+                PayloadRead::Missing,
+                PayloadRead::Missing,
+                false,
+                Some(false),
+                true,
+            ),
+            MissAction::Contended
+        );
+    }
+
+    /// Advertised HTML that has not rendered yet is unknown, not "no HTML".
+    #[test]
+    fn empty_text_plus_unread_html_is_contention_not_unsupported() {
+        assert_eq!(
+            classify_miss(
+                PayloadRead::Present(""),
+                PayloadRead::Unknown,
+                PayloadRead::Missing,
+                false,
+                Some(false),
+                true,
+            ),
+            MissAction::Contended
+        );
+    }
+
+    #[test]
+    fn advertised_unread_image_is_contention() {
+        assert_eq!(
+            classify_miss(
+                PayloadRead::Present(""),
+                PayloadRead::Missing,
+                PayloadRead::Missing,
+                true,
+                Some(false),
+                true,
+            ),
+            MissAction::Contended
+        );
+    }
+
+    #[test]
+    fn unknown_format_enum_after_empty_text_is_not_a_lock_or_a_clear() {
+        assert_eq!(
+            classify_miss(
+                PayloadRead::Present(""),
+                PayloadRead::Missing,
+                PayloadRead::Missing,
+                false,
+                None,
+                true,
+            ),
+            MissAction::Unsupported
+        );
+    }
+
+    #[test]
+    fn nonempty_unicode_text_keeps_html_and_rtf_companions() {
+        let captured = rich_capture_from_payloads(
+            PayloadRead::Present("visible"),
+            PayloadRead::Present("<i>visible</i>"),
+            PayloadRead::Present(r"{\rtf1 visible}"),
+        )
+        .expect("non-empty text is still captured");
+        assert_eq!(captured.searchable_text, "visible");
+        assert_eq!(captured.html.as_deref(), Some("<i>visible</i>"));
+        assert_eq!(captured.rtf.as_deref(), Some(r"{\rtf1 visible}"));
+    }
+
+    #[test]
+    fn empty_html_and_rtf_are_not_content() {
+        assert!(rich_capture_from_payloads(
+            PayloadRead::Present(""),
+            PayloadRead::Present(""),
+            PayloadRead::Present(""),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn html_entities_and_tags_decode_to_searchable_text() {
+        assert_eq!(
+            plain_text_from_html("<div>A&nbsp;&amp;&nbsp;B</div>"),
+            "A & B"
+        );
+    }
+
+    #[test]
+    fn rtf_control_words_are_stripped() {
+        assert_eq!(
+            plain_text_from_rtf(r"{\rtf1\ansi\deff0 {\fonttbl} Hello}"),
+            "Hello"
+        );
+    }
+}

--- a/src-tauri/src/clipboard_miss.rs
+++ b/src-tauri/src/clipboard_miss.rs
@@ -27,21 +27,86 @@ pub(crate) struct RichCapture {
     pub rtf: Option<String>,
 }
 
-/// After materialize has no content, why — and what the capture path should do.
+/// Everything one materialize attempt learned before it decides what to do.
 ///
-/// Three states, not two: empty text is not a lock, and a missing format is
-/// not empty text.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum MissAction {
-    /// HTML or RTF has content. Store that clip; do not diagnose a lock.
-    CaptureRich,
-    /// Placeholder-only empty clipboard. Password-manager auto-clear.
-    Cleared,
-    /// Empty or missing text, no rich payload, no image. Private/custom only
-    /// or nothing we store. Mark handled; do not restart the listener.
-    Unsupported,
-    /// Could not open the clipboard, or a supported payload stayed unreadable.
-    Contended,
+/// Kept as one struct so production and the tests below feed [`decide_capture`]
+/// the same facts. The decision used to live inline in
+/// `materialize_clipboard_content_once`, where no test could reach it.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AttemptFacts<'a> {
+    pub text: PayloadRead<'a>,
+    pub html: PayloadRead<'a>,
+    pub rtf: PayloadRead<'a>,
+    /// An image format is advertised on the clipboard.
+    pub image_advertised: bool,
+    /// An image actually decoded on this attempt.
+    pub image_readable: bool,
+    /// Last of the bounded attempts: nothing will be retried after this one.
+    pub last_attempt: bool,
+}
+
+/// What the caller should do with one materialize attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CaptureDecision {
+    /// Store the image that already decoded.
+    Image,
+    /// Store this text / HTML / RTF clip.
+    Rich(RichCapture),
+    /// Nothing to store and nothing left to wait for. Not a lock: the caller
+    /// marks the sequence handled (or cleared) instead of restarting the
+    /// listener (SBS-924).
+    DeterminateMiss,
+    /// Try again while attempts remain.
+    Transient,
+}
+
+/// Decide one attempt from what it observed.
+///
+/// Order is the whole point:
+/// 1. Non-empty Unicode text is the copy. HTML and RTF ride along.
+/// 2. Unicode text that is advertised but unread is a delayed render, so retry
+///    while attempts remain rather than storing an HTML-derived stand-in for a
+///    body that is about to arrive.
+/// 3. A readable image beats an HTML/RTF-derived body. A Word, PowerPoint, or
+///    Outlook copy of a picture has empty Unicode text, an HTML wrapper, RTF,
+///    and a bitmap; storing the wrapper would lose the picture entirely.
+/// 4. Otherwise HTML or RTF with content is the clip.
+/// 5. An advertised-but-unread image, or unread HTML/RTF, is still contention.
+pub(crate) fn decide_capture(facts: AttemptFacts<'_>) -> CaptureDecision {
+    let html = nonempty_present(facts.html);
+    let rtf = nonempty_present(facts.rtf);
+
+    if let PayloadRead::Present(body) = facts.text {
+        if !body.is_empty() {
+            return CaptureDecision::Rich(RichCapture {
+                searchable_text: body.to_string(),
+                html: html.map(str::to_string),
+                rtf: rtf.map(str::to_string),
+            });
+        }
+    }
+
+    if matches!(facts.text, PayloadRead::Unknown) && !facts.last_attempt {
+        return CaptureDecision::Transient;
+    }
+
+    if facts.image_readable {
+        return CaptureDecision::Image;
+    }
+
+    if let Some(rich) = rich_capture_from_payloads(facts.text, facts.html, facts.rtf) {
+        return CaptureDecision::Rich(rich);
+    }
+
+    if facts.image_advertised
+        || matches!(facts.text, PayloadRead::Unknown)
+        || matches!(facts.html, PayloadRead::Unknown)
+        || matches!(facts.rtf, PayloadRead::Unknown)
+    {
+        return CaptureDecision::Transient;
+    }
+
+    CaptureDecision::DeterminateMiss
 }
 
 /// Build a storable clip from observed text/HTML/RTF.
@@ -91,59 +156,6 @@ pub(crate) fn rich_capture_from_payloads(
     })
 }
 
-/// Decide the post-miss action from observed facts.
-///
-/// `only_placeholder_text_formats` is `None` when we could not enumerate
-/// formats (unknown). That must not become a clear (would delete the previous
-/// capture) or a lock (the SBS-924 false diagnosis).
-pub(crate) fn classify_miss(
-    text: PayloadRead<'_>,
-    html: PayloadRead<'_>,
-    rtf: PayloadRead<'_>,
-    image_advertised: bool,
-    only_placeholder_text_formats: Option<bool>,
-    clipboard_opened: bool,
-) -> MissAction {
-    if rich_capture_from_payloads(text, html, rtf).is_some() {
-        // Non-empty text, or empty/missing text with HTML/RTF. Neither is a lock.
-        return MissAction::CaptureRich;
-    }
-
-    // Advertised but unread text/HTML/RTF is delayed render or a lost read,
-    // not "empty" and not "missing".
-    if matches!(text, PayloadRead::Unknown)
-        || matches!(html, PayloadRead::Unknown)
-        || matches!(rtf, PayloadRead::Unknown)
-    {
-        return MissAction::Contended;
-    }
-
-    if !clipboard_opened
-        || matches!(text, PayloadRead::Unknown)
-            && matches!(html, PayloadRead::Unknown)
-            && matches!(rtf, PayloadRead::Unknown)
-    {
-        return MissAction::Contended;
-    }
-
-    if image_advertised {
-        return MissAction::Contended;
-    }
-
-    match only_placeholder_text_formats {
-        Some(true) => MissAction::Cleared,
-        Some(false) => MissAction::Unsupported,
-        None => match text {
-            // Known empty text, formats unknown: do not clear (might still
-            // hold a private format) and do not lock (we already read).
-            PayloadRead::Present("") => MissAction::Unsupported,
-            PayloadRead::Present(_) => MissAction::Unsupported,
-            PayloadRead::Missing => MissAction::Unsupported,
-            PayloadRead::Unknown => MissAction::Contended,
-        },
-    }
-}
-
 fn nonempty_present(read: PayloadRead<'_>) -> Option<&str> {
     match read {
         PayloadRead::Present(body) if !body.is_empty() => Some(body),
@@ -151,35 +163,67 @@ fn nonempty_present(read: PayloadRead<'_>) -> Option<&str> {
     }
 }
 
+/// Elements whose text is never the copied content. `xml` and the Office
+/// conditional comments around it carry Word settings such as
+/// `<w:View>Normal</w:View>`, which used to land in the stored clip.
+const NON_CONTENT_ELEMENTS: [&str; 5] = ["head", "style", "script", "xml", "title"];
+
+/// Elements that end a visible run. Whitespace is collapsed at the end, so
+/// emitting a plain space here is enough.
+const BREAKING_ELEMENTS: [&str; 13] = [
+    "p",
+    "div",
+    "br",
+    "tr",
+    "li",
+    "td",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "blockquote",
+];
+
 /// Best-effort visible text from a CF_HTML document (header already stripped).
+///
+/// `get_html` returns the whole StartHTML..EndHTML document, so this has to
+/// ignore comments, non-content elements, and everything outside the
+/// StartFragment..EndFragment markers when the source wrote them.
 pub(crate) fn plain_text_from_html(html: &str) -> String {
+    let chars: Vec<char> = html_fragment(html).chars().collect();
     let mut out = String::new();
-    let mut in_tag = false;
-    let mut tag = String::new();
-    for ch in html.chars() {
-        match ch {
-            '<' => {
-                in_tag = true;
-                tag.clear();
-            }
-            '>' if in_tag => {
-                in_tag = false;
-                let name = tag
-                    .trim_start_matches('/')
-                    .split(|c: char| c.is_ascii_whitespace() || c == '/')
-                    .next()
-                    .unwrap_or("");
-                if matches!(
-                    name.to_ascii_lowercase().as_str(),
-                    "p" | "div" | "br" | "tr" | "li" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
-                ) {
-                    if !out.ends_with(' ') && !out.is_empty() {
-                        out.push(' ');
-                    }
-                }
-            }
-            _ if in_tag => tag.push(ch),
-            _ => out.push(ch),
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] != '<' {
+            out.push(chars[i]);
+            i += 1;
+            continue;
+        }
+        // A comment runs to the first `-->`, which for an Office conditional
+        // block is after the `<![endif]`, so the Word XML inside goes with it.
+        if starts_with(&chars, i, "<!--") {
+            i = match find_from(&chars, i + 4, "-->") {
+                Some(end) => end + 3,
+                None => chars.len(),
+            };
+            continue;
+        }
+        let Some(close) = chars[i..].iter().position(|c| *c == '>').map(|at| i + at) else {
+            // Unterminated tag: nothing after it can be trusted as markup.
+            break;
+        };
+        let raw: String = chars[i + 1..close].iter().collect();
+        let name = tag_name(&raw);
+        i = close + 1;
+        let is_open = !raw.starts_with('/') && !raw.ends_with('/');
+        if is_open && NON_CONTENT_ELEMENTS.contains(&name.as_str()) {
+            i = skip_element(&chars, i, &name);
+            continue;
+        }
+        if BREAKING_ELEMENTS.contains(&name.as_str()) {
+            out.push(' ');
         }
     }
     decode_basic_entities(&out)
@@ -188,13 +232,97 @@ pub(crate) fn plain_text_from_html(html: &str) -> String {
         .join(" ")
 }
 
+/// The copied selection, when the source marked it. Everything outside is
+/// document scaffolding the user did not copy.
+fn html_fragment(html: &str) -> &str {
+    const START: &str = "<!--StartFragment-->";
+    const END: &str = "<!--EndFragment-->";
+    let Some(start) = html.find(START) else {
+        return html;
+    };
+    let rest = &html[start + START.len()..];
+    match rest.find(END) {
+        Some(end) => &rest[..end],
+        None => rest,
+    }
+}
+
+fn tag_name(raw: &str) -> String {
+    raw.trim_start_matches('/')
+        .split(|c: char| c.is_ascii_whitespace() || c == '/' || c == '>')
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase()
+}
+
+fn starts_with(chars: &[char], at: usize, needle: &str) -> bool {
+    needle
+        .chars()
+        .enumerate()
+        .all(|(offset, expected)| chars.get(at + offset) == Some(&expected))
+}
+
+fn find_from(chars: &[char], from: usize, needle: &str) -> Option<usize> {
+    (from..chars.len()).find(|at| starts_with(chars, *at, needle))
+}
+
+/// Index just past `</name>`, or the end of the document when it never closes.
+fn skip_element(chars: &[char], from: usize, name: &str) -> usize {
+    let closing = format!("</{name}");
+    let mut i = from;
+    while i < chars.len() {
+        if chars[i] == '<' {
+            let lowered: String = chars[i..(i + closing.len()).min(chars.len())]
+                .iter()
+                .collect::<String>()
+                .to_ascii_lowercase();
+            if lowered == closing {
+                return match chars[i..].iter().position(|c| *c == '>') {
+                    Some(at) => i + at + 1,
+                    None => chars.len(),
+                };
+            }
+        }
+        i += 1;
+    }
+    chars.len()
+}
+
+/// Destination groups whose contents are binary or table data, not the copied
+/// text. `\pict` is the one that matters most: its hex image bytes used to be
+/// copied straight into the stored clip.
+const RTF_NON_CONTENT_DESTINATIONS: [&str; 8] = [
+    "pict",
+    "fonttbl",
+    "colortbl",
+    "stylesheet",
+    "info",
+    "header",
+    "footer",
+    "themedata",
+];
+
 /// Best-effort visible text from a simple RTF payload.
 pub(crate) fn plain_text_from_rtf(rtf: &str) -> String {
     let bytes = rtf.as_bytes();
     let mut out = String::new();
+    let mut depth: usize = 0;
+    // Depth of the outermost group being skipped, if any.
+    let mut skipping_from: Option<usize> = None;
     let mut i = 0;
     while i < bytes.len() {
         match bytes[i] {
+            b'{' => {
+                depth += 1;
+                i += 1;
+            }
+            b'}' => {
+                if skipping_from == Some(depth) {
+                    skipping_from = None;
+                }
+                depth = depth.saturating_sub(1);
+                i += 1;
+            }
             b'\\' => {
                 i += 1;
                 if i >= bytes.len() {
@@ -202,13 +330,15 @@ pub(crate) fn plain_text_from_rtf(rtf: &str) -> String {
                 }
                 match bytes[i] {
                     b'\\' | b'{' | b'}' => {
-                        out.push(bytes[i] as char);
+                        if skipping_from.is_none() {
+                            out.push(bytes[i] as char);
+                        }
                         i += 1;
                     }
                     b'\'' => {
                         if i + 2 < bytes.len() {
                             if let Ok(value) = u8::from_str_radix(&rtf[i + 1..i + 3], 16) {
-                                if value >= 32 {
+                                if skipping_from.is_none() && value >= 32 {
                                     out.push(value as char);
                                 }
                             }
@@ -217,12 +347,19 @@ pub(crate) fn plain_text_from_rtf(rtf: &str) -> String {
                             i += 1;
                         }
                     }
+                    // `\*` marks an ignorable destination: generator strings,
+                    // list tables, and similar. None of it is copied text.
+                    b'*' => {
+                        skipping_from.get_or_insert(depth);
+                        i += 1;
+                    }
                     b'\n' | b'\r' => i += 1,
                     c if c.is_ascii_alphabetic() => {
-                        i += 1;
+                        let start = i;
                         while i < bytes.len() && bytes[i].is_ascii_alphabetic() {
                             i += 1;
                         }
+                        let word = &rtf[start..i];
                         if i < bytes.len() && (bytes[i] == b'-' || bytes[i].is_ascii_digit()) {
                             if bytes[i] == b'-' {
                                 i += 1;
@@ -231,16 +368,30 @@ pub(crate) fn plain_text_from_rtf(rtf: &str) -> String {
                                 i += 1;
                             }
                         }
+                        // One trailing space is the control-word delimiter, not
+                        // content.
                         if i < bytes.len() && bytes[i] == b' ' {
                             i += 1;
+                        }
+                        if RTF_NON_CONTENT_DESTINATIONS.contains(&word) {
+                            skipping_from.get_or_insert(depth);
+                        } else if skipping_from.is_none()
+                            && matches!(word, "par" | "line" | "tab" | "cell" | "row" | "sect")
+                        {
+                            // Word and Outlook break paragraphs with `\par`. No
+                            // space here concatenates adjacent paragraphs, so
+                            // search stops matching on word boundaries.
+                            out.push(' ');
                         }
                     }
                     _ => i += 1,
                 }
             }
-            b'{' | b'}' | b'\n' | b'\r' => i += 1,
+            b'\n' | b'\r' => i += 1,
             c => {
-                out.push(c as char);
+                if skipping_from.is_none() {
+                    out.push(c as char);
+                }
                 i += 1;
             }
         }
@@ -261,9 +412,33 @@ fn decode_basic_entities(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        classify_miss, plain_text_from_html, plain_text_from_rtf, rich_capture_from_payloads,
-        MissAction, PayloadRead,
+        decide_capture, plain_text_from_html, plain_text_from_rtf, rich_capture_from_payloads,
+        AttemptFacts, CaptureDecision, PayloadRead,
     };
+
+    /// Facts for a clipboard with no image and no attempts left to spend, which
+    /// is the shape most of these cases care about.
+    fn facts<'a>(
+        text: PayloadRead<'a>,
+        html: PayloadRead<'a>,
+        rtf: PayloadRead<'a>,
+    ) -> AttemptFacts<'a> {
+        AttemptFacts {
+            text,
+            html,
+            rtf,
+            image_advertised: false,
+            image_readable: false,
+            last_attempt: false,
+        }
+    }
+
+    fn rich_text(decision: &CaptureDecision) -> &str {
+        match decision {
+            CaptureDecision::Rich(rich) => &rich.searchable_text,
+            other => panic!("expected a rich capture, got {other:?}"),
+        }
+    }
 
     /// SBS-924: empty CF_UNICODETEXT plus live HTML is a rich capture, not a lock.
     #[test]
@@ -278,17 +453,68 @@ mod tests {
         assert_eq!(captured.searchable_text, "Office format only");
         assert_eq!(captured.html.as_deref(), Some(html));
         assert_eq!(captured.rtf, None);
-        assert_eq!(
-            classify_miss(
-                PayloadRead::Present(""),
-                PayloadRead::Present(html),
-                PayloadRead::Missing,
-                false,
-                Some(false),
-                true,
-            ),
-            MissAction::CaptureRich
-        );
+
+        let decision = decide_capture(facts(
+            PayloadRead::Present(""),
+            PayloadRead::Present(html),
+            PayloadRead::Missing,
+        ));
+        assert_eq!(rich_text(&decision), "Office format only");
+    }
+
+    /// SBS-924 follow-up: a Word, PowerPoint, or Outlook copy of a picture has
+    /// empty Unicode text, an HTML wrapper, RTF, and a bitmap. Storing the
+    /// wrapper as a text clip loses the picture, which is never sent on the
+    /// content event and so never reaches the clips table.
+    #[test]
+    fn a_readable_image_beats_an_html_derived_body() {
+        let decision = decide_capture(AttemptFacts {
+            text: PayloadRead::Present(""),
+            html: PayloadRead::Present("<img src=\"file:///C:/Temp/image001.png\">"),
+            rtf: PayloadRead::Present(r"{\rtf1{\pict\pngblip 89504e47}}"),
+            image_advertised: true,
+            image_readable: true,
+            last_attempt: false,
+        });
+        assert_eq!(decision, CaptureDecision::Image);
+    }
+
+    /// Real text still wins over a bitmap that happens to ride along.
+    #[test]
+    fn readable_text_still_beats_an_image() {
+        let decision = decide_capture(AttemptFacts {
+            text: PayloadRead::Present("the copied phrase"),
+            html: PayloadRead::Present("<p>the copied phrase</p>"),
+            rtf: PayloadRead::Missing,
+            image_advertised: true,
+            image_readable: true,
+            last_attempt: false,
+        });
+        assert_eq!(rich_text(&decision), "the copied phrase");
+    }
+
+    /// Advertised CF_UNICODETEXT that has not rendered yet is a delayed read,
+    /// not an empty body. Accepting an HTML-derived stand-in on the first try
+    /// stores that stand-in forever: the sequence is noted as handled and the
+    /// real text is never read again.
+    #[test]
+    fn unread_advertised_text_retries_before_accepting_html() {
+        let attempt = AttemptFacts {
+            text: PayloadRead::Unknown,
+            html: PayloadRead::Present("<p>wrapper</p>"),
+            rtf: PayloadRead::Missing,
+            image_advertised: false,
+            image_readable: false,
+            last_attempt: false,
+        };
+        assert_eq!(decide_capture(attempt), CaptureDecision::Transient);
+
+        // Out of attempts, the wrapper is better than nothing.
+        let last = AttemptFacts {
+            last_attempt: true,
+            ..attempt
+        };
+        assert_eq!(rich_text(&decide_capture(last)), "wrapper");
     }
 
     /// SBS-924: empty text plus a private/custom format is handled, not a lock.
@@ -301,31 +527,12 @@ mod tests {
         )
         .is_none());
         assert_eq!(
-            classify_miss(
+            decide_capture(facts(
                 PayloadRead::Present(""),
                 PayloadRead::Missing,
                 PayloadRead::Missing,
-                false,
-                Some(false),
-                true,
-            ),
-            MissAction::Unsupported
-        );
-    }
-
-    /// SBS-924: placeholder-only empty clipboard is a clear, not a lock.
-    #[test]
-    fn truly_empty_clipboard_is_cleared_not_locked() {
-        assert_eq!(
-            classify_miss(
-                PayloadRead::Present(""),
-                PayloadRead::Missing,
-                PayloadRead::Missing,
-                false,
-                Some(true),
-                true,
-            ),
-            MissAction::Cleared
+            )),
+            CaptureDecision::DeterminateMiss
         );
     }
 
@@ -333,15 +540,12 @@ mod tests {
     #[test]
     fn unopened_clipboard_is_still_a_lock() {
         assert_eq!(
-            classify_miss(
+            decide_capture(facts(
                 PayloadRead::Unknown,
                 PayloadRead::Unknown,
                 PayloadRead::Unknown,
-                false,
-                None,
-                false,
-            ),
-            MissAction::Contended
+            )),
+            CaptureDecision::Transient
         );
     }
 
@@ -360,7 +564,8 @@ mod tests {
 
     #[test]
     fn missing_text_is_not_collapsed_into_empty_text() {
-        // get_text Err is Missing, not Present(""). HTML still wins.
+        // get_text Err with the format not advertised is Missing, not
+        // Present(""). HTML still wins, and there is nothing to wait for.
         let captured = rich_capture_from_payloads(
             PayloadRead::Missing,
             PayloadRead::Present("<p>still here</p>"),
@@ -369,32 +574,13 @@ mod tests {
         .expect("a missing Unicode format must not drop HTML");
         assert_eq!(captured.searchable_text, "still here");
 
-        // Missing text, no rich, no image, private formats: unsupported, not lock.
         assert_eq!(
-            classify_miss(
+            decide_capture(facts(
                 PayloadRead::Missing,
                 PayloadRead::Missing,
                 PayloadRead::Missing,
-                false,
-                Some(false),
-                true,
-            ),
-            MissAction::Unsupported
-        );
-    }
-
-    #[test]
-    fn unread_advertised_unicode_text_is_contention() {
-        assert_eq!(
-            classify_miss(
-                PayloadRead::Unknown,
-                PayloadRead::Missing,
-                PayloadRead::Missing,
-                false,
-                Some(false),
-                true,
-            ),
-            MissAction::Contended
+            )),
+            CaptureDecision::DeterminateMiss
         );
     }
 
@@ -402,45 +588,27 @@ mod tests {
     #[test]
     fn empty_text_plus_unread_html_is_contention_not_unsupported() {
         assert_eq!(
-            classify_miss(
+            decide_capture(facts(
                 PayloadRead::Present(""),
                 PayloadRead::Unknown,
                 PayloadRead::Missing,
-                false,
-                Some(false),
-                true,
-            ),
-            MissAction::Contended
+            )),
+            CaptureDecision::Transient
         );
     }
 
     #[test]
     fn advertised_unread_image_is_contention() {
         assert_eq!(
-            classify_miss(
-                PayloadRead::Present(""),
-                PayloadRead::Missing,
-                PayloadRead::Missing,
-                true,
-                Some(false),
-                true,
-            ),
-            MissAction::Contended
-        );
-    }
-
-    #[test]
-    fn unknown_format_enum_after_empty_text_is_not_a_lock_or_a_clear() {
-        assert_eq!(
-            classify_miss(
-                PayloadRead::Present(""),
-                PayloadRead::Missing,
-                PayloadRead::Missing,
-                false,
-                None,
-                true,
-            ),
-            MissAction::Unsupported
+            decide_capture(AttemptFacts {
+                text: PayloadRead::Present(""),
+                html: PayloadRead::Missing,
+                rtf: PayloadRead::Missing,
+                image_advertised: true,
+                image_readable: false,
+                last_attempt: false,
+            }),
+            CaptureDecision::Transient
         );
     }
 
@@ -475,11 +643,81 @@ mod tests {
         );
     }
 
+    /// `get_html` hands back the whole StartHTML..EndHTML document. Word's
+    /// conditional comments hold settings markup such as
+    /// `<w:View>Normal</w:View>`, which used to be copied into the stored clip
+    /// and pasted instead of the copied phrase.
+    #[test]
+    fn office_conditional_comments_and_settings_are_not_clip_text() {
+        let word = concat!(
+            "<html><head><style>p { margin: 0 }</style>",
+            "<!--[if gte mso 9]><xml><w:WordDocument><w:View>Normal</w:View>",
+            "</w:WordDocument></xml><![endif]--></head>",
+            "<body><p>Hello</p></body></html>"
+        );
+        assert_eq!(plain_text_from_html(word), "Hello");
+    }
+
+    /// When the source marks the selection, only the selection is the copy.
+    #[test]
+    fn only_the_marked_fragment_is_clip_text() {
+        let document = concat!(
+            "<html><body>before<!--StartFragment--><p>the copied phrase</p>",
+            "<!--EndFragment-->after</body></html>"
+        );
+        assert_eq!(plain_text_from_html(document), "the copied phrase");
+    }
+
+    /// A stylesheet in the body is markup, not content.
+    #[test]
+    fn style_and_script_bodies_are_not_clip_text() {
+        assert_eq!(
+            plain_text_from_html("<div><style>.a{color:red}</style>kept<script>x=1</script></div>"),
+            "kept"
+        );
+    }
+
     #[test]
     fn rtf_control_words_are_stripped() {
         assert_eq!(
             plain_text_from_rtf(r"{\rtf1\ansi\deff0 {\fonttbl} Hello}"),
             "Hello"
         );
+    }
+
+    /// `\par` is how Word and Outlook break paragraphs. Dropping it entirely
+    /// runs the paragraphs together, so search stops matching on the word
+    /// boundary between them.
+    #[test]
+    fn rtf_paragraph_breaks_become_whitespace() {
+        assert_eq!(
+            plain_text_from_rtf(r"{\rtf1 Hello\par World}"),
+            "Hello World"
+        );
+        // A control word ends at the first non-letter, so `\par` followed by a
+        // newline is the other shape Word writes. `\parWorld` is a different
+        // control word, not `\par` plus text, and is not RTF Word emits.
+        assert_eq!(
+            plain_text_from_rtf("{\\rtf1 Hello\\par\nWorld}"),
+            "Hello World"
+        );
+        assert_eq!(plain_text_from_rtf(r"{\rtf1 a\tab b\line c}"), "a b c");
+    }
+
+    /// A pasted picture carries its bytes as hex inside `\pict`. Those used to
+    /// be copied straight into the stored body and the History preview.
+    #[test]
+    fn rtf_picture_bytes_and_tables_are_not_clip_text() {
+        let word = concat!(
+            r"{\rtf1\ansi{\fonttbl{\f0 Calibri;}}{\colortbl;\red0\green0\blue0;}",
+            r"{\*\generator Riched20 10.0.0;}",
+            r"{\pict\pngblip\picw100\pich100 89504e470d0a1a0a0000000d49484452}",
+            r" the copied phrase}"
+        );
+        let text = plain_text_from_rtf(word);
+        assert_eq!(text, "the copied phrase");
+        assert!(!text.contains("89504e47"), "picture hex leaked: {text}");
+        assert!(!text.contains("Calibri"), "font table leaked: {text}");
+        assert!(!text.contains("Riched20"), "generator leaked: {text}");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ mod backup;
 mod cf_html;
 mod clip_list;
 mod clipboard;
+mod clipboard_miss;
 mod clipboard_policy;
 mod commands;
 // SBS-408 compatibility-matrix model. Compiled under `test` as well as


### PR DESCRIPTION
## Summary

Empty CF_UNICODETEXT is no longer treated as a clipboard lock. HTML/RTF are stored; private-only copies are handled; a real lock is still a lock.

Fixes https://linear.app/southboundsoftware/issue/SBS-924/cubby-empty-cf-unicodetext-copies-are-diagnosed-as-a-clipboard-lock

A user who copies HTML/RTF with empty Unicode text now gets a History row and can paste the rich formats back.

## Why

Empty Unicode text made materialize skip HTML/RTF, then advertised CF_UNICODETEXT was classified as contention.

## Quality gate

Linux: cargo fmt passed. rustc --test clipboard_miss.rs: 14 passed. Full crate tests do not compile here. Windows CI owns the rest.

## Fail without the fix

Reverted only the helper to the old empty-text-is-lock collapse. Five tests failed (empty+HTML dropped, empty+RTF dropped, empty+private classified Contended, missing text dropped HTML, unknown enum classified Contended). Clear and real-lock tests still passed. Restored the fix; 14 passed.

## Pattern sweep

rg stayed locked / clipboard contended / clipboard_has_supported_format: only clipboard.rs. Determinate empty-text misses no longer take the lock arm. clipboard_is_cleared already treated empty+HTML as not a clear. Probe read_text_with_retry records Ok empty as a read, not a lock. File-payload and hybrid-image paths already Handled.

## What this makes more likely

HTML/RTF-only copies now enter history. skip_likely_secrets and forget-on-clear run on derived text. Advertised-but-unread HTML/RTF still retries as contention.

## Gaps

Could not run full cargo test or clippy on Linux. No live Office format-only copy. HTML/RTF to text is best-effort stripping. No committed Linux harness. Distinct from SBS-919 / 922 / 908 / 912. Not merged.

## Fail-without-fix output

```

running 12 tests
test tests::advertised_unread_image_is_contention ... ok
test tests::empty_html_and_rtf_are_not_content ... ok

thread 'tests::empty_text_plus_html_is_captured_not_locked' (407374) panicked at /home/box/projects/cubby-sbs-924/src-tauri/src/clipboard_miss.rs:248:10:
empty Unicode text must not drop HTML
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'tests::empty_text_plus_rtf_is_captured' (407376) panicked at /home/box/projects/cubby-sbs-924/src-tauri/src/clipboard_miss.rs:327:10:
empty Unicode text must not drop RTF

thread 'tests::empty_text_plus_private_format_is_unsupported_not_locked' (407375) panicked at /home/box/projects/cubby-sbs-924/src-tauri/src/clipboard_miss.rs:274:9:
assertion `left == right` failed
  left: Contended
 right: Unsupported

thread 'tests::missing_text_is_not_collapsed_into_empty_text' (407378) panicked at /home/box/projects/cubby-sbs-924/src-tauri/src/clipboard_miss.rs:340:10:
a missing Unicode format must not drop HTML
test tests::rtf_control_words_are_stripped ... ok
test tests::truly_empty_clipboard_is_cleared_not_locked ... ok
test tests::empty_text_plus_html_is_captured_not_locked ... FAILED
thread 'tests::unknown_format_enum_after_empty_text_is_not_a_lock_or_a_clear' (407382) panicked at /home/box/projects/cubby-sbs-924/src-tauri/src/clipboard_miss.rs:374:9:
assertion `left == right` failed
  left: Contended
 right: Unsupported

test tests::nonempty_unicode_text_keeps_html_and_rtf_companions ... ok
test tests::empty_text_plus_rtf_is_captured ... FAILED
test tests::empty_text_plus_private_format_is_unsupported_not_locked ... FAILED
test tests::missing_text_is_not_collapsed_into_empty_text ... FAILED
test tests::html_entities_and_tags_decode_to_searchable_text ... ok
test tests::unknown_format_enum_after_empty_text_is_not_a_lock_or_a_clear ... FAILED
test tests::unopened_clipboard_is_still_a_lock ... ok

failures:

failures:
    tests::empty_text_plus_html_is_captured_not_locked
    tests::empty_text_plus_private_format_is_unsupported_not_locked
    tests::empty_text_plus_rtf_is_captured
    tests::missing_text_is_not_collapsed_into_empty_text
    tests::unknown_format_enum_after_empty_text_is_not_a_lock_or_a_clear

test result: FAILED. 7 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


```


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows clipboard listener to store HTML/RTF content when Unicode text is empty
> - The Windows clipboard listener previously treated empty `CF_UNICODETEXT` as a clipboard lock and restarted; it now distinguishes determinate misses, transient contention, and truly cleared clipboards.
> - A new [`clipboard_miss`](https://github.com/tsouth89/cubby-clipboard/pull/229/files#diff-2bc2fea85385b1b53cabfbafc00679ddd062c7cda5d1e5ff4468ae83327de1d0) module provides a `decide_capture` classifier and `rich_capture_from_payloads` builder that derive searchable text from HTML or RTF when Unicode text is absent.
> - HTML-to-text and RTF-to-text extractors strip scaffolding (Office XML, font/color tables, picture bytes) to produce clean previews and search bodies.
> - Advertised-but-unread text or images trigger retries; readable images take priority over HTML/RTF wrappers.
> - Behavioral Change: copies that previously caused a listener restart now either store HTML/RTF-derived content, emit a `Cleared` event, or are silently handled without restarting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 982fa61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->