### PR TITLE
SBS-935: Recover interrupted settings.json replace instead of first-run 30-day retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - Search no longer ships full decrypted clip bodies on every keystroke; flyout and History search rows use the same preview-only contract as the list (SBS-912)
 
 ### Fixed
+- Recover an interrupted settings.json replace from the leftover temp instead of treating it as a first-run 30-day retention (SBS-935)
 - Record startup quarantine and rolling-backup restore in the on-disk log, instead of discarding those lines before the logger exists (SBS-929)
 - Skip-likely-secrets now scans the first 8 KiB of a large paste, so a 9 KiB log or PEM starting with a known token or `-----BEGIN` marker is skipped instead of stored (SBS-922)
 - A failed clip reload no longer looks like a healthy current list: same-filter refresh shows a retry banner, superseded loads are not treated as success, and folder / app / count reloads toast instead of staying silent (SBS-805)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,7 @@ pub mod perf_budget;
 mod search_index;
 mod secrets;
 mod settings_commands;
+mod settings_load;
 mod settings_manager;
 mod shortcuts;
 mod startup_recovery_log;

--- a/src-tauri/src/settings_load.rs
+++ b/src-tauri/src/settings_load.rs
@@ -34,14 +34,6 @@ pub fn resolve_settings_disk_source(canonical: &Path) -> SettingsDiskSource {
     }
 }
 
