### PR TITLE
SBS-776: Keep portable logs inside the portable data root

### DIFF
--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -356,6 +356,14 @@ for (const [variant, expectedKind] of [
   if (variant !== 'Webview' && arm.includes('TargetKind::Webview')) {
     throw new Error(`LogTarget::${variant} must not map to TargetKind::Webview`);
   }
+  if (variant === 'LogDir') {
+    if (!arm.includes('TargetKind::Folder')) {
+      throw new Error('LogTarget::LogDir must map portable runs to TargetKind::Folder');
+    }
+    if (!arm.includes('persistent_log_sink')) {
+      throw new Error('LogTarget::LogDir must choose Folder vs LogDir via persistent_log_sink');
+    }
+  }
 }
 
 const countWebviewKind = (source) => source.split('TargetKind::Webview').length - 1;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,20 +67,24 @@ fn to_plugin_log_target(target: log_targets::LogTarget) -> tauri_plugin_log::Tar
         log_targets::LogTarget::Webview => {
             tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Webview)
         }
-        // Where "on disk" is depends on the distribution: a portable run keeps
-        // its logs inside the folder the user carries, an installed run uses
-        // the OS log directory. Resolved here rather than in a helper so the
-        // SBS-837 release gate can still read `TargetKind::LogDir` in this arm
-        // and prove nothing swapped it for `Webview`.
-        log_targets::LogTarget::LogDir => {
-            tauri_plugin_log::Target::new(match portable_log_dir(portable_data_dir()) {
-                Some(path) => tauri_plugin_log::TargetKind::Folder {
-                    path,
-                    file_name: None,
-                },
-                None => tauri_plugin_log::TargetKind::LogDir { file_name: None },
-            })
-        }
+        // Folder vs LogDir is decided by `persistent_log_sink` so the rule is
+        // unit-tested without a Tauri builder. The arm still names both
+        // TargetKinds so the SBS-837 release gate can prove nothing swapped
+        // LogDir for Webview, and so a portable run cannot silently keep
+        // TargetKind::LogDir (SBS-776).
+        log_targets::LogTarget::LogDir => tauri_plugin_log::Target::new(
+            match log_targets::persistent_log_sink(portable_data_dir()) {
+                log_targets::PersistentLogSink::Folder(path) => {
+                    tauri_plugin_log::TargetKind::Folder {
+                        path,
+                        file_name: None,
+                    }
+                }
+                log_targets::PersistentLogSink::OsLogDir => {
+                    tauri_plugin_log::TargetKind::LogDir { file_name: None }
+                }
+            },
+        ),
     }
 }
 
@@ -913,27 +917,13 @@ fn self_update_supported_for(portable: bool) -> bool {
     !cfg!(feature = "app-store") && !portable
 }
 
-/// Where a portable build keeps its logs, given its data root.
-///
-/// Portable mode promises no AppData footprint, and `TargetKind::LogDir`
-/// resolves to `%LOCALAPPDATA%\<identifier>\logs` regardless of mode. That left
-/// a persistent record of the user's activity outside the folder they carry
-/// with them, which is the whole point of the portable build.
-///
-/// Takes the root as an argument rather than reading it, so the mapping is
-/// testable without an installed executable next to a `portable.txt`, and so
-/// `commands::excluded_log_dir` can ask where the logs would sit inside a data
-/// directory it already has in hand. That second caller is why the storage
-/// readout and this mapping cannot drift apart: logs land inside the history
-/// data directory in portable mode, and the size measurement must skip exactly
-/// the folder this function names — and only then.
-///
-/// The first caller is the `LogTarget::LogDir` arm of `to_plugin_log_target`,
-/// which decides between the portable folder and the OS log directory.
+/// Thin wrapper over `log_targets::portable_log_dir` for
+/// `commands::excluded_log_dir`. The plugin mapper calls
+/// `persistent_log_sink` itself; both share one match.
 pub(crate) fn portable_log_dir(
     portable_root: Option<std::path::PathBuf>,
 ) -> Option<std::path::PathBuf> {
-    portable_root.map(|root| root.join("logs"))
+    log_targets::portable_log_dir(portable_root)
 }
 
 /// Explain an unreadable storage key before exiting.
