### PR TITLE
SBS-810: Allow Settings website and privacy URLs through the opener glob

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - run: node .github/scripts/check-privileged-action-pins.mjs
       - run: node .github/scripts/check-shipped-windows-ci.mjs
       - run: pnpm run test
-      - run: node --test product_pages/worker.test.mjs product_pages/analytics.test.mjs .github/scripts/check-privileged-action-pins.test.mjs .github/scripts/check-shipped-windows-ci.test.mjs scripts/product-page-claims.test.mjs scripts/release-check-helpers.test.mjs
+      - run: node --test product_pages/worker.test.mjs product_pages/analytics.test.mjs .github/scripts/check-privileged-action-pins.test.mjs .github/scripts/check-shipped-windows-ci.test.mjs scripts/product-page-claims.test.mjs scripts/release-check-helpers.test.mjs scripts/opener-allowlist.test.mjs
       - run: pnpm audit --prod
       # The rule that decides whether a live download URL may be overwritten.
       - name: Publish-guard rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - Pre-merge CI now cargo-checks x64 and ARM64 default and Microsoft Store feature builds, so those configurations fail on the pull request instead of at release (SBS-779)
 
 ### Fixed
+- Open cubbyclipboard.com and the privacy policy from Settings, including the trailing-slash and www forms the live site uses, without allowing the rest of the web (SBS-810)
 - Revive an expired screenshot original when that same image is copied again, including a consecutive duplicate that used to be skipped, so Paste and Copy work immediately and recognized text stays (SBS-769)
 - Keep the previous original when a recapture cannot write the full image, instead of losing both (SBS-836)
 - Refuse an encrypted backup export when any live clip field cannot be fully decrypted, and leave an existing destination file unchanged (SBS-772)

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -5,6 +5,13 @@ import { fileURLToPath } from 'node:url';
 import { checkPrivilegedActionPins } from '../.github/scripts/check-privileged-action-pins.mjs';
 import { findFileListHistoryClaims } from './product-page-claims.mjs';
 import { extractDefaultSkipLikelySecrets, evaluateSecretHeuristicsDoc, saysDefaultOff } from './release-check-helpers.mjs';
+import {
+  assertAllowlistNotWideOpen,
+  extractAllowlistPatterns,
+  extractOpenedUrls,
+  isUrlAllowed,
+  urlSlashVariants,
+} from './opener-allowlist.mjs';
 
 const root = new URL('../', import.meta.url);
 const rootDir = fileURLToPath(root);
@@ -249,25 +256,32 @@ for (const [docName, doc] of [
   }
 }
 