-/// Retention after a missing canonical file when a leftover temp parsed.
-///
-/// Unreadable temp uses 0 — the same safe default as parse-failure quarantine.
-/// This function is not used for a true first run (no temp).
-pub fn auto_delete_days_from_interrupted_tmp(parsed_tmp_days: Option<i64>) -> i64 {
-    parsed_tmp_days.unwrap_or(0)
-}
-
 /// First-run `AppSettings::default()` (30-day) must not be written over a
 /// leftover `settings.json.tmp`.
 pub fn may_persist_first_run_defaults(source: SettingsDiskSource) -> bool {
@@ -112,7 +104,7 @@ mod tests {
         );
 
         let days = parse_auto_delete_days(&fs::read_to_string(&tmp).unwrap()).unwrap();
-        assert_eq!(auto_delete_days_from_interrupted_tmp(Some(days)), 0);
+        assert_eq!(days, 0, "the leftover temp is the keep-forever choice");
 
         // Production persist for an un-seeded interrupted write: promote the
         // leftover temp. The old path wrote AppSettings::default() (30) onto
@@ -131,12 +123,6 @@ mod tests {
         let on_disk = parse_auto_delete_days(&fs::read_to_string(&canonical).unwrap()).unwrap();
         assert_eq!(on_disk, 0);
         let _ = fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn unreadable_interrupted_tmp_uses_safe_zero_retention() {
-        assert_eq!(auto_delete_days_from_interrupted_tmp(None), 0);
-        assert_ne!(auto_delete_days_from_interrupted_tmp(None), 30);
     }
 
     #[test]

--- a/src-tauri/src/settings_load.rs
+++ b/src-tauri/src/settings_load.rs
@@ -1,0 +1,179 @@
+//! Settings disk recovery for an interrupted `settings.json` replace (SBS-935).
+//!
+//! On FAT/exFAT, `MoveFileExW(REPLACE_EXISTING)` is delete-then-rename. A crash
+//! after the destination is gone leaves `settings.json.tmp` holding the only
+//! copy of the new preferences. That is not a first run: treating it as
+//! `AppSettings::default()` would adopt 30-day retention and then overwrite
+//! the leftover temp.
+//!
+//! This file has no crate dependencies so `rustc --test` can pin the contract
+//! on a Linux box that cannot compile the Windows crate.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Same sibling name `SettingsManager::save` writes before replace.
+pub fn settings_tmp_path(canonical: &Path) -> PathBuf {
+    canonical.with_extension("json.tmp")
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsDiskSource {
+    Canonical,
+    InterruptedTmp,
+    Missing,
+}
+
+pub fn resolve_settings_disk_source(canonical: &Path) -> SettingsDiskSource {
+    if canonical.exists() {
+        SettingsDiskSource::Canonical
+    } else if settings_tmp_path(canonical).exists() {
+        SettingsDiskSource::InterruptedTmp
+    } else {
+        SettingsDiskSource::Missing
+    }
+}
+
+/// Retention after a missing canonical file when a leftover temp parsed.
+///
+/// Unreadable temp uses 0 — the same safe default as parse-failure quarantine.
+/// This function is not used for a true first run (no temp).
+pub fn auto_delete_days_from_interrupted_tmp(parsed_tmp_days: Option<i64>) -> i64 {
+    parsed_tmp_days.unwrap_or(0)
+}
+
+/// First-run `AppSettings::default()` (30-day) must not be written over a
+/// leftover `settings.json.tmp`.
+pub fn may_persist_first_run_defaults(source: SettingsDiskSource) -> bool {
+    !matches!(source, SettingsDiskSource::InterruptedTmp)
+}
+
+/// Promote the leftover temp into `settings.json` so the interrupted replace
+/// completes without rewriting the recovered preferences as defaults.
+pub fn promote_interrupted_tmp(canonical: &Path) -> Result<(), String> {
+    let tmp = settings_tmp_path(canonical);
+    if canonical.exists() {
+        return Ok(());
+    }
+    if !tmp.exists() {
+        return Err("interrupted settings temp is gone".to_string());
+    }
+    fs::rename(&tmp, canonical).map_err(|e| e.to_string())
+}
+
+/// On exFAT/FAT, replace is delete-then-rename. If dest is gone, put the temp
+/// in place instead of deleting the only copy (same idea as `backup.rs`).
+pub fn recover_dest_gone_replace(tmp: &Path, dest: &Path) -> bool {
+    !dest.exists() && tmp.exists() && fs::rename(tmp, dest).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    fn test_dir() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "cubby-sbs-935-{}-{}",
+            std::process::id(),
+            TEST_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn parse_auto_delete_days(json: &str) -> Option<i64> {
+        let after = json.split_once("\"auto_delete_days\"")?.1.trim_start();
+        let after = after.strip_prefix(':')?.trim_start();
+        let end = after
+            .find(|c: char| c != '-' && !c.is_ascii_digit())
+            .unwrap_or(after.len());
+        after[..end].parse().ok()
+    }
+
+    /// SBS-935: leftover `settings.json.tmp` with keep-forever must load as
+    /// retention 0, and a first-run defaults save must not destroy that temp.
+    #[test]
+    fn interrupted_replace_recovers_tmp_retention_and_does_not_save_defaults() {
+        let dir = test_dir();
+        let canonical = dir.join("settings.json");
+        let tmp = settings_tmp_path(&canonical);
+        fs::write(&tmp, "{\n  \"auto_delete_days\": 0\n}\n").unwrap();
+        assert!(!canonical.exists());
+
+        let source = resolve_settings_disk_source(&canonical);
+        assert_eq!(source, SettingsDiskSource::InterruptedTmp);
+        assert!(
+            !may_persist_first_run_defaults(source),
+            "recovered-from-missing must not persist AppSettings::default() over the leftover temp"
+        );
+
+        let days = parse_auto_delete_days(&fs::read_to_string(&tmp).unwrap()).unwrap();
+        assert_eq!(auto_delete_days_from_interrupted_tmp(Some(days)), 0);
+
+        // Production persist for an un-seeded interrupted write: promote the
+        // leftover temp. The old path wrote AppSettings::default() (30) onto
+        // the same tmp name, then replaced, wiping keep-forever.
+        if may_persist_first_run_defaults(source) {
+            fs::write(&tmp, "{\n  \"auto_delete_days\": 30\n}\n").unwrap();
+        } else {
+            promote_interrupted_tmp(&canonical).unwrap();
+        }
+
+        assert!(canonical.exists(), "interrupted write should be completed");
+        assert!(
+            !tmp.exists(),
+            "promoted temp should no longer sit beside dest"
+        );
+        let on_disk = parse_auto_delete_days(&fs::read_to_string(&canonical).unwrap()).unwrap();
+        assert_eq!(on_disk, 0);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unreadable_interrupted_tmp_uses_safe_zero_retention() {
+        assert_eq!(auto_delete_days_from_interrupted_tmp(None), 0);
+        assert_ne!(auto_delete_days_from_interrupted_tmp(None), 30);
+    }
+
+    #[test]
+    fn true_first_run_may_persist_product_defaults() {
+        let dir = test_dir();
+        let canonical = dir.join("settings.json");
+        let source = resolve_settings_disk_source(&canonical);
+        assert_eq!(source, SettingsDiskSource::Missing);
+        assert!(may_persist_first_run_defaults(source));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dest_gone_rename_puts_temp_in_place() {
+        let dir = test_dir();
+        let dest = dir.join("settings.json");
+        let tmp = settings_tmp_path(&dest);
+        fs::write(&tmp, "{\n  \"auto_delete_days\": 0\n}\n").unwrap();
+        assert!(recover_dest_gone_replace(&tmp, &dest));
+        assert!(dest.exists());
+        assert!(!tmp.exists());
+        let on_disk = parse_auto_delete_days(&fs::read_to_string(&dest).unwrap()).unwrap();
+        assert_eq!(on_disk, 0);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dest_gone_rename_does_not_touch_an_existing_destination() {
+        let dir = test_dir();
+        let dest = dir.join("settings.json");
+        let tmp = settings_tmp_path(&dest);
+        fs::write(&dest, "{\n  \"auto_delete_days\": 365\n}\n").unwrap();
+        fs::write(&tmp, "{\n  \"auto_delete_days\": 0\n}\n").unwrap();
+        assert!(!recover_dest_gone_replace(&tmp, &dest));
+        assert!(tmp.exists());
+        let on_disk = parse_auto_delete_days(&fs::read_to_string(&dest).unwrap()).unwrap();
+        assert_eq!(on_disk, 365);
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/settings_manager.rs
+++ b/src-tauri/src/settings_manager.rs
@@ -18,11 +18,24 @@ pub struct SettingsManager {
 
 enum DiskRead {
     Settings {
-        settings: AppSettings,
+        // Boxed: AppSettings is ~226 bytes and `Missing` carries nothing, so
+        // an inline field makes every DiskRead that size.
+        settings: Box<AppSettings>,
         recovered_unreadable: bool,
         recovered_interrupted: bool,
     },
     Missing,
+}
+
+/// How the loaded settings reached memory, as far as the disk is concerned.
+/// Drives the one write `SettingsManager::new` is allowed to make.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SettingsOrigin {
+    /// The file that should have held preferences could not be parsed and has
+    /// been quarantined, so nothing on that path can still be lost.
+    recovered_unreadable: bool,
+    /// The preferences came from a leftover `settings.json.tmp`.
+    recovered_interrupted: bool,
 }
 
 impl SettingsManager {
@@ -36,64 +49,139 @@ impl SettingsManager {
         // resolve_settings_load_path. In release that helper copies a legacy
         // AppData file onto `path` when `path` is missing, which would hide an
         // interrupted FAT/exFAT replace sitting in settings.json.tmp (SBS-935).
-        let (mut settings, recovered_unreadable, recovered_interrupted, missing) =
-            match Self::read_settings_from_disk(&path) {
-                DiskRead::Settings {
-                    settings,
+        let (mut settings, origin) = match Self::read_settings_from_disk(&path) {
+            DiskRead::Settings {
+                settings,
+                recovered_unreadable,
+                recovered_interrupted,
+            } => {
+                let origin = SettingsOrigin {
                     recovered_unreadable,
                     recovered_interrupted,
-                } => (settings, recovered_unreadable, recovered_interrupted, false),
-                DiskRead::Missing => {
-                    let load_path = Self::resolve_settings_load_path(app, &base, &path);
-                    if load_path.exists() {
-                        match Self::parse_settings_file(&load_path) {
-                            Ok(settings) => (settings, false, false, false),
-                            Err(error) => (
-                                Self::recover_from_unreadable_settings(&load_path, &error),
-                                true,
-                                false,
-                                false,
-                            ),
-                        }
-                    } else {
-                        (Self::migrate_from_sqlite(db).await, false, false, true)
+                };
+                // The unreadable file has already been quarantined, so looking
+                // further cannot lose anything. A legacy AppData file that
+                // still parses holds the user's real preferences; safe defaults
+                // turn retention off for someone who never asked for that.
+                let settings = if recovered_unreadable {
+                    Self::settings_from_load_path(&Self::resolve_settings_load_path(
+                        app, &base, &path,
+                    ))
+                    .unwrap_or(*settings)
+                } else {
+                    *settings
+                };
+                (settings, origin)
+            }
+            DiskRead::Missing => {
+                let load_path = Self::resolve_settings_load_path(app, &base, &path);
+                if load_path.exists() {
+                    match Self::parse_settings_file(&load_path) {
+                        Ok(settings) => (
+                            settings,
+                            SettingsOrigin {
+                                recovered_unreadable: false,
+                                recovered_interrupted: false,
+                            },
+                        ),
+                        Err(error) => (
+                            Self::recover_from_unreadable_settings(&load_path, &error),
+                            SettingsOrigin {
+                                recovered_unreadable: true,
+                                recovered_interrupted: false,
+                            },
+                        ),
                     }
+                } else {
+                    (
+                        Self::migrate_from_sqlite(db).await,
+                        SettingsOrigin {
+                            recovered_unreadable: false,
+                            recovered_interrupted: false,
+                        },
+                    )
                 }
-            };
+            }
+        };
 
         let seeded_defaults = Self::seed_default_sensitive_apps(&mut settings);
-
-        // Ensure we save it once immediately if migrating or seeding, so the
-        // file exists and the one-time password-manager ignore list sticks.
-        // An interrupted replace must persist the recovered object (or promote
-        // the leftover temp), never AppSettings::default() 30-day retention.
         let manager = Self {
             file_path: path,
             settings: RwLock::new(settings.clone()),
         };
-        let persist_source = if recovered_interrupted {
-            SettingsDiskSource::InterruptedTmp
-        } else if missing {
-            SettingsDiskSource::Missing
-        } else {
-            SettingsDiskSource::Canonical
-        };
-        if recovered_interrupted && !seeded_defaults && !recovered_unreadable {
-            if let Err(error) = promote_interrupted_tmp(&manager.file_path) {
-                log::error!("SETTINGS: Failed to promote interrupted settings write: {error}");
-                if let Err(error) = manager.save(settings) {
-                    log::error!("SETTINGS: Failed to persist recovered settings: {error}");
-                }
+        manager.persist_after_load(settings, origin, seeded_defaults);
+        manager
+    }
+
+    /// The disk half of [`SettingsManager::new`].
+    ///
+    /// Split out so a test can drive it against a real [`SettingsManager::save`]
+    /// without a Tauri `AppHandle`. Reverting either rule below has to fail
+    /// `interrupted_tmp_is_promoted_before_any_write` or
+    /// `legacy_in_place_still_writes_the_canonical_file`.
+    fn persist_after_load(
+        &self,
+        settings: AppSettings,
+        origin: SettingsOrigin,
+        seeded_defaults: bool,
+    ) {
+        self.persist_after_load_using(settings, origin, seeded_defaults, promote_interrupted_tmp)
+    }
+
+    /// `promote` is injected so a test can fail the rename the way a sharing
+    /// violation or a read-only parent does. That failure is the one path where
+    /// the leftover temp is still the only copy of the preferences.
+    fn persist_after_load_using(
+        &self,
+        settings: AppSettings,
+        origin: SettingsOrigin,
+        seeded_defaults: bool,
+        promote: impl Fn(&Path) -> Result<(), String>,
+    ) {
+        // An interrupted replace leaves settings.json.tmp holding the only copy
+        // of the preferences, and `save` writes that same temp name. Rename it
+        // into place before anything else writes, so a disk-full or a crash
+        // during a seed rewrite cannot truncate the one file that still has the
+        // user's settings. If the rename fails, leave those bytes alone and
+        // write nothing at all (SBS-935).
+        if origin.recovered_interrupted && !origin.recovered_unreadable {
+            if let Err(error) = promote(&self.file_path) {
+                log::error!(
+                    "SETTINGS: Failed to promote interrupted settings write: {error}; leaving {} untouched",
+                    settings_tmp_path(&self.file_path).display()
+                );
+                return;
             }
-        } else if seeded_defaults
-            || recovered_unreadable
-            || (missing && may_persist_first_run_defaults(persist_source))
-        {
-            if let Err(error) = manager.save(settings) {
+        }
+
+        // A missing canonical file is a true first run, a SQLite migration, or
+        // a legacy AppData file that had to be loaded in place because the copy
+        // failed. All three have to write settings.json, or the next launch
+        // reads the legacy path again and the canonical one never appears.
+        let canonical_missing = !self.file_path.exists();
+        let source = resolve_settings_disk_source(&self.file_path);
+        if seeded_defaults || (canonical_missing && may_persist_first_run_defaults(source)) {
+            if let Err(error) = self.save(settings) {
                 log::error!("SETTINGS: Failed to persist settings: {error}");
             }
         }
-        manager
+    }
+
+    /// A settings file that still parses, for use only after the file that
+    /// should have held the preferences was quarantined.
+    ///
+    /// Takes the resolved path rather than the `AppHandle` so this half is
+    /// testable: `resolve_settings_load_path`'s legacy AppData branch is
+    /// `cfg(not(debug_assertions))` and does not exist in a test build.
+    ///
+    /// Deliberately does not fall through to the SQLite migration: a key that
+    /// is absent there comes back as `AppSettings::default()` 30-day retention,
+    /// which is the mass-delete the safe defaults exist to avoid.
+    fn settings_from_load_path(load_path: &Path) -> Option<AppSettings> {
+        if !load_path.exists() {
+            return None;
+        }
+        Self::parse_settings_file(load_path).ok()
     }
 
     fn parse_settings_file(path: &Path) -> Result<AppSettings, String> {
@@ -108,12 +196,12 @@ impl SettingsManager {
         match resolve_settings_disk_source(canonical) {
             SettingsDiskSource::Canonical => match Self::parse_settings_file(canonical) {
                 Ok(settings) => DiskRead::Settings {
-                    settings,
+                    settings: Box::new(settings),
                     recovered_unreadable: false,
                     recovered_interrupted: false,
                 },
                 Err(error) => DiskRead::Settings {
-                    settings: Self::recover_from_unreadable_settings(canonical, &error),
+                    settings: Box::new(Self::recover_from_unreadable_settings(canonical, &error)),
                     recovered_unreadable: true,
                     recovered_interrupted: false,
                 },
@@ -127,13 +215,13 @@ impl SettingsManager {
                             tmp.display()
                         );
                         DiskRead::Settings {
-                            settings,
+                            settings: Box::new(settings),
                             recovered_unreadable: false,
                             recovered_interrupted: true,
                         }
                     }
                     Err(error) => DiskRead::Settings {
-                        settings: Self::recover_from_unreadable_settings(&tmp, &error),
+                        settings: Box::new(Self::recover_from_unreadable_settings(&tmp, &error)),
                         recovered_unreadable: true,
                         recovered_interrupted: true,
                     },
@@ -483,6 +571,206 @@ mod tests {
             serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(on_disk.auto_delete_days, 0);
         assert!(on_disk.has_completed_onboarding);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    fn manager_at(path: &std::path::Path, settings: AppSettings) -> SettingsManager {
+        SettingsManager {
+            file_path: path.to_path_buf(),
+            settings: RwLock::new(settings),
+        }
+    }
+
+    /// SBS-935: the leftover temp is the only copy of the preferences, and
+    /// `save` writes that same temp name. `persist_after_load` must rename it
+    /// into place first, and must write nothing at all when that rename fails —
+    /// otherwise a seed rewrite truncates the one file that still has the
+    /// user's settings.
+    #[test]
+    fn interrupted_tmp_is_promoted_before_any_write() {
+        let dir =
+            std::env::temp_dir().join(format!("cubby-settings-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+        let tmp = settings_tmp_path(&path);
+        // seeded = false is the case that used to reach save(): an older temp
+        // written before default_sensitive_apps_seeded existed defaults to
+        // false, so seeding mutates the object and asks for a persist.
+        let recovered = AppSettings {
+            auto_delete_days: 0,
+            default_sensitive_apps_seeded: false,
+            ..AppSettings::default()
+        };
+        let recovered_bytes = serde_json::to_string_pretty(&recovered).unwrap();
+        fs::write(&tmp, &recovered_bytes).unwrap();
+
+        let mut loaded = recovered.clone();
+        let seeded = SettingsManager::seed_default_sensitive_apps(&mut loaded);
+        assert!(seeded, "an older temp must still ask for the one-time seed");
+
+        let manager = manager_at(&path, loaded.clone());
+        manager.persist_after_load(
+            loaded,
+            SettingsOrigin {
+                recovered_unreadable: false,
+                recovered_interrupted: true,
+            },
+            seeded,
+        );
+
+        assert!(path.exists(), "the interrupted replace must be completed");
+        let on_disk: AppSettings =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            on_disk.auto_delete_days, 0,
+            "keep-forever must survive the seed rewrite"
+        );
+        assert!(on_disk.default_sensitive_apps_seeded);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// The same load with a promote that cannot succeed. `settings.json.tmp`
+    /// is the only copy, so a failed promote must leave those bytes exactly as
+    /// they were rather than truncating them with `fs::write`.
+    #[test]
+    fn a_failed_promote_leaves_the_only_copy_untouched() {
+        let dir =
+            std::env::temp_dir().join(format!("cubby-settings-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+        let tmp = settings_tmp_path(&path);
+        let recovered = AppSettings {
+            auto_delete_days: 0,
+            default_sensitive_apps_seeded: false,
+            ..AppSettings::default()
+        };
+        let recovered_bytes = serde_json::to_string_pretty(&recovered).unwrap();
+        fs::write(&tmp, &recovered_bytes).unwrap();
+
+        let mut loaded = recovered.clone();
+        let seeded = SettingsManager::seed_default_sensitive_apps(&mut loaded);
+        let manager = manager_at(&path, loaded.clone());
+        manager.persist_after_load_using(
+            loaded,
+            SettingsOrigin {
+                recovered_unreadable: false,
+                recovered_interrupted: true,
+            },
+            seeded,
+            |_| Err("sharing violation".to_string()),
+        );
+
+        assert_eq!(
+            fs::read_to_string(&tmp).unwrap(),
+            recovered_bytes,
+            "a failed promote must not rewrite the only copy of the preferences"
+        );
+        assert!(
+            !path.exists(),
+            "nothing may be written while the temp still holds the only copy"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// SBS-935 regression guard: the persist trigger used to be
+    /// `!file_path.exists()`. A legacy AppData file loaded in place (the copy
+    /// onto the canonical path failed) parses fine and is already seeded, so a
+    /// trigger that only looks at those two flags never writes settings.json
+    /// and every launch reads the legacy path again.
+    #[test]
+    fn legacy_in_place_still_writes_the_canonical_file() {
+        let dir =
+            std::env::temp_dir().join(format!("cubby-settings-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+        let loaded = AppSettings {
+            auto_delete_days: 365,
+            default_sensitive_apps_seeded: true,
+            ..AppSettings::default()
+        };
+        let seeded = false;
+
+        let manager = manager_at(&path, loaded.clone());
+        manager.persist_after_load(
+            loaded,
+            SettingsOrigin {
+                recovered_unreadable: false,
+                recovered_interrupted: false,
+            },
+            seeded,
+        );
+
+        assert!(path.exists(), "a missing canonical file must be written");
+        let on_disk: AppSettings =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(on_disk.auto_delete_days, 365);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// A canonical file that parsed and needs no seed must not be rewritten.
+    #[test]
+    fn a_healthy_canonical_load_writes_nothing() {
+        let dir =
+            std::env::temp_dir().join(format!("cubby-settings-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+        let on_disk_bytes = "{\n  \"note\": \"written by hand\"\n}\n";
+        fs::write(&path, on_disk_bytes).unwrap();
+
+        let loaded = AppSettings {
+            default_sensitive_apps_seeded: true,
+            ..AppSettings::default()
+        };
+        let manager = manager_at(&path, loaded.clone());
+        manager.persist_after_load(
+            loaded,
+            SettingsOrigin {
+                recovered_unreadable: false,
+                recovered_interrupted: false,
+            },
+            false,
+        );
+
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            on_disk_bytes,
+            "a healthy load must leave settings.json exactly as it found it"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// SBS-935: safe defaults turn retention off, which is right when nothing
+    /// else is known and wrong when a file that still parses is sitting there.
+    /// After the unreadable file has been quarantined, that file wins.
+    #[test]
+    fn a_parseable_file_beats_safe_defaults_after_a_quarantine() {
+        let dir =
+            std::env::temp_dir().join(format!("cubby-settings-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let legacy = dir.join("legacy-settings.json");
+        let real = AppSettings {
+            auto_delete_days: 365,
+            default_sensitive_apps_seeded: true,
+            ..AppSettings::default()
+        };
+        fs::write(&legacy, serde_json::to_string_pretty(&real).unwrap()).unwrap();
+
+        let found = SettingsManager::settings_from_load_path(&legacy)
+            .expect("a legacy file that parses must be used");
+        assert_eq!(found.auto_delete_days, 365);
+        assert_ne!(
+            found.auto_delete_days,
+            SettingsManager::safe_default_settings().auto_delete_days,
+            "the user's real retention must win over safe-zero"
+        );
+
+        // Absent and unreadable both fall back to the safe defaults the caller
+        // already holds.
+        assert!(SettingsManager::settings_from_load_path(&dir.join("nothing.json")).is_none());
+        let broken = dir.join("broken.json");
+        fs::write(&broken, "{\"theme\": \"dark\", TRUNCATED").unwrap();
+        assert!(SettingsManager::settings_from_load_path(&broken).is_none());
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/settings_manager.rs
+++ b/src-tauri/src/settings_manager.rs
@@ -1,5 +1,9 @@
 use crate::database::Database;
 use crate::models::AppSettings;
+use crate::settings_load::{
+    may_persist_first_run_defaults, promote_interrupted_tmp, recover_dest_gone_replace,
+    resolve_settings_disk_source, settings_tmp_path, SettingsDiskSource,
+};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
@@ -12,46 +16,131 @@ pub struct SettingsManager {
     settings: RwLock<AppSettings>,
 }
 
+enum DiskRead {
+    Settings {
+        settings: AppSettings,
+        recovered_unreadable: bool,
+        recovered_interrupted: bool,
+    },
+    Missing,
+}
+
 impl SettingsManager {
     pub async fn new(app: &AppHandle, db: &Database) -> Self {
         // Keep settings on the same data root as the database (including the
         // debug `/dev` isolation from SOU-227 and portable mode).
         let base = crate::get_data_dir();
         let path = base.join("settings.json");
-        let load_path = Self::resolve_settings_load_path(app, &base, &path);
 
-        let (settings, recovered_unreadable) = if load_path.exists() {
-            match fs::read_to_string(&load_path)
-                .map_err(|e| e.to_string())
-                .and_then(|content| serde_json::from_str(&content).map_err(|e| e.to_string()))
-            {
-                Ok(settings) => (settings, false),
-                Err(error) => (
-                    Self::recover_from_unreadable_settings(&load_path, &error),
-                    true,
-                ),
-            }
-        } else {
-            // One-shot import from the old SQLite settings tables. After the
-            // first successful JSON write, settings.json is the sole source.
-            (Self::migrate_from_sqlite(db).await, false)
-        };
+        // Check the canonical path (and its leftover temp) before
+        // resolve_settings_load_path. In release that helper copies a legacy
+        // AppData file onto `path` when `path` is missing, which would hide an
+        // interrupted FAT/exFAT replace sitting in settings.json.tmp (SBS-935).
+        let (mut settings, recovered_unreadable, recovered_interrupted, missing) =
+            match Self::read_settings_from_disk(&path) {
+                DiskRead::Settings {
+                    settings,
+                    recovered_unreadable,
+                    recovered_interrupted,
+                } => (settings, recovered_unreadable, recovered_interrupted, false),
+                DiskRead::Missing => {
+                    let load_path = Self::resolve_settings_load_path(app, &base, &path);
+                    if load_path.exists() {
+                        match Self::parse_settings_file(&load_path) {
+                            Ok(settings) => (settings, false, false, false),
+                            Err(error) => (
+                                Self::recover_from_unreadable_settings(&load_path, &error),
+                                true,
+                                false,
+                                false,
+                            ),
+                        }
+                    } else {
+                        (Self::migrate_from_sqlite(db).await, false, false, true)
+                    }
+                }
+            };
 
-        let mut settings = settings;
         let seeded_defaults = Self::seed_default_sensitive_apps(&mut settings);
 
         // Ensure we save it once immediately if migrating or seeding, so the
         // file exists and the one-time password-manager ignore list sticks.
+        // An interrupted replace must persist the recovered object (or promote
+        // the leftover temp), never AppSettings::default() 30-day retention.
         let manager = Self {
             file_path: path,
             settings: RwLock::new(settings.clone()),
         };
-        if seeded_defaults || recovered_unreadable || !manager.file_path.exists() {
+        let persist_source = if recovered_interrupted {
+            SettingsDiskSource::InterruptedTmp
+        } else if missing {
+            SettingsDiskSource::Missing
+        } else {
+            SettingsDiskSource::Canonical
+        };
+        if recovered_interrupted && !seeded_defaults && !recovered_unreadable {
+            if let Err(error) = promote_interrupted_tmp(&manager.file_path) {
+                log::error!("SETTINGS: Failed to promote interrupted settings write: {error}");
+                if let Err(error) = manager.save(settings) {
+                    log::error!("SETTINGS: Failed to persist recovered settings: {error}");
+                }
+            }
+        } else if seeded_defaults
+            || recovered_unreadable
+            || (missing && may_persist_first_run_defaults(persist_source))
+        {
             if let Err(error) = manager.save(settings) {
                 log::error!("SETTINGS: Failed to persist settings: {error}");
             }
         }
         manager
+    }
+
+    fn parse_settings_file(path: &Path) -> Result<AppSettings, String> {
+        fs::read_to_string(path)
+            .map_err(|e| e.to_string())
+            .and_then(|content| serde_json::from_str(&content).map_err(|e| e.to_string()))
+    }
+
+    /// Read the canonical settings file, or a leftover sibling temp from an
+    /// interrupted replace. Does not consult legacy AppData or SQLite.
+    fn read_settings_from_disk(canonical: &Path) -> DiskRead {
+        match resolve_settings_disk_source(canonical) {
+            SettingsDiskSource::Canonical => match Self::parse_settings_file(canonical) {
+                Ok(settings) => DiskRead::Settings {
+                    settings,
+                    recovered_unreadable: false,
+                    recovered_interrupted: false,
+                },
+                Err(error) => DiskRead::Settings {
+                    settings: Self::recover_from_unreadable_settings(canonical, &error),
+                    recovered_unreadable: true,
+                    recovered_interrupted: false,
+                },
+            },
+            SettingsDiskSource::InterruptedTmp => {
+                let tmp = settings_tmp_path(canonical);
+                match Self::parse_settings_file(&tmp) {
+                    Ok(settings) => {
+                        log::warn!(
+                            "SETTINGS: settings.json is missing; recovered interrupted write from {} (SBS-935)",
+                            tmp.display()
+                        );
+                        DiskRead::Settings {
+                            settings,
+                            recovered_unreadable: false,
+                            recovered_interrupted: true,
+                        }
+                    }
+                    Err(error) => DiskRead::Settings {
+                        settings: Self::recover_from_unreadable_settings(&tmp, &error),
+                        recovered_unreadable: true,
+                        recovered_interrupted: true,
+                    },
+                }
+            }
+            SettingsDiskSource::Missing => DiskRead::Missing,
+        }
     }
 
     /// Prefer the canonical settings path. In release builds, migrate once from
@@ -206,10 +295,29 @@ impl SettingsManager {
         // a truncated settings.json (a truncated file used to silently reset
         // every preference on the next launch).
         let mut lock = self.settings.write().unwrap();
-        let tmp_path = self.file_path.with_extension("json.tmp");
+        let tmp_path = settings_tmp_path(&self.file_path);
         fs::write(&tmp_path, json).map_err(|e| e.to_string())?;
         if let Err(error) = replace_file_atomically(&tmp_path, &self.file_path) {
-            let _ = fs::remove_file(&tmp_path);
+            // On exFAT/FAT, replace is delete-the-target-then-rename. A failure
+            // after the destination entry is gone leaves the temp holding the
+            // only copy of the preferences, so deleting it here would destroy
+            // both the old file and the new one. Try to put it in place instead
+            // (same dest-gone fallback as backup.rs; SBS-935).
+            if recover_dest_gone_replace(&tmp_path, &self.file_path) {
+                log::warn!(
+                    "SETTINGS: replacing settings.json failed ({error}); the new file was renamed into place instead"
+                );
+                *lock = new_settings;
+                return Ok(());
+            }
+            if self.file_path.exists() {
+                let _ = fs::remove_file(&tmp_path);
+            } else {
+                log::error!(
+                    "SETTINGS: replacing settings.json failed ({error}) and the destination is gone; leaving {}",
+                    tmp_path.display()
+                );
+            }
             return Err(error);
         }
         *lock = new_settings;
@@ -317,6 +425,89 @@ mod tests {
             serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(on_disk.auto_delete_days, 365);
         assert!(!path.with_extension("json.tmp").exists());
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// SBS-935: an interrupted replace leaves settings.json.tmp and no
+    /// settings.json. Load must recover keep-forever (0), not first-run 30,
+    /// and must not persist AppSettings::default() over the leftover temp.
+    #[test]
+    fn interrupted_tmp_recovers_retention_and_is_not_overwritten_by_defaults() {
+        let dir =
+            std::env::temp_dir().join(format!("cubby-settings-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+        let tmp = settings_tmp_path(&path);
+        let recovered = AppSettings {
+            auto_delete_days: 0,
+            default_sensitive_apps_seeded: true,
+            has_completed_onboarding: true,
+            ..AppSettings::default()
+        };
+        fs::write(&tmp, serde_json::to_string_pretty(&recovered).unwrap()).unwrap();
+        assert!(!path.exists());
+
+        let source = resolve_settings_disk_source(&path);
+        assert_eq!(source, SettingsDiskSource::InterruptedTmp);
+        assert!(!may_persist_first_run_defaults(source));
+
+        match SettingsManager::read_settings_from_disk(&path) {
+            DiskRead::Settings {
+                settings,
+                recovered_unreadable,
+                recovered_interrupted,
+            } => {
+                assert!(!recovered_unreadable);
+                assert!(recovered_interrupted);
+                assert_eq!(settings.auto_delete_days, 0);
+                assert!(settings.has_completed_onboarding);
+                assert_ne!(
+                    settings.auto_delete_days,
+                    AppSettings::default().auto_delete_days
+                );
+
+                // Seeded flag is already true, so new() promotes the leftover
+                // temp rather than saving AppSettings::default() over it.
+                let mut loaded = settings;
+                let seeded = SettingsManager::seed_default_sensitive_apps(&mut loaded);
+                assert!(!seeded);
+                promote_interrupted_tmp(&path).unwrap();
+            }
+            DiskRead::Missing => panic!("leftover settings.json.tmp must not be a first-run miss"),
+        }
+
+        assert!(path.exists());
+        assert!(!tmp.exists());
+        let on_disk: AppSettings =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(on_disk.auto_delete_days, 0);
+        assert!(on_disk.has_completed_onboarding);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unreadable_interrupted_tmp_uses_safe_defaults_not_thirty_day() {
+        let dir =
+            std::env::temp_dir().join(format!("cubby-settings-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+        let tmp = settings_tmp_path(&path);
+        fs::write(&tmp, "{\"theme\": \"dark\", TRUNCATED").unwrap();
+
+        match SettingsManager::read_settings_from_disk(&path) {
+            DiskRead::Settings {
+                settings,
+                recovered_unreadable,
+                recovered_interrupted,
+            } => {
+                assert!(recovered_unreadable);
+                assert!(recovered_interrupted);
+                assert_eq!(settings.auto_delete_days, 0);
+            }
+            DiskRead::Missing => panic!("unreadable leftover temp is not a first-run miss"),
+        }
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/settings_manager.rs
+++ b/src-tauri/src/settings_manager.rs
@@ -398,11 +398,11 @@ impl SettingsManager {
                 *lock = new_settings;
                 return Ok(());
             }
-            if self.file_path.exists() {
+            if self.file_path.is_file() {
                 let _ = fs::remove_file(&tmp_path);
             } else {
                 log::error!(
-                    "SETTINGS: replacing settings.json failed ({error}) and the destination is gone; leaving {}",
+                    "SETTINGS: replacing settings.json failed ({error}) and the destination is not a file; leaving {}",
                     tmp_path.display()
                 );
             }
@@ -513,6 +513,35 @@ mod tests {
             serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(on_disk.auto_delete_days, 365);
         assert!(!path.with_extension("json.tmp").exists());
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// If settings.json is a directory, replace cannot succeed. Deleting the
+    /// temp would throw away the only copy of the new preferences.
+    #[test]
+    fn save_leaves_tmp_when_destination_is_a_directory() {
+        let dir =
+            std::env::temp_dir().join(format!("cubby-settings-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+        fs::create_dir_all(&path).unwrap();
+
+        let manager = SettingsManager {
+            file_path: path.clone(),
+            settings: RwLock::new(AppSettings::default()),
+        };
+        let updated = AppSettings {
+            auto_delete_days: 365,
+            ..AppSettings::default()
+        };
+        manager
+            .save(updated)
+            .expect_err("replacing a directory must fail");
+        assert!(
+            settings_tmp_path(&path).exists(),
+            "the new preferences must remain in the temp"
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
## Summary

- Recover leftover settings.json.tmp after an interrupted FAT/exFAT replace instead of first-run 30-day retention (SBS-935).
- save() gets the backup.rs dest-gone fallback so a failed replace does not delete the only copy.

## Test plan

- [x] rustc --edition 2021 --test src-tauri/src/settings_load.rs — 5 passed
- [x] Fail-without-fix: resolve_settings_disk_source ignored tmp — test failed left Missing right InterruptedTmp; restored
- [ ] Windows CI cargo test --all-targets and clippy (crate does not compile here: glib-2.0 missing)

Not merged. Leave open / In Progress.

## What a user who hits this now sees

A portable USB user who yanks mid-save no longer comes back to a first-run 30-day window. Startup loads leftover settings.json.tmp (keep-forever stays 0), promotes it to settings.json, and startup retention runs with that recovered value.

## Quality gate

Formatter: rustfmt --edition 2021 --check on settings_load.rs, settings_manager.rs, lib.rs: ok.
Required CI is Windows cargo test --all-targets + clippy -D warnings. This box failed cargo test at glib-sys. No Linux harness invented as Windows CI. src-tauri/target deleted.
Standalone helper: rustc --edition 2021 --test src-tauri/src/settings_load.rs — 5 passed.

## Fail without the fix

Reverted only resolve_settings_disk_source to Missing when canonical is gone. interrupted_replace_recovers_tmp_retention_and_does_not_save_defaults failed: left Missing, right InterruptedTmp. Restored.

## Pattern sweep

settings_manager.rs: fixed (dest-gone + tmp load).
backup.rs persist_backup_file: already has dest-gone. Left.
image_persist.rs: same MoveFileExW, no dest-gone. Left — missing image is not first-run 30-day retention. Pass 6 already looked.
database.rs rolling backup: dest-gone loses cubby.db.bak only; live cubby.db untouched. Left.
crypto.rs storage.key: SBS-908. Left.

## Gaps

Could not run cargo test --all-targets or clippy here.
Did not add dest-gone to image persist or rolling backup.
Did not change true first-run 30 when both files are absent.
Did not touch SBS-908 or the parse-failure quarantine path.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Recover interrupted settings.json replace from leftover temp file instead of treating it as first-run
> - On startup, `SettingsManager` now detects a leftover `settings.json.tmp` when `settings.json` is missing and loads from it, avoiding a spurious first-run 30-day retention default.
> - Adds [`settings_load.rs`](https://github.com/tsouth89/cubby-clipboard/pull/231/files#diff-208a2c2fe40666cd2616f2700d4f952813643d5e5214c181ce7c842173b320d8) with helpers to resolve the correct disk source (`Canonical`, `InterruptedTmp`, or `Missing`), promote the temp into place, and recover from delete-then-rename filesystem failures.
> - `SettingsManager.save` now calls `recover_dest_gone_replace` on replace failure to move the temp into the destination, preventing data loss on filesystems where atomic replace is implemented as delete-then-rename.
> - If temp promotion fails (e.g. sharing violation), no writes occur so the temp is preserved as the only copy of settings on disk.
> - Behavioral Change: unreadable canonical or temp files are quarantined before legacy migration logic runs; legacy AppData/SQLite is only consulted when both canonical and temp are absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7da136c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->