@@ -1406,29 +1396,7 @@ pub fn update_tray_icon(tray: &TrayIcon, theme: &tauri::Theme) {
 
 #[cfg(test)]
 mod portable_tests {
-    use super::{
-        portable_data_dir, portable_log_dir, self_update_supported, self_update_supported_for,
-    };
-    use std::path::PathBuf;
-
-    /// Portable logs belong beside the portable data, not in AppData. The build
-    /// promises no AppData footprint, and `TargetKind::LogDir` ignores that.
-    #[test]
-    fn portable_logs_live_inside_the_portable_root() {
-        let root = PathBuf::from(r"D:\USB\Cubby\data");
-        assert_eq!(
-            portable_log_dir(Some(root.clone())),
-            Some(root.join("logs"))
-        );
-    }
-
-    /// An installed build must keep using the OS log directory. `None` is what
-    /// tells the `LogTarget::LogDir` mapping to fall back to
-    /// `TargetKind::LogDir`.
-    #[test]
-    fn installed_logs_stay_with_the_os_log_directory() {
-        assert_eq!(portable_log_dir(None), None);
-    }
+    use super::{portable_data_dir, self_update_supported, self_update_supported_for};
 
     /// The wiring from the real environment into the rule. The test binary has
     /// no `portable.txt` beside it, so this pins the installed path end to end;

--- a/src-tauri/src/log_targets.rs
+++ b/src-tauri/src/log_targets.rs
@@ -10,6 +10,23 @@ pub(crate) enum LogTarget {
     LogDir,
 }
 
+/// Where a release `LogDir` target actually writes.
+///
+/// `tauri-plugin-log`'s `TargetKind::LogDir` always resolves to the Tauri
+/// AppData log path (`%LOCALAPPDATA%\<identifier>\logs` on Windows), even
+/// when the rest of the app is running from a portable folder. Portable mode
+/// promises no AppData footprint (SBS-776), so a known portable root maps to
+/// a folder inside that root instead.
+///
+/// `None` is the installed run. This function does not probe the executable;
+/// the caller passes the already-resolved portable data root (or `None`) so
+/// both arms are testable without a `portable.txt` beside the test binary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PersistentLogSink {
+    Folder(std::path::PathBuf),
+    OsLogDir,
+}
+
 /// Targets for a debug (`true`) or release (`false`) build.
 ///
 /// Debug keeps Stdout + Webview so `tauri dev` can show Rust logs in the
@@ -24,9 +41,35 @@ pub(crate) fn log_targets(debug_assertions: bool) -> &'static [LogTarget] {
     }
 }
 
+/// Choose the persistent-log sink for a known portable root, or installed.
+///
+/// SBS-776: a portable root must not select the OS / Tauri AppData log
+/// directory. An installed run (`None`) must keep using it.
+pub(crate) fn persistent_log_sink(portable_root: Option<std::path::PathBuf>) -> PersistentLogSink {
+    match portable_root {
+        Some(root) => PersistentLogSink::Folder(root.join("logs")),
+        None => PersistentLogSink::OsLogDir,
+    }
+}
+
+/// Where a portable build keeps its logs, given its data root.
+///
+/// `Some` only when the run is portable, so storage measurement can skip
+/// exactly this folder and only then. Installed runs return `None` and keep
+/// their logs under `%LOCALAPPDATA%`, outside the history data directory.
+pub(crate) fn portable_log_dir(
+    portable_root: Option<std::path::PathBuf>,
+) -> Option<std::path::PathBuf> {
+    match persistent_log_sink(portable_root) {
+        PersistentLogSink::Folder(path) => Some(path),
+        PersistentLogSink::OsLogDir => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{log_targets, LogTarget};
+    use super::{log_targets, persistent_log_sink, portable_log_dir, LogTarget, PersistentLogSink};
+    use std::path::{Path, PathBuf};
 
     #[test]
     fn production_targets_do_not_include_webview() {
@@ -55,5 +98,62 @@ mod tests {
             targets.contains(&LogTarget::Webview),
             "debug builds may keep Webview"
         );
+    }
+
+    /// Portable logs belong inside the portable data root, not AppData.
+    /// Selecting `OsLogDir` here is the SBS-776 failure: `TargetKind::LogDir`
+    /// then creates `%LOCALAPPDATA%\<identifier>\logs`.
+    #[test]
+    fn portable_root_selects_a_folder_inside_that_root() {
+        let root = PathBuf::from(r"D:\USB\Cubby\data");
+        match persistent_log_sink(Some(root.clone())) {
+            PersistentLogSink::Folder(path) => {
+                assert_eq!(path, root.join("logs"));
+                assert!(
+                    path.starts_with(&root),
+                    "portable logs must stay under the portable data root"
+                );
+            }
+            PersistentLogSink::OsLogDir => {
+                panic!("a portable root must not select the Tauri AppData log directory")
+            }
+        }
+    }
+
+    /// An installed build must keep using the OS log directory. `None` is what
+    /// tells the `LogTarget::LogDir` mapping to fall back to
+    /// `TargetKind::LogDir`.
+    #[test]
+    fn installed_run_keeps_the_os_log_directory() {
+        assert_eq!(persistent_log_sink(None), PersistentLogSink::OsLogDir);
+        assert_eq!(portable_log_dir(None), None);
+    }
+
+    /// Clean-profile smoke at the path-selection layer: a brand-new portable
+    /// data root must resolve under itself and must not look like Tauri
+    /// AppData (`%LOCALAPPDATA%\<identifier>\logs`).
+    #[test]
+    fn clean_portable_profile_does_not_select_appdata() {
+        let root = std::env::temp_dir()
+            .join("cubby-sbs-776-clean-profile")
+            .join("data");
+        let sink = persistent_log_sink(Some(root.clone()));
+        let PersistentLogSink::Folder(path) = sink else {
+            panic!("clean portable profile selected OsLogDir");
+        };
+        assert_eq!(path, root.join("logs"));
+        assert!(path.starts_with(&root));
+        assert!(
+            !looks_like_tauri_appdata_log_path(&path),
+            "portable sink looked like Tauri AppData: {}",
+            path.display()
+        );
+    }
+
+    fn looks_like_tauri_appdata_log_path(path: &Path) -> bool {
+        let rendered = path.to_string_lossy();
+        rendered.contains("AppData")
+            || rendered.contains("LOCALAPPDATA")
+            || rendered.contains("ai.southforge.cubbyclipboard")
     }
 }

--- a/src-tauri/src/log_targets.rs
+++ b/src-tauri/src/log_targets.rs
@@ -150,10 +150,13 @@ mod tests {
         );
     }
 
