### PR TITLE
SBS-805: Surface a failed clip reload instead of keeping a silent stale list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 ## Unreleased
 
 ### Fixed
+- A failed clip reload no longer looks like a healthy current list: same-filter refresh shows a retry banner, superseded loads are not treated as success, and folder / app / count reloads toast instead of staying silent (SBS-805)
 - Portable first-run can install `storage.key` on FAT/exFAT: CreateHardLinkW is NTFS-only, and the previous hard-link-only install deleted the temp key and panicked (SBS-908)
 
 ## v1.3.2
@@ -35,7 +36,6 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - The image window no longer offers Copy image after the original has expired (SBS-807)
 - Keep clip edits, history files, and captures from mixing together or vanishing
 - Stop a failed paste and a failed history reload from reporting success
-- A failed clip reload no longer looks like a healthy current list: same-filter refresh shows a retry banner, superseded loads are not treated as success, and folder / app / count reloads toast instead of staying silent (SBS-805)
 - Keep History preview details in sync after a save and after a reveal
 - Keep hidden clips blank in search results, and finish folder and duplicate cleanup
 - Keep the flyout visible while Settings is open, and honor the toggle and always-on-top preferences

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - The image window no longer offers Copy image after the original has expired (SBS-807)
 - Keep clip edits, history files, and captures from mixing together or vanishing
 - Stop a failed paste and a failed history reload from reporting success
+- A failed clip reload no longer looks like a healthy current list: same-filter refresh shows a retry banner, superseded loads are not treated as success, and folder / app / count reloads toast instead of staying silent (SBS-805)
 - Keep History preview details in sync after a save and after a reveal
 - Keep hidden clips blank in search results, and finish folder and duplicate cleanup
 - Keep the flyout visible while Settings is open, and honor the toggle and always-on-top preferences

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,12 @@ import { useUpdater } from './hooks/useUpdater';
 import { useRevealedClips } from './hooks/useRevealedClips';
 import { isImeKey, shouldCaptureTypeToSearch } from './utils/flyoutSearch';
 import { folderSelectionAfterReload } from './utils/folderSelection';
-import { clipLoadFailure } from './utils/clipLoadFailure';
+import {
+  clipLoadAnnouncesSuccess,
+  clipLoadFailure,
+  type ClipLoadResult,
+  sidecarReloadFailure,
+} from './utils/clipLoadFailure';
 import { useTranslation } from 'react-i18next';
 import { Toaster, toast } from 'sonner';
 import { generateDemoClips } from './debug/demoData';
