### PR TITLE
SBS-929: Keep startup quarantine and restore lines in the log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - Search no longer ships full decrypted clip bodies on every keystroke; flyout and History search rows use the same preview-only contract as the list (SBS-912)
 
 ### Fixed
+- Record startup quarantine and rolling-backup restore in the on-disk log, instead of discarding those lines before the logger exists (SBS-929)
 - Skip-likely-secrets now scans the first 8 KiB of a large paste, so a 9 KiB log or PEM starting with a known token or `-----BEGIN` marker is skipped instead of stored (SBS-922)
 - A failed clip reload no longer looks like a healthy current list: same-filter refresh shows a retry banner, superseded loads are not treated as success, and folder / app / count reloads toast instead of staying silent (SBS-805)
 - Portable first-run can install `storage.key` on FAT/exFAT: CreateHardLinkW is NTFS-only, and the previous hard-link-only install deleted the temp key and panicked (SBS-908)

--- a/docs/CLIPBOARD_RELIABILITY.md
+++ b/docs/CLIPBOARD_RELIABILITY.md
@@ -20,6 +20,7 @@ Clipboard capture is Cubby's primary product promise. A polished history UI is n
 - Keep local history durable: on startup, run SQLite `PRAGMA quick_check` on the existing `cubby.db`. If the file cannot be opened or fails the check, quarantine it (and any `-wal`/`-shm` sidecars) under a timestamped `*.corrupt-*` name and start a fresh empty database so capture never blocks on a broken store.
 - Refresh a rolling `cubby.db.bak` snapshot of a healthy database at most once per 24 hours (after a WAL checkpoint), both when the database opens and while Cubby stays running, so operators have a recent recovery point without copying on every launch or requiring a quit.
 - Never log clipboard content, previews, or decryptable payloads during recovery; logs may include paths and short structural diagnostics only. The DPAPI-protected `storage.key` and image blobs are left in place when the DB is quarantined.
+- Quarantine, restore-from-backup, and empty-history fallback are recorded through the same startup log buffer as migrations so they appear in the on-disk log after the logger is installed (SBS-929).
 
 ## Format baseline
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -117,7 +117,8 @@ issue. Do not paste clipboard contents into bug reports or logs.
    to something like `cubby.db.corrupt-YYYYMMDD-HHMMSS`. `storage.key` must
    still be present. History is empty (expected after quarantine).
 4. Logs under the app log dir mention quarantine/structural failure only; no
-   clip text or image payloads.
+   clip text or image payloads. The quarantine or restore line must appear in
+   the same log file as `Cubby starting...` (SBS-929).
 
 ### Single-instance and autostart
 