+    /// What `TargetKind::LogDir` actually produces is
+    /// `%LOCALAPPDATA%\<identifier>\logs`, so the identifier segment is the
+    /// marker. Do not widen this to the substring "AppData": on Windows
+    /// `std::env::temp_dir()` is `%LOCALAPPDATA%\Temp`, so a correct portable
+    /// mapping rooted in TEMP would fail this check.
     fn looks_like_tauri_appdata_log_path(path: &Path) -> bool {
-        let rendered = path.to_string_lossy();
-        rendered.contains("AppData")
-            || rendered.contains("LOCALAPPDATA")
-            || rendered.contains("ai.southforge.cubbyclipboard")
+        path.components()
+            .any(|component| component.as_os_str() == "ai.southforge.cubbyclipboard")
     }
 }


### PR DESCRIPTION
## Summary

- Portable release logs go to `<portable data root>/logs` via `TargetKind::Folder`, not Tauri `TargetKind::LogDir` (`%LOCALAPPDATA%\<identifier>\logs`) (SBS-776).
- `persistent_log_sink` is the path-selection rule; `to_plugin_log_target` maps `Folder` vs `LogDir` from it. Installed runs stay on the OS log directory.
- Release gate now requires the `LogDir` arm to name both `TargetKind::Folder` and `persistent_log_sink`.

## What a user who hits this now sees

A portable user who runs `Cubby Clipboard.exe` next to `portable.txt` gets the persistent log file under `data/logs` in the folder they carry. The installed build still writes to the Tauri AppData log directory.

## Test plan

- [x] `rustc --edition 2021 --test src-tauri/src/log_targets.rs` — 6 passed
- [x] Fail-without-fix: `persistent_log_sink` always returned `OsLogDir` — `portable_root_selects_a_folder_inside_that_root` and `clean_portable_profile_does_not_select_appdata` failed; restored
- [x] `node scripts/check-release.mjs` — `Cubby Clipboard v1.3.2 release metadata is consistent.`
- [x] `rustfmt --edition 2021 --check` on `log_targets.rs` and `lib.rs`
- [ ] Windows CI `cargo test --all-targets` and `clippy -D warnings` (crate does not compile here: glib-2.0 missing)

Not merged. Leave open / In Progress.

## Quality gate

Formatter: `rustfmt --edition 2021 --check` on `log_targets.rs`, `lib.rs`: ok.

Required CI is Windows `cargo test --manifest-path src-tauri/Cargo.toml --all-targets` + `clippy --all-targets -- -D warnings`. This box failed `cargo test` at `glib-sys` (`Package glib-2.0 was not found`). No Linux harness invented as Windows CI. `src-tauri/target` deleted.

Standalone helper:

```
running 6 tests
test tests::clean_portable_profile_does_not_select_appdata ... ok
test tests::installed_run_keeps_the_os_log_directory ... ok
test tests::production_targets_do_not_include_webview ... ok
test tests::production_targets_still_include_log_dir ... ok
test tests::debug_targets_include_stdout_and_webview ... ok
test tests::portable_root_selects_a_folder_inside_that_root ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`node scripts/check-release.mjs`: `Cubby Clipboard v1.3.2 release metadata is consistent.`

## Fail without the fix

Reverted only `persistent_log_sink` to always return `OsLogDir`. Output:

```
test tests::clean_portable_profile_does_not_select_appdata ... FAILED
test tests::portable_root_selects_a_folder_inside_that_root ... FAILED

---- tests::clean_portable_profile_does_not_select_appdata stdout ----
thread '...' panicked at src-tauri/src/log_targets.rs:140:13:
clean portable profile selected OsLogDir

---- tests::portable_root_selects_a_folder_inside_that_root stdout ----
thread '...' panicked at src-tauri/src/log_targets.rs:116:17:
a portable root must not select the Tauri AppData log directory

test result: FAILED. 4 passed; 2 failed
```

Restored. Installed-arm tests still passed with the revert, so they are not tautologies for the portable case.

## Pattern sweep

`rg -n "app_data_dir|app_log_dir|TargetKind::LogDir|portable_log_dir|persistent_log_sink" src-tauri/src scripts`

- `log_targets.rs`: `persistent_log_sink` / `portable_log_dir` — this PR.
- `lib.rs` `to_plugin_log_target`: maps the sink onto `TargetKind::Folder` / `TargetKind::LogDir` — this PR.
- `commands.rs` `excluded_log_dir` / `history_disk_bytes`: still uses `crate::portable_log_dir` so Storage used skips the same folder the logger writes. Left as-is.
- `settings_manager.rs` `app.path().app_data_dir()`: release-only **read** of a legacy `settings.json` to copy into `get_data_dir()`. Not a log write. Left.
- `dirs::data_dir()` in `get_data_dir()`: installed history path only; portable returns earlier. Left.
- No `app_log_dir()` call in Cubby sources. The only AppData log path is `TargetKind::LogDir` in the installed arm.

No open-log / reveal-logs IPC command exists (checked `generate_handler!`). Nothing to retarget.

## Leftovers (portable AppData writes not in this PR)

- WebView2 user data still lands under `%LOCALAPPDATA%\ai.southforge.cubbyclipboard\` (EBWebView). The portable README says nothing is written to AppData; that is still untrue for the webview profile. Not logs. Left.
- `settings_manager.rs` may *read* (and copy from) Tauri `app_data_dir()` on a release portable first launch if `settings.json` is missing. Saves go to the portable root. Left.
- `storage.key` / DPAPI: SBS-775 / SBS-908. Left as instructed.
- If `current_exe()` fails, `portable_data_dir()` returns `None` and logs use `OsLogDir` (unknown collapsed into installed). Could not produce that failure here.

## Gaps

- Could not run `cargo test --all-targets` or clippy here (glib-2.0 / Windows crate).
- Could not run a real portable `Cubby Clipboard.exe` on a clean Windows profile. The smoke check is path-selection only (`clean_portable_profile_does_not_select_appdata`).
- Did not redirect WebView2 data or change settings migration.
- Did not add an open-logs command; none exists.
- CHANGELOG v1.3.2 already names SBS-776 from #202; no second user-visible line added.
- Did not mark Linear Done.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep portable logs inside the portable data root by delegating to `persistent_log_sink`
> - Introduces a `PersistentLogSink` enum in [log_targets.rs](https://github.com/tsouth89/cubby-clipboard/pull/232/files#diff-7746912cd8f2a0347b9d62c531ec7531c173be2a6ccb8722ee5138e2fb82e401) with `Folder(PathBuf)` and `OsLogDir` variants, and a `persistent_log_sink(portable_root)` selector that maps `Some(root)` to `Folder(root/logs)` and `None` to `OsLogDir`.
> - Rewrites the `LogTarget::LogDir` arm in [lib.rs](https://github.com/tsouth89/cubby-clipboard/pull/232/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c) to match on `persistent_log_sink(portable_data_dir())`, producing `TargetKind::Folder` for portable runs and `TargetKind::LogDir` otherwise.
> - Updates `portable_log_dir` to delegate to `log_targets::portable_log_dir` instead of constructing `root.join("logs")` directly, centralizing the path logic.
> - Adds a release gate assertion in [check-release.mjs](https://github.com/tsouth89/cubby-clipboard/pull/232/files#diff-14ac66f5d0a1f9e003460f1b27bce6e68f7665390d99e23d897038130d21cdca) that fails the build if the `LogDir` match arm does not reference both `TargetKind::Folder` and `persistent_log_sink`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e482195.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->