-// A URL the frontend opens but the capability does not allow is rejected at the
-// Tauri boundary, which reads to the user as a button that does nothing.
-const openerScope = capability.permissions.find(
-  (permission) => permission?.identifier === 'opener:allow-open-url'
-);
-// No `$` anchor: these sources are CRLF, so a trailing `\r` would leave the
-// pattern matching nothing and the gate passing on an empty set.
-const allowedUrls = new Set((openerScope?.allow ?? []).map((entry) => entry.url));
-const openedUrls = [...settingsPanelSource.matchAll(/^const \w*URL = '([^']+)';/gm)].map(
-  ([, url]) => url
-);
-if (openedUrls.length === 0) {
+// SBS-810: a URL the frontend opens but the capability does not allow is
+// rejected at the Tauri boundary, which reads as a button that does nothing.
+// Match the way tauri-plugin-opener does (Rust glob), including the
+// trailing-slash homepage the live site actually uses. Exact JSON equality
+// was how cubbyclipboard.com sat in the allowlist and still failed.
+const openerPatterns = extractAllowlistPatterns(capability);
+assertAllowlistNotWideOpen(openerPatterns);
+const settingsOpenedUrls = extractOpenedUrls(settingsPanelSource);
+if (settingsOpenedUrls.length === 0) {
   throw new Error('Could not find the Settings link URL constants to check against the allowlist');
 }
+const frontendFilesForOpener = await collectFrontendSources(path.join(rootDir, 'frontend', 'src'));
+const openedUrls = new Set(settingsOpenedUrls);
+for (const filePath of frontendFilesForOpener) {
+  const source = await readFile(filePath, 'utf8');
+  for (const url of extractOpenedUrls(source)) {
+    openedUrls.add(url);
+  }
+}
 for (const openedUrl of openedUrls) {
-  if (!allowedUrls.has(openedUrl)) {
-    throw new Error(
-      `Settings opens ${openedUrl}, but src-tauri/capabilities/default.json does not allow it`
-    );
+  for (const variant of urlSlashVariants(openedUrl)) {
+    if (!isUrlAllowed(variant, openerPatterns)) {
+      throw new Error(
+        `Settings opens ${variant}, but src-tauri/capabilities/default.json does not allow it`
+      );
+    }
   }
 }
 

--- a/scripts/opener-allowlist.mjs
+++ b/scripts/opener-allowlist.mjs
@@ -1,0 +1,76 @@
+// SBS-810: opener allowlist matching used by check-release.mjs.
+
+// tauri-plugin-opener compares the URL string the frontend passes to
+// openUrl against each capability url with the Rust glob crate
+// (Pattern::matches). Star and question-mark do not cross slash.
+// This helper copies that rule so the release gate tests the same
+// thing the plugin will enforce, not string equality of the JSON.
+
+const GLOB_ESCAPE = /[\\^$+.()|[\]{}-]/g;
+
+export function rustGlobMatches(pattern, value) {
+  let regex = "^";
+  for (const char of pattern) {
+    if (char === "*") {
+      regex += "[^/]*";
+    } else if (char === "?") {
+      regex += "[^/]";
+    } else {
+      regex += char.replace(GLOB_ESCAPE, "\\$&");
+    }
+  }
+  regex += "$";
+  return new RegExp(regex).test(value);
+}
+
+export function extractAllowlistPatterns(capability) {
+  const openerScope = (capability?.permissions ?? []).find(
+    (permission) => permission?.identifier === "opener:allow-open-url"
+  );
+  return (openerScope?.allow ?? [])
+    .map((entry) => entry?.url)
+    .filter((url) => typeof url === "string" && url.length > 0);
+}
+
+export function isUrlAllowed(url, patterns) {
+  return patterns.some((pattern) => rustGlobMatches(pattern, url));
+}
+
+export function isPatternWideOpen(pattern) {
+  if (pattern === "*" || pattern === "**") return true;
+  const host = pattern.match(/^https?:\/\/([^/]*)/)?.[1];
+  return host === "*" || host === "**" || host === "";
+}
+
+export function assertAllowlistNotWideOpen(patterns) {
+  const wide = patterns.filter(isPatternWideOpen);
+  if (wide.length > 0) {
+    throw new Error(
+      "Opener allowlist must not permit the entire web; refused: " + wide.join(", ")
+    );
+  }
+}
+
+// No dollar-anchor: sources can be CRLF, so a trailing CR would leave
+// the pattern matching nothing and the gate passing on an empty set.
+const OPENED_URL_PATTERN =
+  /(?:^const \w*URL = |openUrl\(\s*)['"](https?:[^'"]+)['"]/gm;
+
+export function extractOpenedUrls(source) {
+  return [...source.matchAll(OPENED_URL_PATTERN)].map(([, url]) => url.replace(/\r$/, ""));
+}
+
+export function urlSlashVariants(url) {
+  // rust-url adds a trailing slash only to origin URLs. Path URLs such as
+  // /privacy stay as written, and the live privacy canonical has no slash.
+  try {
+    const parsed = new URL(url);
+    const originOnly = parsed.pathname === "/" || parsed.pathname === "";
+    if (!originOnly) return [url];
+    const origin = parsed.protocol + "//" + parsed.host;
+    return [origin, origin + "/"];
+  } catch {
+    return [url];
+  }
+}
+

--- a/scripts/opener-allowlist.test.mjs
+++ b/scripts/opener-allowlist.test.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import {
+  assertAllowlistNotWideOpen,
+  extractAllowlistPatterns,
+  extractOpenedUrls,
+  isPatternWideOpen,
+  isUrlAllowed,
+  rustGlobMatches,
+  urlSlashVariants,
+} from './opener-allowlist.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const PRODUCT_URLS = [
+  'https://cubbyclipboard.com',
+  'https://cubbyclipboard.com/',
+  'https://cubbyclipboard.com/privacy',
+  'https://www.cubbyclipboard.com',
+  'https://www.cubbyclipboard.com/',
+  'https://www.cubbyclipboard.com/privacy',
+  'https://github.com/tsouth89/cubby-clipboard',
+];
+
+const BLOCKED_URLS = [
+  'https://evil.example',
+  'https://github.com/other/repo',
+  'https://cubbyclipboard.com.evil.com',
+  'https://notcubbyclipboard.com/privacy',
+];
+
+const GITHUB_ONLY = ['https://github.com/tsouth89/cubby-clipboard'];
+
+test('rust glob star does not cross a slash and question-mark is one char', () => {
+  assert.equal(rustGlobMatches('https://example.com/*', 'https://example.com/privacy'), true);
+  assert.equal(rustGlobMatches('https://example.com/*', 'https://example.com/'), true);
+  assert.equal(rustGlobMatches('https://example.com/*', 'https://example.com'), false);
+  assert.equal(rustGlobMatches('https://example.com/*', 'https://example.com/a/b'), false);
+  assert.equal(rustGlobMatches('https://example.com', 'https://example.com'), true);
+  assert.equal(rustGlobMatches('https://example.com', 'https://example.com/'), false);
+  assert.equal(rustGlobMatches('https://ex?mple.com', 'https://example.com'), true);
+});
+
+test('live allowlist opens product website and privacy, including slash and www', async () => {
+  const capability = JSON.parse(
+    await readFile(path.join(repoRoot, 'src-tauri/capabilities/default.json'), 'utf8')
+  );
+  const patterns = extractAllowlistPatterns(capability);
+  assertAllowlistNotWideOpen(patterns);
+  for (const url of PRODUCT_URLS) {
+    assert.equal(isUrlAllowed(url, patterns), true, url);
+  }
+  for (const url of BLOCKED_URLS) {
+    assert.equal(isUrlAllowed(url, patterns), false, url);
+  }
+});
+
+test('github-only allowlist still blocks the product website and privacy', () => {
+  for (const url of [
+    'https://cubbyclipboard.com',
+    'https://cubbyclipboard.com/',
+    'https://cubbyclipboard.com/privacy',
+    'https://www.cubbyclipboard.com',
+  ]) {
+    assert.equal(isUrlAllowed(url, GITHUB_ONLY), false, url);
+  }
+  assert.equal(isUrlAllowed('https://github.com/tsouth89/cubby-clipboard', GITHUB_ONLY), true);
+});
+
+test('host-wildcard patterns are treated as opening the entire web', () => {
+  assert.equal(isPatternWideOpen('https://*'), true);
+  assert.equal(isPatternWideOpen('http://*'), true);
+  assert.equal(isPatternWideOpen('*'), true);
+  assert.equal(isPatternWideOpen('https://cubbyclipboard.com/*'), false);
+  assert.throws(() => assertAllowlistNotWideOpen(['https://*']), /entire web/);
+});
+
+test('extractOpenedUrls finds Settings const URL assignments', () => {
+  const source = [
+    "const GITHUB_URL = 'https://github.com/tsouth89/cubby-clipboard';",
+    "const WEBSITE_URL = 'https://cubbyclipboard.com';",
+    "const PRIVACY_URL = 'https://cubbyclipboard.com/privacy';",
+  ].join('\n');
+  assert.deepEqual(extractOpenedUrls(source), [
+    'https://github.com/tsouth89/cubby-clipboard',
+    'https://cubbyclipboard.com',
+    'https://cubbyclipboard.com/privacy',
+  ]);
+});
+
+test('slash variants cover the live homepage with and without a trailing slash', () => {
+  assert.deepEqual(urlSlashVariants('https://cubbyclipboard.com'), [
+    'https://cubbyclipboard.com',
+    'https://cubbyclipboard.com/',
+  ]);
+});
+
+
+test('path URLs keep their written form; rust-url does not add a slash', () => {
+  assert.deepEqual(urlSlashVariants('https://cubbyclipboard.com/privacy'), [
+    'https://cubbyclipboard.com/privacy',
+  ]);
+});
+

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -26,10 +26,19 @@
           "url": "https://github.com/tsouth89/cubby-clipboard"
         },
         {
+          "url": "https://github.com/tsouth89/cubby-clipboard/*"
+        },
+        {
           "url": "https://cubbyclipboard.com"
         },
         {
-          "url": "https://cubbyclipboard.com/privacy"
+          "url": "https://cubbyclipboard.com/*"
+        },
+        {
+          "url": "https://www.cubbyclipboard.com"
+        },
+        {
+          "url": "https://www.cubbyclipboard.com/*"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Settings website and privacy buttons call `openUrl` with the product URLs. tauri-plugin-opener matches those strings with the Rust glob crate, where `*` does not cross `/` and an exact origin does not match a trailing slash.
- The live homepage canonical is `https://cubbyclipboard.com/` (sitemap + og:url). `www.cubbyclipboard.com` also serves the site. The previous exact-string allowlist listed the no-slash origin and `/privacy` only.
- This PR allowlists the GitHub repo, first-level repo paths, cubbyclipboard.com, www.cubbyclipboard.com, and first-level paths on both hosts. It does not add `opener:default` or `https://*`.
- `check-release.mjs` now uses the same glob matching, requires origin slash variants, scans every frontend `const *URL` / `openUrl('https://...')`, and refuses host-wildcard patterns. `scripts/opener-allowlist.test.mjs` is on the required CI `node --test` line.

## What a user who hits this now sees

About → cubbyclipboard.com and Privacy policy open the live product pages, including the trailing-slash homepage and the www host. A random `https://` URL is still rejected at the Tauri boundary; that path still shows the existing toast.

## Sweep

In-app opener calls: only SettingsPanel.tsx (GITHUB_URL, WEBSITE_URL, PRIVACY_URL). No other Settings/About openUrl.

First-level product paths (support, terms, start, download) are now allowed if a later Settings link is added. They are not linked from Settings today.

Nested GitHub paths (issues/new, releases/latest, blob) are not allowlisted. Not linked from Settings.

downloads.cubbyclipboard.com is used by store scripts, not Settings.

## Quality gate

Required CI job test on windows-latest still owns format, release:check, build, node tests, cargo fmt, cargo test, clippy.

Ran here: opener unit tests 7 passed; release check consistent; full node test list 81 passed; rustfmt check clean.

## Fail without the production change

Reverted only src-tauri/capabilities/default.json to origin/main (exact origin and /privacy, no globs), then ran the new tests:

live allowlist test failed: https://cubbyclipboard.com/  false !== true

release check failed: Settings opens https://cubbyclipboard.com/, but default.json does not allow it

Restored the glob allowlist; both commands passed again.

## Leftovers / gaps

- Nested GitHub paths are still blocked. Settings does not open them.
- A privacy URL with a trailing slash is still blocked. The live canonical has no slash.
- Did not click the Settings buttons on a Windows build.
- Full Windows cargo test / clippy not run on this Linux box.
- rustGlobMatches copies star/question-mark semantics; it treats [ as a literal because Cubby patterns do not use classes.

## What this makes more likely

A compromised Settings page can now open any first-level path on cubbyclipboard.com or www, and the first path segment under the GitHub repo. Other hosts and nested paths stay denied. The existing toast fires less often because more product URLs succeed.

## Test plan

- [ ] About tab: cubbyclipboard.com opens the site
- [ ] About tab: Privacy policy opens /privacy
- [ ] GitHub source link still opens
- [ ] A URL not on the allowlist still toasts instead of opening