@@ -317,7 +322,7 @@ function App() {
       append: boolean = false,
       searchQuery: string = '',
       filter: ContentFilter = 'all'
-    ) => {
+    ): Promise<ClipLoadResult> => {
       const perfId = ++loadPerfIdRef.current;
       const filterKey = JSON.stringify([folderId, searchQuery.trim(), filter]);
       const loadStart = perfLogEnabled ? performance.now() : 0;
@@ -326,7 +331,6 @@ function App() {
 
       try {
         setIsLoading(true);
-        setLoadError(false);
 
         const currentOffset = append ? clipsRef.current.length : 0;
         // The index lowercases but does not trim, so a leading space matches
@@ -393,7 +397,7 @@ function App() {
         // A newer load supersedes this one (e.g. the reset when the flyout
         // closes starts an unfiltered load while a filtered one is in flight).
         // Discard the stale result so it can't overwrite the current view.
-        if (perfId !== loadPerfIdRef.current) return true;
+        if (perfId !== loadPerfIdRef.current) return 'superseded';
 
         if (append) {
           setClips((prev) => {
@@ -429,13 +433,13 @@ function App() {
             });
           });
         }
-        return true;
+        setLoadError(false);
+        return 'applied';
       } catch (error) {
-        // Superseded: a newer load owns the view, so this one failing is not a
-        // failure to refresh — report success and let the newer load speak.
-        if (perfId !== loadPerfIdRef.current) return true;
+        // Superseded is unknown, not success: a caller that toasts "deleted"
+        // from this return would announce work the newer load has not applied.
+        if (perfId !== loadPerfIdRef.current) return 'superseded';
         console.error('Failed to load clips:', error);
-        setLoadError(true);
         setHasMore(false);
         const failure = clipLoadFailure({
           append,
@@ -448,6 +452,12 @@ function App() {
           // same-filter refresh rather than another filter change.
           visibleFilterKeyRef.current = filterKey;
         }
+        // Banner (same-filter replace) and panel (empty list) both read
+        // loadError. Pagination keeps the first page healthy, so it toasts
+        // instead of marking the list stale.
+        if (!append) {
+          setLoadError(true);
+        }
         if (failure.notify) {
           toast.error(t(append ? 'clipList.loadMoreFailed' : 'clipList.refreshFailed'), {
             // One id, so a backend that keeps failing on every clipboard change
@@ -455,7 +465,7 @@ function App() {
             id: 'clip-load-failed',
           });
         }
-        return false;
+        return 'failed';
       } finally {
         if (perfId === loadPerfIdRef.current) setIsLoading(false);
       }
@@ -466,7 +476,7 @@ function App() {
   const loadFolders = useCallback(async () => {
     if (assetCaptureEnabled) {
       setFolders([]);
-      return;
+      return true;
     }
     try {
       const data = await invoke<FolderItem[]>('get_folders');
@@ -477,8 +487,15 @@ function App() {
         selectedFolderRef.current = next;
         setSelectedFolder(next);
       }
+      return true;
     } catch (error) {
       console.error('Failed to load folders:', error);
+      // Last-known-good folders stay; unknown is not an empty folder list.
+      const failure = sidecarReloadFailure();
+      if (failure.notify) {
+        toast.error('Couldn’t refresh folders', { id: 'folder-load-failed' });
+      }
+      return false;
     }
   }, []);
 
@@ -510,13 +527,19 @@ function App() {
   const refreshTotalCount = useCallback(async () => {
     if (assetCaptureEnabled) {
       setTotalClipCount(generateDemoClips().length);
-      return;
+      return true;
     }
     try {
       const count = await invoke<number>('get_clipboard_history_size');
       setTotalClipCount(count);
+      return true;
     } catch (e) {
       console.error('Failed to get history size', e);
+      const failure = sidecarReloadFailure();
+      if (failure.notify) {
+        toast.error('Couldn’t refresh the clip count', { id: 'history-count-load-failed' });
+      }
+      return false;
     }
   }, []);
 
@@ -706,8 +729,10 @@ function App() {
         // row blank under a toast saying it is visible again. loadClips reports
         // failure rather than throwing, so the toast has to read its result.
         const reloaded = await refreshCurrentFolder();
-        if (!reloaded) {
-          toast.error('Visibility changed, but the list could not be reloaded');
+        if (!clipLoadAnnouncesSuccess(reloaded)) {
+          if (reloaded === 'failed') {
+            toast.error('Visibility changed, but the list could not be reloaded');
+          }
           return;
         }
         toast.success(hidden ? 'Clip hidden' : 'Clip no longer hidden');
@@ -990,8 +1015,12 @@ function App() {
       if (selectedFolder === folderId) {
         setSelectedFolder(null);
       }
-      await loadFolders();
-      refreshTotalCount();
+      const foldersReloaded = await loadFolders();
+      await refreshTotalCount();
+      if (!foldersReloaded) {
+        toast.error('Folder deleted, but the folder list could not be reloaded');
+        return;
+      }
       toast.success(t('folders.folderDeleted'));
     } catch (error) {
       console.error('Failed to delete folder:', error);
@@ -1020,7 +1049,7 @@ function App() {
         loadFolders(),
         refreshTotalCount(),
       ]);
-      if (!reloaded) {
+      if (!clipLoadAnnouncesSuccess(reloaded)) {
         return;
       }
       toast.success(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -728,13 +728,10 @@ function App() {
         // when the reload lands, so reporting success before then can leave a
         // row blank under a toast saying it is visible again. loadClips reports
         // failure rather than throwing, so the toast has to read its result.
-        const reloaded = await refreshCurrentFolder();
-        if (!clipLoadAnnouncesSuccess(reloaded)) {
-          if (reloaded === 'failed') {
-            toast.error('Visibility changed, but the list could not be reloaded');
-          }
-          return;
-        }
+        // Same-filter reload: a failure shows the stale banner over the rows.
+        // A toast here would be a second channel for one failed reload, and a
+        // superseded reload belongs to the newer load that owns the view.
+        if (!clipLoadAnnouncesSuccess(await refreshCurrentFolder())) return;
         toast.success(hidden ? 'Clip hidden' : 'Clip no longer hidden');
       } catch (error) {
         console.error('Failed to change clip visibility:', error);
@@ -912,15 +909,20 @@ function App() {
     onCopy: handleCopySelected,
   });
 
+  /**
+   * `created` is about the folder, `reloaded` about the sidebar. They differ:
+   * the folder exists even when `get_folders` then fails, and loadFolders has
+   * already toasted that failure. The caller uses `reloaded` only to decide
+   * whether to stack a success toast on top of that error.
+   */
   const handleCreateFolder = async (name: string) => {
     try {
       await invoke('create_folder', { name, icon: null, color: null });
-      await loadFolders();
-      return true;
+      return { created: true, reloaded: await loadFolders() };
     } catch (error) {
       console.error('Failed to create folder:', error);
       toast.error(t('notifications.folderCreateFailed'));
-      return false;
+      return { created: false, reloaded: false };
     }
   };
 
@@ -937,12 +939,14 @@ function App() {
         );
       }
 
-      await loadFolders();
-      toast.success(
-        folderId
-          ? `Moved to ${folders.find((folder) => folder.id === folderId)?.name ?? 'folder'}`
-          : 'Removed from folder'
-      );
+      // A failed folder reload already toasted. One message per failure.
+      if (await loadFolders()) {
+        toast.success(
+          folderId
+            ? `Moved to ${folders.find((folder) => folder.id === folderId)?.name ?? 'folder'}`
+            : 'Removed from folder'
+        );
+      }
     } catch (error) {
       console.error('Failed to move clip:', error);
       toast.error('Failed to move clip');
@@ -989,16 +993,18 @@ function App() {
   // Updated Create Folder to handle Rename
   const handleCreateOrRenameFolder = async (name: string) => {
     if (folderModalMode === 'create') {
-      const created = await handleCreateFolder(name);
+      const { created, reloaded } = await handleCreateFolder(name);
       if (!created) return;
-      toast.success(t('folders.folderCreated', { name }));
+      // The folder exists, so the modal closes either way. Resubmitting the
+      // same name would only fail as a duplicate. loadFolders already said the
+      // sidebar is stale, so do not add a success toast next to that error.
+      if (reloaded) toast.success(t('folders.folderCreated', { name }));
       setShowAddFolderModal(false);
       setNewFolderName('');
     } else if (folderModalMode === 'rename' && editingFolderId) {
       try {
         await invoke('rename_folder', { id: editingFolderId, name });
-        await loadFolders();
-        toast.success(t('folders.folderRenamed', { name }));
+        if (await loadFolders()) toast.success(t('folders.folderRenamed', { name }));
         setShowAddFolderModal(false);
         setNewFolderName('');
       } catch (error) {
@@ -1015,12 +1021,13 @@ function App() {
       if (selectedFolder === folderId) {
         setSelectedFolder(null);
       }
+      // delete_folder also emits clipboard-change, and that listener runs its
+      // own loadFolders. Both reloads share the folder-load-failed toast id, so
+      // a failure here is already on screen exactly once; adding a second
+      // message would stack two errors for one refresh.
       const foldersReloaded = await loadFolders();
       await refreshTotalCount();
-      if (!foldersReloaded) {
-        toast.error('Folder deleted, but the folder list could not be reloaded');
-        return;
-      }
+      if (!foldersReloaded) return;
       toast.success(t('folders.folderDeleted'));
     } catch (error) {
       console.error('Failed to delete folder:', error);

--- a/frontend/src/components/ClipList.tsx
+++ b/frontend/src/components/ClipList.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { ClipboardItem } from '../types';
 import { ClipCard } from './ClipCard';
 import { AlertCircle, RefreshCw } from 'lucide-react';
+import { clipListErrorSurface } from '../utils/clipLoadFailure';
 
 interface ClipListProps {
   clips: ClipboardItem[];
@@ -89,26 +90,29 @@ export function ClipList({
     );
   }
 
+  const errorSurface = clipListErrorSurface(loadError, clips.length);
+
+  if (errorSurface === 'panel') {
+    return (
+      <div className="flex h-full flex-col items-center justify-center px-10 text-center">
+        <AlertCircle size={22} className="mb-3 text-destructive" />
+        <p className="text-sm font-medium text-foreground/90">{t('clipList.loadFailed')}</p>
+        <p className="mt-1 text-xs leading-5 text-muted-foreground">
+          {t('clipList.loadFailedDesc')}
+        </p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-4 flex items-center gap-1.5 rounded-md border border-white/[0.1] bg-white/[0.05] px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-white/[0.09]"
+        >
+          <RefreshCw size={13} />
+          {t('clipList.retry')}
+        </button>
+      </div>
+    );
+  }
+
   if (clips.length === 0) {
-    if (loadError) {
-      return (
-        <div className="flex h-full flex-col items-center justify-center px-10 text-center">
-          <AlertCircle size={22} className="mb-3 text-destructive" />
-          <p className="text-sm font-medium text-foreground/90">{t('clipList.loadFailed')}</p>
-          <p className="mt-1 text-xs leading-5 text-muted-foreground">
-            {t('clipList.loadFailedDesc')}
-          </p>
-          <button
-            type="button"
-            onClick={onRetry}
-            className="mt-4 flex items-center gap-1.5 rounded-md border border-white/[0.1] bg-white/[0.05] px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-white/[0.09]"
-          >
-            <RefreshCw size={13} />
-            {t('clipList.retry')}
-          </button>
-        </div>
-      );
-    }
     return (
       <div className="flex h-full flex-col items-center justify-center px-10 text-center">
         <p className="text-sm font-medium text-foreground/80">{emptyTitle}</p>
@@ -117,14 +121,14 @@ export function ClipList({
     );
   }
 
-  return (
+  const list = (
     <div
       ref={listRef}
       data-el="clip-list"
       id="clip-listbox"
       role="listbox"
       aria-label="Clipboard history"
-      className="no-scrollbar h-full overflow-y-auto px-2 pb-2"
+      className={`no-scrollbar overflow-y-auto px-2 pb-2 ${errorSurface === 'banner' ? 'min-h-0 flex-1' : 'h-full'}`}
       onScroll={(event) => {
         if (!hasMore || isLoading) return;
         const element = event.currentTarget;
@@ -164,6 +168,37 @@ export function ClipList({
           <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary/25 border-t-primary" />
         </div>
       )}
+    </div>
+  );
+
+  if (errorSurface !== 'banner') {
+    return list;
+  }
+
+  // Banner lives outside the listbox so the options stay its only children.
+  // A failed same-filter refresh used to keep these rows with no in-list
+  // error (SBS-805); the toast dismissed and the page looked current.
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div
+        role="alert"
+        data-el="clip-list-stale"
+        className="mx-2 mb-2 flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2"
+      >
+        <AlertCircle size={14} className="shrink-0 text-destructive" />
+        <p className="min-w-0 flex-1 text-xs font-medium text-foreground/90">
+          {t('clipList.refreshFailed')}
+        </p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="flex shrink-0 items-center gap-1.5 rounded-md border border-white/[0.1] bg-white/[0.05] px-2 py-1 text-xs font-medium text-foreground transition-colors hover:bg-white/[0.09]"
+        >
+          <RefreshCw size={13} />
+          {t('clipList.retry')}
+        </button>
+      </div>
+      {list}
     </div>
   );
 }

--- a/frontend/src/utils/clipLoadFailure.test.ts
+++ b/frontend/src/utils/clipLoadFailure.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { clipLoadFailure } from './clipLoadFailure';
+import {
+  clipListErrorSurface,
+  clipLoadAnnouncesSuccess,
+  clipLoadFailure,
+  sidecarReloadFailure,
+} from './clipLoadFailure';
 
 describe('clipLoadFailure', () => {
   it('clears the list when a replace load for new filters fails', () => {
@@ -7,16 +12,17 @@ describe('clipLoadFailure', () => {
     // filter. Leaving them up shows stale results as if they still matched.
     expect(
       clipLoadFailure({ append: false, visibleRowsStillApply: false, hasVisibleClips: true })
-    ).toEqual({ clearList: true, notify: false });
+    ).toEqual({ clearList: true, notify: false, showBanner: false });
   });
 
-  it('keeps the list when a refresh with unchanged filters fails', () => {
+  it('keeps the list and shows a banner when a refresh with unchanged filters fails', () => {
     // Clipboard-change, window focus, post-edit, and pin reloads all replace
     // the list with the same query. The rows are still correct, so a failed
-    // refresh must not swap a good first page for the empty error panel.
+    // refresh must not swap a good first page for the empty error panel —
+    // but it also must not look healthy. The banner is that third state.
     expect(
       clipLoadFailure({ append: false, visibleRowsStillApply: true, hasVisibleClips: true })
-    ).toEqual({ clearList: false, notify: true });
+    ).toEqual({ clearList: false, notify: false, showBanner: true });
   });
 
   it('does not clear the list when a pin reload fails', () => {
@@ -28,37 +34,73 @@ describe('clipLoadFailure', () => {
     ).toBe(false);
   });
 
-  it('keeps the list when an append load fails', () => {
+  it('keeps the list and toasts when an append load fails', () => {
     // Page one is still correct for the active filters. Only pagination broke.
+    // The user is at the bottom, so a top banner would sit off screen.
     expect(
       clipLoadFailure({ append: true, visibleRowsStillApply: true, hasVisibleClips: true })
-    ).toEqual({ clearList: false, notify: true });
+    ).toEqual({ clearList: false, notify: true, showBanner: false });
   });
 
   it('stays quiet when nothing was on screen to keep', () => {
     // A first load, or a retry after the list already emptied, leaves the error
-    // panel showing. A message on top of it would say the same thing twice.
+    // panel showing. A message or banner on top of it would say the same thing twice.
     expect(
       clipLoadFailure({ append: false, visibleRowsStillApply: true, hasVisibleClips: false })
-    ).toEqual({ clearList: false, notify: false });
+    ).toEqual({ clearList: false, notify: false, showBanner: false });
   });
 
   it('always tells the user exactly one way', () => {
     for (const append of [true, false]) {
       for (const visibleRowsStillApply of [true, false]) {
         for (const hasVisibleClips of [true, false]) {
-          const { clearList, notify } = clipLoadFailure({
+          const { clearList, notify, showBanner } = clipLoadFailure({
             append,
             visibleRowsStillApply,
             hasVisibleClips,
           });
-          // ClipList renders its error panel and retry button only on an empty
-          // list, so an empty list is already a message. Neither would fail
-          // silently; both would talk over the panel.
+          // ClipList renders its error panel on an empty list and a stale
+          // banner on a populated one. Neither plus a toast would talk over
+          // the in-list UI; both missing is the silent-stale-list bug.
           const listEmptyAfter = clearList || !hasVisibleClips;
-          expect(listEmptyAfter !== notify).toBe(true);
+          expect(Number(listEmptyAfter) + Number(notify) + Number(showBanner)).toBe(1);
         }
       }
     }
+  });
+});
+
+describe('clipListErrorSurface', () => {
+  it('hides nothing when there is no load error', () => {
+    expect(clipListErrorSurface(false, 0)).toBe('none');
+    expect(clipListErrorSurface(false, 3)).toBe('none');
+  });
+
+  it('uses the empty-list panel when the list is empty', () => {
+    expect(clipListErrorSurface(true, 0)).toBe('panel');
+  });
+
+  it('uses a banner when a failed reload left rows on screen', () => {
+    // SBS-805: ClipList used to return the healthy list whenever
+    // clips.length > 0, so loadError was set and then ignored.
+    expect(clipListErrorSurface(true, 3)).toBe('banner');
+  });
+});
+
+describe('clipLoadAnnouncesSuccess', () => {
+  it('announces only a load that actually landed', () => {
+    expect(clipLoadAnnouncesSuccess('applied')).toBe(true);
+    expect(clipLoadAnnouncesSuccess('failed')).toBe(false);
+    // Superseded is unknown, not success. Treating it as true made a
+    // delete/unhide toast fire while the newer load still owned the view.
+    expect(clipLoadAnnouncesSuccess('superseded')).toBe(false);
+  });
+});
+
+describe('sidecarReloadFailure', () => {
+  it('keeps the last-known-good sidecar list and requires a notify', () => {
+    // Folders, source apps, and the history count used to catch, log, and
+    // leave the previous value up with no user-visible error.
+    expect(sidecarReloadFailure()).toEqual({ keepPrevious: true, notify: true });
   });
 });

--- a/frontend/src/utils/clipLoadFailure.test.ts
+++ b/frontend/src/utils/clipLoadFailure.test.ts
@@ -97,6 +97,47 @@ describe('clipLoadAnnouncesSuccess', () => {
   });
 });
 
+describe('a handler that reloads the list after its own work', () => {
+  // The three bulk handlers, both handleToggleHidden implementations, and
+  // handleSaveText all follow one rule: check the result, withhold the success
+  // toast, and add nothing of their own. These cases are what that rule is for.
+
+  it('says nothing when a newer load superseded the reload', () => {
+    // History starts loadClips(false) from the clipboard-change listener
+    // whenever a new copy lands, which is common while the window is open.
+    // That newer load supersedes the bulk reload. Collapsing this to "not
+    // success" and toasting made every bulk action report a failure it did
+    // not have.
+    expect(clipLoadAnnouncesSuccess('superseded')).toBe(false);
+  });
+
+  it('leaves a failed same-filter reload to the banner', () => {
+    // Pin keeps the rows, so ClipList renders the stale banner. A handler
+    // toast on top of it is two channels for one failed reload.
+    const failure = clipLoadFailure({
+      append: false,
+      visibleRowsStillApply: true,
+      hasVisibleClips: true,
+    });
+    expect(failure.showBanner).toBe(true);
+    expect(failure.notify).toBe(false);
+    expect(clipListErrorSurface(true, 3)).toBe('banner');
+  });
+
+  it('leaves a failed delete or move reload to the empty-list panel', () => {
+    // Delete and move take rows out of the query, so the handler marks them
+    // stale first. The list empties and ClipList renders the panel.
+    const failure = clipLoadFailure({
+      append: false,
+      visibleRowsStillApply: false,
+      hasVisibleClips: true,
+    });
+    expect(failure.clearList).toBe(true);
+    expect(failure.notify).toBe(false);
+    expect(clipListErrorSurface(true, 0)).toBe('panel');
+  });
+});
+
 describe('sidecarReloadFailure', () => {
   it('keeps the last-known-good sidecar list and requires a notify', () => {
     // Folders, source apps, and the history count used to catch, log, and

--- a/frontend/src/utils/clipLoadFailure.ts
+++ b/frontend/src/utils/clipLoadFailure.ts
@@ -26,16 +26,23 @@ export interface ClipLoadFailure {
    */
   clearList: boolean;
   /**
-   * Say the load failed out of band. The error panel only renders on an empty
-   * list, so any failure that leaves rows on screen is otherwise silent.
+   * Say the load failed out of band. Used for pagination: the first page is
+   * still correct, the user is at the bottom, and a top-of-list banner would
+   * sit off screen.
    */
   notify: boolean;
+  /**
+   * Keep the rows but mark the list stale. ClipList only had an error panel
+   * for an empty list (SBS-805); a same-filter refresh that failed used to
+   * look like a healthy current page once the toast dismissed.
+   */
+  showBanner: boolean;
 }
 
 /**
- * The user always learns exactly once: either the list ends up empty and the
- * error panel takes over, or a message fires. Doing neither is the
- * silent-stale-list bug, and doing both talks over the panel.
+ * The user always learns exactly once: empty list → error panel, append →
+ * toast, same-filter replace → banner. Doing none is the silent-stale-list
+ * bug. Doing two talks over the panel.
  */
 export function clipLoadFailure({
   append,
@@ -43,5 +50,41 @@ export function clipLoadFailure({
   hasVisibleClips,
 }: ClipLoadAttempt): ClipLoadFailure {
   const clearList = !append && !visibleRowsStillApply;
-  return { clearList, notify: !clearList && hasVisibleClips };
+  const listEmptyAfter = clearList || !hasVisibleClips;
+  return {
+    clearList,
+    notify: !listEmptyAfter && append,
+    showBanner: !listEmptyAfter && !append,
+  };
+}
+
+/**
+ * How ClipList should present `loadError`. A populated list used to ignore
+ * the flag, which is the "hides the error" half of SBS-805.
+ */
+export function clipListErrorSurface(
+  loadError: boolean,
+  clipCount: number
+): 'none' | 'panel' | 'banner' {
+  if (!loadError) return 'none';
+  return clipCount === 0 ? 'panel' : 'banner';
+}
+
+/**
+ * A load that finished, a load that failed, and a load that no longer owns
+ * the view are three states. Callers that treat superseded as success
+ * announce work the user cannot see (SBS-805).
+ */
+export type ClipLoadResult = 'applied' | 'failed' | 'superseded';
+
+export function clipLoadAnnouncesSuccess(result: ClipLoadResult): boolean {
+  return result === 'applied';
+}
+
+/**
+ * Folders, source-app filters, and the history count are sidecar lists.
+ * A failed reload must not look like a fresh read of those lists.
+ */
+export function sidecarReloadFailure(): { keepPrevious: true; notify: true } {
+  return { keepPrevious: true, notify: true };
 }

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -17,7 +17,12 @@ import { collectBulkCopyText } from '../utils/bulkCopy';
 import { ClipDetails } from '../utils/clipPreviewState';
 import { customRange, DATE_PRESET_LABELS, DatePreset, presetRange } from '../utils/dateRange';
 import { folderSelectionAfterReload } from '../utils/folderSelection';
-import { clipLoadFailure } from '../utils/clipLoadFailure';
+import {
+  clipLoadAnnouncesSuccess,
+  clipLoadFailure,
+  type ClipLoadResult,
+  sidecarReloadFailure,
+} from '../utils/clipLoadFailure';
 import {
   applySelectionClick,
   EMPTY_SELECTION,
@@ -118,7 +123,7 @@ export function HistoryWindow() {
   const { from: dateFrom, to: dateTo } = dateRange;
 
   const loadClips = useCallback(
-    async (append: boolean) => {
+    async (append: boolean): Promise<ClipLoadResult> => {
       const loadId = ++loadIdRef.current;
       const offset = append ? clipsRef.current.length : 0;
       const query = searchQuery.trim();
@@ -133,7 +138,6 @@ export function HistoryWindow() {
 
       try {
         setIsLoading(true);
-        setLoadError(false);
 
         const data = query
           ? await invoke<ClipboardItem[]>('search_clips', {
@@ -160,17 +164,17 @@ export function HistoryWindow() {
               sourceApp,
             });
 
-        if (loadId !== loadIdRef.current) return true;
+        if (loadId !== loadIdRef.current) return 'superseded';
         setClips((previous) => (append ? [...previous, ...data] : data));
         visibleFilterKeyRef.current = filterKey;
         setHasMore(data.length === PAGE_SIZE);
-        return true;
+        setLoadError(false);
+        return 'applied';
       } catch (error) {
-        // Superseded: a newer load owns the view, so this one failing is not a
-        // failure to refresh — report success and let the newer load speak.
-        if (loadId !== loadIdRef.current) return true;
+        // Superseded is unknown, not success: a caller that toasts "deleted"
+        // from this return would announce work the newer load has not applied.
+        if (loadId !== loadIdRef.current) return 'superseded';
         console.error('Failed to load clips:', error);
-        setLoadError(true);
         setHasMore(false);
         const failure = clipLoadFailure({
           append,
@@ -183,6 +187,9 @@ export function HistoryWindow() {
           // same-filter refresh rather than another filter change.
           visibleFilterKeyRef.current = filterKey;
         }
+        if (!append) {
+          setLoadError(true);
+        }
         if (failure.notify) {
           toast.error(t(append ? 'clipList.loadMoreFailed' : 'clipList.refreshFailed'), {
             // One id, so a backend that keeps failing on every clipboard change
@@ -190,7 +197,7 @@ export function HistoryWindow() {
             id: 'clip-load-failed',
           });
         }
-        return false;
+        return 'failed';
       } finally {
         if (loadId === loadIdRef.current) setIsLoading(false);
       }
@@ -207,24 +214,42 @@ export function HistoryWindow() {
         selectedFolderRef.current = next;
         setSelectedFolder(next);
       }
+      return true;
     } catch (error) {
       console.error('Failed to load folders:', error);
+      const failure = sidecarReloadFailure();
+      if (failure.notify) {
+        toast.error('Couldn’t refresh folders', { id: 'folder-load-failed' });
+      }
+      return false;
     }
   }, []);
 
   const loadSourceApps = useCallback(async () => {
     try {
       setSourceApps(await invoke<SourceAppCount[]>('get_source_apps'));
+      return true;
     } catch (error) {
       console.error('Failed to load source apps:', error);
+      const failure = sidecarReloadFailure();
+      if (failure.notify) {
+        toast.error('Couldn’t refresh apps', { id: 'source-apps-load-failed' });
+      }
+      return false;
     }
   }, []);
 
   const refreshTotalCount = useCallback(async () => {
     try {
       setTotalClipCount(await invoke<number>('get_clipboard_history_size'));
+      return true;
     } catch (error) {
       console.error('Failed to get history size:', error);
+      const failure = sidecarReloadFailure();
+      if (failure.notify) {
+        toast.error('Couldn’t refresh the clip count', { id: 'history-count-load-failed' });
+      }
+      return false;
     }
   }, []);
 
@@ -341,7 +366,7 @@ export function HistoryWindow() {
         refreshTotalCount(),
         loadSourceApps(),
       ]);
-      return reloaded;
+      return clipLoadAnnouncesSuccess(reloaded);
     },
     [clearSelection, loadClips, loadFolders, refreshTotalCount, loadSourceApps]
   );
@@ -540,9 +565,9 @@ export function HistoryWindow() {
         // Hidden rows still ship empty content after reload; keep the session
         // reveal in sync so leaving this clip and coming back does not revert.
         updateRevealed(clipId, { content: text, preview: text });
-        // Same-filter reload: loadClips already toasts refreshFailed on
+        // Same-filter reload: loadClips already shows the stale banner on
         // failure. A second toast here would talk over it.
-        if (!(await loadClips(false))) {
+        if (!clipLoadAnnouncesSuccess(await loadClips(false))) {
           return;
         }
         toast.success('Clip updated');
@@ -616,8 +641,11 @@ export function HistoryWindow() {
         forgetRevealed(clipId);
         // loadClips reports failure rather than throwing, so a stale list after
         // a failed reload would otherwise be announced as success.
-        if (!(await loadClips(false))) {
-          toast.error('Visibility changed, but the list could not be reloaded');
+        const reloaded = await loadClips(false);
+        if (!clipLoadAnnouncesSuccess(reloaded)) {
+          if (reloaded === 'failed') {
+            toast.error('Visibility changed, but the list could not be reloaded');
+          }
           return;
         }
         toast.success(hidden ? 'Clip hidden' : 'Clip no longer hidden');

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -348,12 +348,15 @@ export function HistoryWindow() {
   const clearSelection = useCallback(() => setSelection(EMPTY_SELECTION), []);
 
   /**
-   * Returns whether the list actually reloaded. loadClips reports failure
-   * rather than throwing, so callers must check this before announcing success:
-   * the rows on screen still describe the state before the bulk change.
+   * Returns the list reload's own result, not a boolean. loadClips reports
+   * failure rather than throwing, so callers must check this before announcing
+   * success: the rows on screen still describe the state before the bulk
+   * change. Collapsing this to a boolean turns `superseded` into `failed`, and
+   * a clipboard-change refresh supersedes this reload often enough that every
+   * bulk action would report an error it did not have.
    */
   const afterBulkChange = useCallback(
-    async (rowsStillApply = false) => {
+    async (rowsStillApply = false): Promise<ClipLoadResult> => {
       clearSelection();
       // Delete and move take rows out of this query. Pin does not, so a failed
       // reload must keep the still-matching list instead of wiping it.
@@ -366,7 +369,7 @@ export function HistoryWindow() {
         refreshTotalCount(),
         loadSourceApps(),
       ]);
-      return clipLoadAnnouncesSuccess(reloaded);
+      return reloaded;
     },
     [clearSelection, loadClips, loadFolders, refreshTotalCount, loadSourceApps]
   );
@@ -380,10 +383,10 @@ export function HistoryWindow() {
         ids: selectedIds,
         hardDelete: true,
       });
-      if (!(await afterBulkChange())) {
-        toast.error('Deleted, but the list could not be reloaded');
-        return;
-      }
+      // A failed reload already speaks: ClipList shows the error panel once
+      // these rows are dropped. A superseded reload belongs to a newer load.
+      // Either way this handler only withholds its success toast.
+      if (!clipLoadAnnouncesSuccess(await afterBulkChange())) return;
       toast.success(deleted === 1 ? 'Deleted 1 clip' : `Deleted ${deleted} clips`);
     } catch (error) {
       console.error('Failed to delete clips:', error);
@@ -396,10 +399,8 @@ export function HistoryWindow() {
       if (selectionCount === 0) return;
       try {
         await invoke<number>('set_clips_pinned', { ids: selectedIds, pinned });
-        if (!(await afterBulkChange(true))) {
-          toast.error('Pin state changed, but the list could not be reloaded');
-          return;
-        }
+        // Pin keeps the rows, so a failed reload shows the stale banner.
+        if (!clipLoadAnnouncesSuccess(await afterBulkChange(true))) return;
         toast.success(
           pinned ? `Pinned ${selectionCount} clips` : `Unpinned ${selectionCount} clips`
         );
@@ -416,10 +417,7 @@ export function HistoryWindow() {
       if (selectionCount === 0) return;
       try {
         await invoke<number>('move_clips_to_folder', { ids: selectedIds, folderId });
-        if (!(await afterBulkChange())) {
-          toast.error('Moved, but the list could not be reloaded');
-          return;
-        }
+        if (!clipLoadAnnouncesSuccess(await afterBulkChange())) return;
         toast.success(
           folderId
             ? `Moved ${selectionCount} clips to ${folders.find((f) => f.id === folderId)?.name ?? 'folder'}`
@@ -641,13 +639,10 @@ export function HistoryWindow() {
         forgetRevealed(clipId);
         // loadClips reports failure rather than throwing, so a stale list after
         // a failed reload would otherwise be announced as success.
-        const reloaded = await loadClips(false);
-        if (!clipLoadAnnouncesSuccess(reloaded)) {
-          if (reloaded === 'failed') {
-            toast.error('Visibility changed, but the list could not be reloaded');
-          }
-          return;
-        }
+        // Same-filter reload: a failure shows the stale banner over the rows,
+        // the way handleSaveText already relies on. A toast here would be a
+        // second channel for one failed reload.
+        if (!clipLoadAnnouncesSuccess(await loadClips(false))) return;
         toast.success(hidden ? 'Clip hidden' : 'Clip no longer hidden');
       } catch (error) {
         console.error('Failed to change clip visibility:', error);


### PR DESCRIPTION
## Summary

- Failed same-filter clip reload shows a retry banner instead of a healthy list (SBS-805).
- loadClips returns applied | failed | superseded. Success toasts only on applied.
- Folder, source-app, and history-count reloads toast on failure.

Not merged. Leave SBS-805 open / In Progress.

## What a user who hits this now sees

A same-filter refresh that fails keeps the matching rows and shows a banner with Try again. A filter-change failure still clears the list and shows the empty error panel. A delete or unhide whose reload is superseded no longer toasts success. A folder, app, or count reload that fails keeps last-known-good and toasts.

## Quality gate

CI test job: format check, vitest, tsc, Windows cargo test all-targets, clippy deny warnings.
Ran here: prettier ts/tsx/css clean. vitest 11 files, 128 passed. tsc noEmit clean. Full Windows crate tests not run on this box. No Rust changes. No target dir to delete.

## Fail without the fix

Reverted only production helpers in clipLoadFailure.ts. vitest clipLoadFailure.test.ts: 4 failed, 7 passed. Restored; 128 passed.

1. same-filter refresh expected showBanner true, got notify true / showBanner false
2. clipListErrorSurface(true, 3) expected banner, got none
3. clipLoadAnnouncesSuccess(superseded) expected false, got true
4. sidecarReloadFailure expected notify true, got false

## Pattern sweep

Grep: catch error, setLoadError, clipLoadFailure, console.error in frontend/src.

Fixed: loadClips in App and History (three-state result, banner); loadFolders both windows; loadSourceApps; refreshTotalCount; handleDeleteFolder; visibility/clear/save-text success only on applied.

## What this change makes more likely

Persistent banner on a backend that fails every clipboard-change refresh (intended). afterBulkChange skips success toast when superseded. Sidecar toasts can appear alongside the clip banner if the DB is down; toast ids coalesce repeats.

## Gaps

- Windows cargo test and clippy not run here.
- get_settings still console.error only.
- handleCreateFolder and handleMoveClip still toast success after loadFolders.
- afterBulkChange toasts could-not-reload for both failed and superseded.
- Bulk pin/delete can still pair that toast with the empty error panel.
- get_clips still skips an unreadable row (SBS-830).
- Listen dispose catch left.
- Banner reuses clipList.refreshFailed; no new locale keys.
- No count-unknown badge; toast is the only stale-count signal.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface failed clip reloads with a stale-data banner instead of a silent healthy list
> - `loadClips` now returns a tri-state `ClipLoadResult` (`'applied' | 'failed' | 'superseded'`) instead of a boolean; failed replace-loads set an error state while append failures and superseded loads no longer masquerade as success.
> - A stale-data banner with a retry button appears above the clip list when a same-filter refresh fails but rows are still present; empty-list failures continue to show the full error panel.
> - `loadFolders`, `loadSourceApps`, and `refreshTotalCount` now return a boolean and emit a single toast on failure while retaining the previous value, replacing silent failures.
> - Success toasts for bulk actions, folder create/rename/move/delete, clear history, and toggle-hidden are now gated on `clipLoadAnnouncesSuccess`, preventing false-positive confirmations when the reload was superseded or failed.
> - Behavioral Change: operations that previously showed a success toast even when the subsequent reload failed will now show no success toast; the error surface (banner, panel, or toast) is the sole signal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50745f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->