--- a/docs/SOU-218-ACCEPTANCE.md
+++ b/docs/SOU-218-ACCEPTANCE.md
@@ -25,6 +25,7 @@ Status key: **Pass** (automated or verified) · **Pending** (needs human session
 | Healthy DB gets rolling backup | `healthy_database_gets_a_rolling_backup` | Pass |
 | Fresh backup is not rewritten | `fresh_rolling_backup_is_not_rewritten` | Pass |
 | Garbage DB is quarantined; fresh open works | `garbage_database_is_quarantined_and_fresh_open_succeeds` | Pass |
+| Quarantine/restore notices are returned for `startup_log` | `apply_database_health_returns_quarantine_notices`, `unusable_rolling_backup_reports_empty_history` (SBS-929) | Pass |
 | Structural corruption is quarantined | `structurally_corrupt_sqlite_is_quarantined` | Pass |
 | `storage.key` survives quarantine | `quarantine_rename_preserves_sibling_key_file` | Pass |
 | Encrypted DB without key still fails closed | `encrypted_database_without_its_key_fails_closed` | Pass |

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -2600,6 +2600,52 @@ mod tests {
         let _ = std::fs::remove_dir_all(directory);
     }
 
+    /// SBS-929: the healthy path still has one thing to say. A refresh that
+    /// cannot write a copy is best-effort for capture, but the user must be
+    /// able to find out that the recovery copy is not current.
+    ///
+    /// The fixture is a database file that is gone by the time the refresh
+    /// opens it — the file-level failure a full disk or a revoked permission
+    /// produces at the same point. `apply_database_health` is called with
+    /// `Healthy` directly, which is the arm under test.
+    #[tokio::test]
+    async fn healthy_path_reports_a_failed_backup_refresh() {
+        let directory = temp_dir();
+        let database_path = directory.join("cubby.db");
+        assert!(
+            !database_path.exists(),
+            "the refresh must be the thing that fails, not the health check"
+        );
+
+        let notices = apply_database_health(&database_path, DatabaseHealth::Healthy)
+            .await
+            .expect("a failed backup refresh must not block startup");
+        assert_has_notice(
+            &notices,
+            log::Level::Warn,
+            "Could not refresh history backup",
+        );
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    /// SBS-929: `Database::new` must hand its caller the lines
+    /// `prepare_database_file` produced. Dropping that vec on the `Ok` tuple
+    /// is exactly the silent-startup bug, and every other test in this file
+    /// calls `prepare_database_file` directly, so nothing else would catch it.
+    #[tokio::test]
+    async fn database_new_returns_the_prepare_notices() {
+        let directory = temp_dir();
+        let database_path = directory.join("cubby.db");
+        std::fs::write(&database_path, b"this is not a sqlite database").unwrap();
+
+        let (_database, notices) = Database::new(database_path.to_str().unwrap())
+            .await
+            .expect("a quarantined history should still open a fresh database");
+        assert_has_notice(&notices, log::Level::Error, "quarantining");
+        assert_has_notice(&notices, log::Level::Warn, "empty history");
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
     /// SBS-929: the leftover migrate `log::info!` for file-reference rows
     /// must come back as a collectable notice.
     #[tokio::test]

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -34,11 +34,16 @@ impl Database {
     /// DPAPI account mismatch (recoverable, explain it) apart from everything
     /// else (a bug or a broken disk). `From<String>` keeps the `?` on each
     /// String-producing step below unchanged.
-    pub async fn new(db_path: &str) -> Result<Self, crate::crypto::StorageError> {
+    /// Opens storage and returns any history-rewrite notices that happened
+    /// before the logger exists. The caller must flush those through the
+    /// existing `startup_log` buffer (SBS-929); `log::` here is discarded.
+    pub async fn new(
+        db_path: &str,
+    ) -> Result<(Self, Vec<(log::Level, String)>), crate::crypto::StorageError> {
         let path = Path::new(db_path);
         // Fail open for capture: a corrupt history is quarantined and replaced
         // with an empty database rather than blocking the app (SOU-218).
-        prepare_database_file(path).await?;
+        let notices = prepare_database_file(path).await?;
 
         let image_dir = path
             .parent()
@@ -77,12 +82,15 @@ impl Database {
             encryption_version.as_deref() != Some("1"),
         )?);
 
-        Ok(Self {
-            pool,
-            crypto,
-            image_dir,
-            search_index: Arc::new(crate::search_index::SearchIndex::default()),
-        })
+        Ok((
+            Self {
+                pool,
+                crypto,
+                image_dir,
+                search_index: Arc::new(crate::search_index::SearchIndex::default()),
+            },
+            notices,
+        ))
     }
 
     /// Collapse duplicate `content_hash` rows and make the constraint
@@ -269,7 +277,10 @@ impl Database {
         Ok(removed)
     }
 
-    pub async fn migrate(&self) -> Result<(), sqlx::Error> {
+    /// Schema setup. Returns notices for history it rewrote (legacy
+    /// file-reference rows). Those must be flushed through `startup_log`;
+    /// `log::` here is discarded (SBS-929).
+    pub async fn migrate(&self) -> Result<Vec<(log::Level, String)>, sqlx::Error> {
         sqlx::query(
             r#"
             CREATE TABLE IF NOT EXISTS folders (
@@ -491,15 +502,24 @@ impl Database {
                 .execute(&self.pool)
                 .await?
                 .rows_affected();
+        let mut notices = Vec::new();
         if removed_file_references > 0 {
-            log::info!(
-                "STORAGE: Removed {} legacy file-reference history items",
-                removed_file_references
-            );
+            notices.push(to_startup_line(
+                crate::startup_recovery_log::removed_file_references(removed_file_references),
+            ));
         }
 
-        Ok(())
+        Ok(notices)
     }
+}
+
+fn to_startup_line(notice: crate::startup_recovery_log::RecoveryNotice) -> (log::Level, String) {
+    let level = match notice.level {
+        crate::startup_recovery_log::RecoveryLevel::Error => log::Level::Error,
+        crate::startup_recovery_log::RecoveryLevel::Warn => log::Level::Warn,
+        crate::startup_recovery_log::RecoveryLevel::Info => log::Level::Info,
+    };
+    (level, notice.message)
 }
 
 /// Ensure `db_path` is either absent (will be created) or a healthy SQLite file.
@@ -508,35 +528,45 @@ impl Database {
 /// when SQLite proves the file is not a database. Transient open/query errors
 /// (BUSY, LOCKED, I/O, permissions) leave the original file untouched and
 /// surface a startup error instead (SBS-770).
-async fn prepare_database_file(db_path: &Path) -> Result<(), String> {
+///
+/// History-rewrite notices are returned so `run_app` can flush them through
+/// `startup_log` after the logger exists (SBS-929).
+async fn prepare_database_file(db_path: &Path) -> Result<Vec<(log::Level, String)>, String> {
     if !db_path.exists() {
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     apply_database_health(db_path, assess_database_file(db_path).await).await
 }
 
-async fn apply_database_health(db_path: &Path, health: DatabaseHealth) -> Result<(), String> {
+async fn apply_database_health(
+    db_path: &Path,
+    health: DatabaseHealth,
+) -> Result<Vec<(log::Level, String)>, String> {
     match health {
         DatabaseHealth::Healthy => {
             if let Err(error) = refresh_rolling_backup(db_path).await {
                 // Backup is best-effort; a full disk must not block capture.
-                log::warn!("STORAGE: Could not refresh history backup: {error}");
+                return Ok(vec![to_startup_line(
+                    crate::startup_recovery_log::backup_refresh_failed(&error),
+                )]);
             }
-            Ok(())
+            Ok(Vec::new())
         }
         DatabaseHealth::Corrupt { reason } => {
             // Structural diagnostics only: never log row contents.
-            log::error!(
-                "STORAGE: Clipboard history database is unusable ({}); quarantining",
-                sanitize_storage_diagnostic(&reason)
-            );
+            let sanitized = sanitize_storage_diagnostic(&reason);
             let path = db_path.to_path_buf();
             tokio::task::spawn_blocking(move || quarantine_database_files(&path))
                 .await
                 .map_err(|e| format!("quarantine task failed: {e}"))??;
-            restore_from_rolling_backup(db_path).await;
-            Ok(())
+            let restore = restore_from_rolling_backup(db_path).await;
+            Ok(
+                crate::startup_recovery_log::notices_for_corrupt(&sanitized, restore)
+                    .into_iter()
+                    .map(to_startup_line)
+                    .collect(),
+            )
         }
         DatabaseHealth::Unassessable { reason } => Err(format!(
             "could not assess clipboard history ({}); the existing database was left untouched",
@@ -549,37 +579,35 @@ async fn apply_database_health(db_path: &Path, health: DatabaseHealth) -> Result
 /// the user keeps up to 24h-old history instead of silently starting from
 /// zero. The backup file itself is kept (copy, not rename) as a second chance
 /// for manual recovery. Best-effort: any failure falls back to a fresh file.
-async fn restore_from_rolling_backup(db_path: &Path) {
+async fn restore_from_rolling_backup(
+    db_path: &Path,
+) -> crate::startup_recovery_log::RestoreOutcome {
     let backup = rolling_backup_path(db_path);
     if !backup.exists() {
-        log::warn!("STORAGE: No rolling backup found; starting with an empty history");
-        return;
+        return crate::startup_recovery_log::RestoreOutcome::NoBackup;
     }
 
     match assess_database_file(&backup).await {
         DatabaseHealth::Healthy => {}
         DatabaseHealth::Corrupt { reason } | DatabaseHealth::Unassessable { reason } => {
-            log::error!(
-                "STORAGE: Rolling backup failed verification ({}); starting with an empty history",
-                sanitize_storage_diagnostic(&reason)
-            );
-            return;
+            return crate::startup_recovery_log::RestoreOutcome::BackupUnusable {
+                reason: sanitize_storage_diagnostic(&reason),
+            };
         }
     }
 
     let source = backup.clone();
     let destination = db_path.to_path_buf();
     match tokio::task::spawn_blocking(move || std::fs::copy(&source, &destination)).await {
-        Ok(Ok(_)) => log::warn!(
-            "STORAGE: Restored clipboard history from rolling backup {}",
-            backup.display()
-        ),
-        Ok(Err(error)) => log::error!(
-            "STORAGE: Could not restore history backup: {error}; starting with an empty history"
-        ),
-        Err(error) => log::error!(
-            "STORAGE: Backup restore task failed: {error}; starting with an empty history"
-        ),
+        Ok(Ok(_)) => crate::startup_recovery_log::RestoreOutcome::Restored {
+            path: backup.display().to_string(),
+        },
+        Ok(Err(error)) => crate::startup_recovery_log::RestoreOutcome::CopyFailed {
+            error: error.to_string(),
+        },
+        Err(error) => crate::startup_recovery_log::RestoreOutcome::TaskFailed {
+            error: error.to_string(),
+        },
     }
 }
 
@@ -1257,6 +1285,16 @@ mod tests {
             std::env::temp_dir().join(format!("cubby-db-test-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&directory).unwrap();
         directory
+    }
+
+    /// SBS-929: a history rewrite that only `log::`'d would return no lines.
+    fn assert_has_notice(notices: &[(log::Level, String)], level: log::Level, needle: &str) {
+        assert!(
+            notices
+                .iter()
+                .any(|(got_level, message)| *got_level == level && message.contains(needle)),
+            "expected {level} notice containing {needle:?}, got {notices:?}"
+        );
     }
 
     /// uuid, is_pinned, is_hidden, folder_id, notes.
@@ -2246,9 +2284,11 @@ mod tests {
         std::fs::write(&database_path, b"this is not a sqlite database").unwrap();
         std::fs::write(&wal_path, b"wal-garbage").unwrap();
 
-        prepare_database_file(&database_path)
+        let notices = prepare_database_file(&database_path)
             .await
             .expect("corrupt history should be quarantined");
+        assert_has_notice(&notices, log::Level::Error, "quarantining");
+        assert_has_notice(&notices, log::Level::Warn, "empty history");
 
         assert!(!database_path.exists(), "main DB should be moved aside");
         assert!(!wal_path.exists(), "WAL sidecar should be moved aside");
@@ -2276,7 +2316,7 @@ mod tests {
         );
 
         // Fresh open after quarantine must create a usable database.
-        let db = Database::new(database_path.to_str().unwrap())
+        let (db, _notices) = Database::new(database_path.to_str().unwrap())
             .await
             .expect("fresh database should open after quarantine");
         db.migrate().await.expect("fresh schema should apply");
@@ -2311,9 +2351,21 @@ mod tests {
 
         std::fs::write(&database_path, b"this is not a sqlite database").unwrap();
 
-        prepare_database_file(&database_path)
+        let notices = prepare_database_file(&database_path)
             .await
             .expect("corrupt history should be quarantined and restored");
+        assert_has_notice(&notices, log::Level::Error, "quarantining");
+        assert_has_notice(
+            &notices,
+            log::Level::Warn,
+            "Restored clipboard history from rolling backup",
+        );
+        assert!(
+            !notices
+                .iter()
+                .any(|(_, message)| message.contains("empty history")),
+            "a successful restore must not also claim empty history, got {notices:?}"
+        );
 
         assert!(
             database_path.exists(),
@@ -2388,9 +2440,10 @@ mod tests {
         }
         std::fs::write(&database_path, bytes).unwrap();
 
-        prepare_database_file(&database_path)
+        let notices = prepare_database_file(&database_path)
             .await
             .expect("corrupt sqlite should quarantine rather than fail startup");
+        assert_has_notice(&notices, log::Level::Error, "quarantining");
         assert!(!database_path.exists());
         let _ = std::fs::remove_dir_all(directory);
     }
@@ -2493,5 +2546,87 @@ mod tests {
             b"key-bytes"
         );
         let _ = std::fs::remove_dir_all(directory);
+    }
+
+    /// SBS-929: an unusable rolling backup is an empty-history fallback, and
+    /// that line must be returned rather than only `log::`'d.
+    #[tokio::test]
+    async fn unusable_rolling_backup_reports_empty_history() {
+        let directory = temp_dir();
+        let database_path = directory.join("cubby.db");
+        let backup_path = rolling_backup_path(&database_path);
+        std::fs::write(&database_path, b"this is not a sqlite database").unwrap();
+        std::fs::write(&backup_path, b"this is not a sqlite backup").unwrap();
+
+        let notices = prepare_database_file(&database_path)
+            .await
+            .expect("corrupt history should fail open even when the backup is unusable");
+        assert_has_notice(&notices, log::Level::Error, "quarantining");
+        assert_has_notice(
+            &notices,
+            log::Level::Error,
+            "Rolling backup failed verification",
+        );
+        assert_has_notice(&notices, log::Level::Error, "empty history");
+        assert!(
+            !database_path.exists(),
+            "unusable backup must not be installed"
+        );
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    /// SBS-929: `apply_database_health` itself must return the lines. A
+    /// `log::` inside this function is the discarded path the ticket names.
+    #[tokio::test]
+    async fn apply_database_health_returns_quarantine_notices() {
+        let directory = temp_dir();
+        let database_path = directory.join("cubby.db");
+        std::fs::write(&database_path, b"broken").unwrap();
+
+        let notices = apply_database_health(
+            &database_path,
+            DatabaseHealth::Corrupt {
+                reason: "file is not a database".to_string(),
+            },
+        )
+        .await
+        .expect("corrupt health should fail open");
+        assert_has_notice(&notices, log::Level::Error, "quarantining");
+        assert_has_notice(&notices, log::Level::Warn, "empty history");
+        assert!(
+            !notices.is_empty(),
+            "returning no notices is the pre-fix bug (log:: only)"
+        );
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    /// SBS-929: the leftover migrate `log::info!` for file-reference rows
+    /// must come back as a collectable notice.
+    #[tokio::test]
+    async fn migrate_reports_removed_legacy_file_references() {
+        let database = migrated_database().await;
+        sqlx::query(
+            r#"INSERT INTO clips (uuid, clip_type, content, text_preview, content_hash)
+               VALUES ('file-1', 'file', x'00', 'preview', 'file-hash')"#,
+        )
+        .execute(&database.pool)
+        .await
+        .expect("legacy file-reference row should insert");
+
+        let notices = database
+            .migrate()
+            .await
+            .expect("migrate should remove the leftover file row");
+        assert_has_notice(
+            &notices,
+            log::Level::Info,
+            "legacy file-reference history items",
+        );
+        let remaining: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM clips WHERE clip_type = 'file'")
+                .fetch_one(&database.pool)
+                .await
+                .expect("count should query");
+        assert_eq!(remaining, 0);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,6 +47,7 @@ mod secrets;
 mod settings_commands;
 mod settings_manager;
 mod shortcuts;
+mod startup_recovery_log;
 pub mod win_v_activation;
 mod win_v_replacement;
 mod window_state;
@@ -97,8 +98,8 @@ pub fn run_app() {
     let rt = get_runtime().expect("Failed to get global tokio runtime");
     let _guard = rt.enter();
 
-    let db = match rt.block_on(async { Database::new(&db_path_str).await }) {
-        Ok(db) => db,
+    let (db, mut startup_log) = match rt.block_on(async { Database::new(&db_path_str).await }) {
+        Ok(pair) => pair,
         // The one storage failure a user can cause without anything being
         // broken, and the one they can undo. Panicking here produced a silent
         // launch failure: this runs before the logger exists, so the message
@@ -114,12 +115,13 @@ pub fn run_app() {
     //
     // `tauri_plugin_log` is not installed until the builder runs, far below, so
     // a `log::info!` or `log::error!` up here goes nowhere -- which silently
-    // cost the record of a migration that modified a real user's history. These
-    // messages are collected instead and flushed in `setup`, once the logger
-    // exists. Add to this rather than logging directly.
-    let mut startup_log: Vec<(log::Level, String)> = Vec::new();
+    // cost the record of a migration that modified a real user's history, and
+    // of a quarantine/restore that rewrote it (SBS-929). `Database::new`
+    // returns those lines; this buffer is that same vec, then migrations
+    // append. Flushed in `setup` once the logger exists. Add to this rather
+    // than logging directly.
     rt.block_on(async {
-        db.migrate().await.expect("Cubby database migration failed");
+        startup_log.extend(db.migrate().await.expect("Cubby database migration failed"));
         let migrated = commands::migrate_encrypted_storage(&db)
             .await
             .unwrap_or_else(|error| panic!("Cubby encrypted storage migration failed: {error}"));

--- a/src-tauri/src/perf_budget.rs
+++ b/src-tauri/src/perf_budget.rs
@@ -353,7 +353,7 @@ mod measurements {
 
     async fn on_disk_database(dir: &std::path::Path) -> (Database, std::path::PathBuf) {
         let path = dir.join("cubby.db");
-        let database = Database::new(path.to_str().expect("utf-8 path"))
+        let (database, _notices) = Database::new(path.to_str().expect("utf-8 path"))
             .await
             .expect("database should open");
         database.migrate().await.expect("migration should succeed");

--- a/src-tauri/src/startup_recovery_log.rs
+++ b/src-tauri/src/startup_recovery_log.rs
@@ -1,0 +1,211 @@
+//! History-rewrite notices that must be flushed after the logger exists.
+//!
+//! `Database::new` and `migrate` run before `tauri_plugin_log` is installed.
+//! A `log::` call in that window is discarded. These constructors are the
+//! only supported way to record a quarantine, restore, or empty-history
+//! fallback so `run_app` can push the line into the existing `startup_log`
+//! buffer (SBS-929).
+//!
+//! This file has no crate dependencies so `rustc --test` can pin the
+//! messages on a Linux box that cannot compile the Windows crate.
+
+/// Severity of a pre-logger recovery line. Mapped to `log::Level` at the
+/// flush site so this module stays standalone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryLevel {
+    Error,
+    Warn,
+    Info,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoveryNotice {
+    pub level: RecoveryLevel,
+    pub message: String,
+}
+
+impl RecoveryNotice {
+    fn new(level: RecoveryLevel, message: impl Into<String>) -> Self {
+        Self {
+            level,
+            message: message.into(),
+        }
+    }
+}
+
+/// What happened after the unusable history file was moved aside.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RestoreOutcome {
+    NoBackup,
+    BackupUnusable { reason: String },
+    Restored { path: String },
+    CopyFailed { error: String },
+    TaskFailed { error: String },
+}
+
+pub fn quarantine(reason: &str) -> RecoveryNotice {
+    RecoveryNotice::new(
+        RecoveryLevel::Error,
+        format!("STORAGE: Clipboard history database is unusable ({reason}); quarantining"),
+    )
+}
+
+pub fn no_rolling_backup() -> RecoveryNotice {
+    RecoveryNotice::new(
+        RecoveryLevel::Warn,
+        "STORAGE: No rolling backup found; starting with an empty history",
+    )
+}
+
+pub fn backup_unusable(reason: &str) -> RecoveryNotice {
+    RecoveryNotice::new(
+        RecoveryLevel::Error,
+        format!(
+            "STORAGE: Rolling backup failed verification ({reason}); starting with an empty history"
+        ),
+    )
+}
+
+pub fn restored(path: &str) -> RecoveryNotice {
+    RecoveryNotice::new(
+        RecoveryLevel::Warn,
+        format!("STORAGE: Restored clipboard history from rolling backup {path}"),
+    )
+}
+
+pub fn restore_copy_failed(error: &str) -> RecoveryNotice {
+    RecoveryNotice::new(
+        RecoveryLevel::Error,
+        format!(
+            "STORAGE: Could not restore history backup: {error}; starting with an empty history"
+        ),
+    )
+}
+
+pub fn restore_task_failed(error: &str) -> RecoveryNotice {
+    RecoveryNotice::new(
+        RecoveryLevel::Error,
+        format!("STORAGE: Backup restore task failed: {error}; starting with an empty history"),
+    )
+}
+
+pub fn backup_refresh_failed(error: &str) -> RecoveryNotice {
+    RecoveryNotice::new(
+        RecoveryLevel::Warn,
+        format!("STORAGE: Could not refresh history backup: {error}"),
+    )
+}
+
+pub fn removed_file_references(count: u64) -> RecoveryNotice {
+    RecoveryNotice::new(
+        RecoveryLevel::Info,
+        format!("STORAGE: Removed {count} legacy file-reference history items"),
+    )
+}
+
+/// The lines a corrupt-DB fail-open must return. Returning an empty vec
+/// here is the pre-fix bug: `log::` inside `Database::new` and nothing
+/// for `startup_log` to flush.
+pub fn notices_for_corrupt(reason: &str, restore: RestoreOutcome) -> Vec<RecoveryNotice> {
+    let mut notices = vec![quarantine(reason)];
+    notices.push(match restore {
+        RestoreOutcome::NoBackup => no_rolling_backup(),
+        RestoreOutcome::BackupUnusable { reason } => backup_unusable(&reason),
+        RestoreOutcome::Restored { path } => restored(&path),
+        RestoreOutcome::CopyFailed { error } => restore_copy_failed(&error),
+        RestoreOutcome::TaskFailed { error } => restore_task_failed(&error),
+    });
+    notices
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the failure mode this module exists for: a history rewrite
+    /// that only `log::`'d would hand `startup_log` an empty vec.
+    #[test]
+    fn notices_for_corrupt_are_not_empty() {
+        let notices = notices_for_corrupt("file is not a database", RestoreOutcome::NoBackup);
+        assert!(
+            !notices.is_empty(),
+            "a corrupt-DB fail-open must return collectable lines, not log:: and discard"
+        );
+        assert!(
+            notices
+                .iter()
+                .any(|n| n.level == RecoveryLevel::Error && n.message.contains("quarantining")),
+            "expected a quarantine line, got {notices:?}"
+        );
+        assert!(
+            notices.iter().any(|n| n.message.contains("empty history")),
+            "expected an empty-history fallback line, got {notices:?}"
+        );
+    }
+
+    #[test]
+    fn successful_restore_is_not_silent() {
+        let notices = notices_for_corrupt(
+            "quick_check: not ok",
+            RestoreOutcome::Restored {
+                path: "cubby.db.bak".to_string(),
+            },
+        );
+        assert!(
+            notices.iter().any(|n| n
+                .message
+                .contains("Restored clipboard history from rolling backup")),
+            "expected a restore line, got {notices:?}"
+        );
+        assert!(
+            !notices.iter().any(|n| n.message.contains("empty history")),
+            "a successful restore must not also claim empty history, got {notices:?}"
+        );
+    }
+
+    #[test]
+    fn unusable_backup_is_an_empty_history_fallback() {
+        let notices = notices_for_corrupt(
+            "file is not a database",
+            RestoreOutcome::BackupUnusable {
+                reason: "file is not a database".to_string(),
+            },
+        );
+        assert!(
+            notices
+                .iter()
+                .any(|n| n.message.contains("Rolling backup failed verification")
+                    && n.message.contains("empty history")),
+            "expected an unusable-backup fallback, got {notices:?}"
+        );
+    }
+
+    #[test]
+    fn restore_copy_and_task_failures_are_empty_history_fallbacks() {
+        for outcome in [
+            RestoreOutcome::CopyFailed {
+                error: "disk full".to_string(),
+            },
+            RestoreOutcome::TaskFailed {
+                error: "cancelled".to_string(),
+            },
+        ] {
+            let notices = notices_for_corrupt("quick_check: not ok", outcome);
+            assert!(
+                notices.iter().any(|n| n.message.contains("empty history")),
+                "expected an empty-history fallback, got {notices:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn backup_refresh_failure_and_file_reference_removal_keep_their_wording() {
+        assert!(backup_refresh_failed("disk full")
+            .message
+            .contains("Could not refresh history backup"));
+        assert_eq!(
+            removed_file_references(3).message,
+            "STORAGE: Removed 3 legacy file-reference history items"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Database::new logged quarantine/restore before tauri_plugin_log existed, so those lines were discarded.
- Notices are now returned into the existing startup_log buffer and flushed in setup.
- A quarantined or restored cubby.db leaves a STORAGE line in the on-disk log above Cubby starting...

## Test plan

- [x] rustc --edition 2021 --test src-tauri/src/startup_recovery_log.rs — 5 passed
- [x] Fail-without-fix: empty notices_for_corrupt (pre-fix log::-only path) — 4 helper tests failed, then restored
- [ ] Windows CI: cargo test --manifest-path src-tauri/Cargo.toml --all-targets (cannot compile the Windows crate here)
- [ ] Windows CI: cargo fmt --check and cargo clippy --all-targets -- -D warnings
- [ ] Manual: quit Cubby, replace cubby.db with garbage, relaunch; the log file that contains Cubby starting... also has the quarantine / empty-history or restore line

## What a user who hits this now sees

A corrupt cubby.db still fail-opens (quarantine + restore or empty history). After this change, the on-disk log for that launch contains the STORAGE: quarantine/restore/empty-history line, flushed through startup_log before Cubby starting.... Migrations already used that buffer; this is the same path.

No toast. Encrypted-storage / hash-uniqueness migrations also do not toast — they only flush startup_log. Shortcut conflicts toast via a different helper. I did not invent a toast for this.

## Quality gate

Formatter: rustfmt --edition 2021 --check on the four touched Rust files: ok.

Linter / full crate tests: not run here. Required CI is Windows cargo test --all-targets + cargo clippy --all-targets -- -D warnings. This box cannot compile the crate (glib-2.0 / clipboard-win). No Linux harness invented as Windows CI.

Standalone helper (allowed substitute): rustc --edition 2021 --test src-tauri/src/startup_recovery_log.rs — 5 passed.

Windows CI will also run the database.rs tests that call prepare_database_file / apply_database_health and assert the returned vec (those fail if the production path only log::s).

Frontend was not touched.

## Fail without the fix

Reverted only notices_for_corrupt to Vec::new() (pre-fix log:: and return nothing). 4 helper tests failed with empty vec; restored. Windows database.rs tests assert the same contract on prepare / apply / migrate return values.

## Pattern sweep

rg log:: in database.rs in the Database::new / pre-logger window:

- quarantine / restore / empty-history: Fixed. Returned into startup_log.
- migrate file-reference removal: Fixed. Same leftover the ticket named.
- Healthy-path refresh_rolling_backup failure: Fixed. Returned as a warn notice.
- Failed to close integrity-check connection: Left. Operational, not a history rewrite.
- Failed to close backup checkpoint connection: Left. Scheduler path has a logger.
- Could not stamp history backup time: Left. Copy is still a valid recovery point.
- Refreshed rolling history backup: Left. Success of a copy; scheduler logs after logger exists.
- Keeping existing history backup: Left. Safety skip, not a rewrite.

No other log:: inside Database::new itself.

## What this change makes more likely

startup_log can hold more lines on a bad-DB launch. The flush is the same log::log! loop already used for migrations; diagnostics are still sanitized. Returning notices does not change which files get quarantined or whether restore is best-effort. Database::new and migrate return types changed; Ok-binding sites were updated.

## Gaps

- Could not run cargo test --all-targets or clippy here. Windows CI is the real gate.
- No toast. Migrations do not toast either.
- No native message box (that path is only KeyNotForThisUser).
- Healthy-path backup success / keeping-existing-backup lines still discarded on the first pass. Listed above.
- Close-connection / stamp-time warns still discarded at startup. Listed above.
- Human D4 on docs/SOU-218-ACCEPTANCE.md is still Pending.
- src-tauri/target from the failed Linux compile was deleted. No audit ledger.

Not merged. Leave open / In Progress.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep startup quarantine and restore notices in the on-disk log
> - `Database::new` now returns a `(Database, Vec<(log::Level, String)>)` tuple so startup recovery notices (quarantine, restore-from-backup, empty-history fallback) are captured before the logger exists and flushed after it is installed.
> - `Database::migrate` similarly returns its notices instead of logging them directly, allowing the same deferred-flush pattern.
> - A new [`startup_recovery_log`](https://github.com/tsouth89/cubby-clipboard/pull/230/files#diff-ff349e30c11e0fc15042e66bf842ec3b8decdd2e8fec996d7327e7ebd31b0945) module defines structured `RecoveryNotice` and `RestoreOutcome` types to standardize recovery message construction.
> - [`lib.rs`](https://github.com/tsouth89/cubby-clipboard/pull/230/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c) collects notices from both `Database::new` and `migrate`, then flushes them to the log after the logger is initialized.
> - Behavioral Change: startup quarantine/restore lines now appear in the same on-disk log file as the startup banner rather than being silently discarded.
>
> #### 🖇️ Linked Issues
> Resolves [SBS-929](ticket:jira/SBS-929).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ea2763.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->