### PR TITLE
SBS-780: Keep README and SECURITY from claiming file-list history

### DIFF
--- a/docs/BASELINE_AUDIT.md
+++ b/docs/BASELINE_AUDIT.md
@@ -16,7 +16,7 @@ folder for supported behavior.
 | Inherited area | Cubby status |
 | --- | --- |
 | Clipboard polling and debounce | Replaced with `AddClipboardFormatListener`, ordered capture, and bounded contention retries |
-| Text/image-only storage model | Replaced with encrypted text, HTML, RTF, image, and file-list preservation |
+| Text/image-only storage model | Replaced with encrypted text, HTML, RTF, and image preservation. File-list history was added and later removed; copied files are ignored |
 | Plaintext clipboard storage | Replaced with AES-256-GCM payload encryption and a Windows DPAPI-protected key |
 | Inline/best-effort screenshot OCR | Replaced with a durable, recoverable single-worker queue using local Windows OCR |
 | SQLite/linear search | Replaced with an encrypted-at-rest-safe, memory-only trigram index; SQLite remains authoritative for order, folders, pins, and pagination |

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { checkPrivilegedActionPins } from '../.github/scripts/check-privileged-action-pins.mjs';
-import { findFileListHistoryClaims } from './product-page-claims.mjs';
+import { claimSegments, findFileListHistoryClaims } from './product-page-claims.mjs';
 import { extractDefaultSkipLikelySecrets, evaluateSecretHeuristicsDoc, saysDefaultOff } from './release-check-helpers.mjs';
 import {
   assertAllowlistNotWideOpen,
@@ -264,15 +264,16 @@ const fileMentionPattern = /\bfiles?\b/i;
 const retentionClaimPattern = /\b(?:retained|stores?|supports?|includes?|records?(?:ed)?)\b/i;
 const negationPattern = /\b(?:not|never|ignor\w*)\b/i;
 for (const [docName, doc] of userFacingHistoryDocs) {
-  const fileClaim = doc
-    .replace(/\r?\n/g, ' ')
-    .split(/(?<=[.!?])\s+/)
-    .find(
-      (sentence) =>
-        fileMentionPattern.test(sentence) &&
-        retentionClaimPattern.test(sentence) &&
-        !negationPattern.test(sentence)
-    );
+  // claimSegments, not a bare [.!?] split: markup ends a sentence at `.</p>`
+  // and JSON at `disk.",`, neither of which that split sees. Without it the
+  // install steps in start.html and a whole block of en.json read as one
+  // sentence, so any ordinary "includes" nearby failed the release.
+  const fileClaim = claimSegments(doc).find(
+    (sentence) =>
+      fileMentionPattern.test(sentence) &&
+      retentionClaimPattern.test(sentence) &&
+      !negationPattern.test(sentence)
+  );
   if (fileClaim) {
     throw new Error(
       `${docName} claims file clipboard history is retained or supported, which capture policy deliberately ignores: ${fileClaim.trim()}`

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -219,27 +219,51 @@ if (`${clipboardSource}\n${commandSource}`.includes('ClipboardContent::Files')) 
   );
 }
 
-// The gates above encode that copied files are never stored. Public docs claimed
-// the opposite for months because nothing tied the two together. If file capture
-// is ever restored, delete these lines deliberately along with the design work.
-//
+const [indexPageDoc, startPageDoc, termsPageDoc, pressKitDoc] = await Promise.all([
+  read('product_pages/index.html'),
+  read('product_pages/start.html'),
+  read('product_pages/terms.html'),
+  read('docs/press-kit/description.txt'),
+]);
+
+// SBS-780 / SBS-832: public docs must not claim file-list history while
+// capture policy ignores file payloads. Two detectors on purpose:
+// 1) findFileListHistoryClaims catches a table cell with no verb
+//    ("...and file lists") and "file-drop lists are retained".
+// 2) The weaker sentence scan catches "Cubby stores files" that never
+//    says "file lists". If file capture is restored, delete both
+//    deliberately along with the design work.
+const userFacingHistoryDocs = [
+  ['README.md', readmeDoc],
+  ['SECURITY.md', securityDoc],
+  ['product_pages/privacy.html', privacyPageDoc],
+  ['product_pages/support.html', supportPageDoc],
+  ['product_pages/index.html', indexPageDoc],
+  ['product_pages/start.html', startPageDoc],
+  ['product_pages/terms.html', termsPageDoc],
+  ['docs/press-kit/description.txt', pressKitDoc],
+  ['frontend/src/i18n/locales/en.json', settingsLocaleText],
+];
+
+for (const [docName, doc] of userFacingHistoryDocs) {
+  const [claim] = findFileListHistoryClaims(doc);
+  if (claim) {
+    throw new Error(`${docName} still claims file-list clipboard history: ${claim}`);
+  }
+}
+
 // A sentence only counts as a claim if it says files are retained or
 // supported (retained|stores|supports|includes|records) without also
 // negating that (not|never|ignore). This lets docs correctly say "Cubby does
 // not store file lists" while still catching restated lies like "Cubby
-// stores copied files" that don't use the literal phrase "file lists".
+// stores copied files" that do not use the literal phrase "file lists".
 // Checked per sentence rather than per line: a paragraph line can carry both
 // an accurate negated claim and a false unnegated one, and a negation later
 // in the same line must not paper over a false claim earlier in it.
 const fileMentionPattern = /\bfiles?\b/i;
 const retentionClaimPattern = /\b(?:retained|stores?|supports?|includes?|records?(?:ed)?)\b/i;
 const negationPattern = /\b(?:not|never|ignor\w*)\b/i;
-for (const [docName, doc] of [
-  ['README.md', readmeDoc],
-  ['SECURITY.md', securityDoc],
-  ['product_pages/privacy.html', privacyPageDoc],
-  ['product_pages/support.html', supportPageDoc],
-]) {
+for (const [docName, doc] of userFacingHistoryDocs) {
   const fileClaim = doc
     .replace(/\r?\n/g, ' ')
     .split(/(?<=[.!?])\s+/)
@@ -461,17 +485,6 @@ if (defaultSkipLikelySecrets === 'true' && !/on by default/i.test(skipLikelySecr
 
 if (!securityDoc.includes('RUSTSEC-2023-0071')) {
   throw new Error('SECURITY.md must document the reviewed RSA advisory waiver');
-}
-
-const productPageSources = [
-  ['product_pages/privacy.html', await read('product_pages/privacy.html')],
-  ['product_pages/support.html', await read('product_pages/support.html')],
-];
-for (const [file, source] of productPageSources) {
-  const [claim] = findFileListHistoryClaims(source);
-  if (claim) {
-    throw new Error(`${file} still claims file-list clipboard history: ${claim}`);
-  }
 }
 
 const reviewed = securityDoc.match(/^- Reviewed:\s*(\d{4}-\d{2}-\d{2})\s*$/m)?.[1];

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -3,7 +3,10 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { checkPrivilegedActionPins } from '../.github/scripts/check-privileged-action-pins.mjs';
-import { claimSegments, findFileListHistoryClaims } from './product-page-claims.mjs';
+import {
+  findFileListHistoryClaims,
+  findWeakerFileRetentionClaim,
+} from './product-page-claims.mjs';
 import { extractDefaultSkipLikelySecrets, evaluateSecretHeuristicsDoc, saysDefaultOff } from './release-check-helpers.mjs';
 import {
   assertAllowlistNotWideOpen,
@@ -254,26 +257,15 @@ for (const [docName, doc] of userFacingHistoryDocs) {
 
 // A sentence only counts as a claim if it says files are retained or
 // supported (retained|stores|supports|includes|records) without also
-// negating that (not|never|ignore). This lets docs correctly say "Cubby does
-// not store file lists" while still catching restated lies like "Cubby
-// stores copied files" that do not use the literal phrase "file lists".
-// Checked per sentence rather than per line: a paragraph line can carry both
-// an accurate negated claim and a false unnegated one, and a negation later
-// in the same line must not paper over a false claim earlier in it.
-const fileMentionPattern = /\bfiles?\b/i;
-const retentionClaimPattern = /\b(?:retained|stores?|supports?|includes?|records?(?:ed)?)\b/i;
-const negationPattern = /\b(?:not|never|ignor\w*)\b/i;
+// negating that (no|not|never|without|none|neither|ignore). This lets docs
+// correctly say "No files are retained" while still catching restated lies
+// like "Cubby stores copied files" that do not use the literal phrase
+// "file lists". Checked per sentence rather than per line: a paragraph line
+// can carry both an accurate negated claim and a false unnegated one, and a
+// negation later in the same line must not paper over a false claim earlier
+// in it.
 for (const [docName, doc] of userFacingHistoryDocs) {
-  // claimSegments, not a bare [.!?] split: markup ends a sentence at `.</p>`
-  // and JSON at `disk.",`, neither of which that split sees. Without it the
-  // install steps in start.html and a whole block of en.json read as one
-  // sentence, so any ordinary "includes" nearby failed the release.
-  const fileClaim = claimSegments(doc).find(
-    (sentence) =>
-      fileMentionPattern.test(sentence) &&
-      retentionClaimPattern.test(sentence) &&
-      !negationPattern.test(sentence)
-  );
+  const fileClaim = findWeakerFileRetentionClaim(doc);
   if (fileClaim) {
     throw new Error(
       `${docName} claims file clipboard history is retained or supported, which capture policy deliberately ignores: ${fileClaim.trim()}`

--- a/scripts/product-page-claims.mjs
+++ b/scripts/product-page-claims.mjs
@@ -10,9 +10,18 @@
 // The original SECURITY.md lie used "file-drop lists" / "retained". Both
 // have to count as mentions.
 
-/** Matches "file list(s)", "file-list(s)", "file-drop list(s)", and "copied file(s)". */
+/**
+ * Matches "file list(s)", "file-list(s)", "file-drop list(s)", and "copied
+ * file(s)".
+ *
+ * "list" is required after "drop" on purpose. A bare "file drop" mention was
+ * both too wide and self-cancelling: `NEGATION` contains `\bdrops\b`, so a
+ * no-verb cell such as "Text, HTML, RTF, images, and file drops" negated
+ * itself and reported nothing, while "Windows file-drop (CF_HDROP) is a path
+ * list" was reported as a claim.
+ */
 const FILE_LIST_MENTION =
-  /\b(?:file[\s-]*lists?|file[\s-]*drops?(?:\s+lists?)?|copied files?)\b/gi;
+  /\b(?:file[\s-]*lists?|file[\s-]*drop[\s-]*lists?|copied files?)\b/gi;
 
 /** Verbs that assert support for whatever noun follows them. */
 const CLAIM_VERB =
@@ -27,7 +36,16 @@ const CLAUSE_BOUNDARY = /,|\b(?:but|and)\b/gi;
 /**
  * Split a page into sentence-sized pieces. Block tags are boundaries; inline
  * tags become spaces so "file <strong>lists</strong>" stays one mention.
+ *
+ * Exported because the weaker `\bfiles?\b` scan in check-release.mjs needs
+ * the same boundaries: splitting on `[.!?]` alone does not break at `.</p>`
+ * or `disk."`, which joined a whole install-steps section of start.html into
+ * one span and made an unrelated sentence in it fail the release.
  */
+export function claimSegments(source) {
+  return segments(source);
+}
+
 function segments(source) {
   const decoded = source
     .replace(/&nbsp;|&#160;|&#x0*A0;/gi, ' ')

--- a/scripts/product-page-claims.mjs
+++ b/scripts/product-page-claims.mjs
@@ -122,3 +122,23 @@ export function findFileListHistoryClaims(source) {
   }
   return claims;
 }
+
+/**
+ * Weaker scan used by the release check: a sentence that says files are
+ * retained or supported without also negating that. Broader than
+ * `findFileListHistoryClaims` so "Cubby stores files" still fails even when
+ * it never says "file lists". `no`/`without`/`none`/`neither` have to count
+ * as negation or a disclaimer such as "No files are retained" false-fails.
+ */
+export function findWeakerFileRetentionClaim(source) {
+  const fileMentionPattern = /\bfiles?\b/i;
+  const retentionClaimPattern =
+    /\b(?:retained|stores?|supports?|includes?|records?(?:ed)?)\b/i;
+  const negationPattern = /\b(?:no|not|never|without|none|neither|ignor\w*)\b/i;
+  return claimSegments(source).find(
+    (sentence) =>
+      fileMentionPattern.test(sentence) &&
+      retentionClaimPattern.test(sentence) &&
+      !negationPattern.test(sentence)
+  );
+}

--- a/scripts/product-page-claims.mjs
+++ b/scripts/product-page-claims.mjs
@@ -1,13 +1,18 @@
-// Shared wording guard for the public product pages.
+// Shared wording guard for public docs (SBS-780, SBS-832).
 //
-// Cubby stopped storing copied files as history in v1.2.4, so the pages must
-// not advertise file-list history again. The guard has to tell a claim apart
-// from a disclaimer: "Cubby does not store file lists" is a sentence we *want*
-// to be free to write, so a bare keyword match would fail the release for
-// saying the true thing.
+// Cubby stopped storing copied files as history in v1.2.4, so README,
+// SECURITY.md, and the product pages must not advertise file-list history
+// again. The guard has to tell a claim apart from a disclaimer: "Cubby does
+// not store file lists" is a sentence we *want* to be free to write, so a
+// bare keyword match would fail the release for saying the true thing.
+//
+// The original README lie was a table cell with no verb ("...and file lists").
+// The original SECURITY.md lie used "file-drop lists" / "retained". Both
+// have to count as mentions.
 
-/** Matches "file list(s)", "file-list(s)", and "copied file(s)". */
-const FILE_LIST_MENTION = /\b(?:file[\s-]*lists?|copied files?)\b/gi;
+/** Matches "file list(s)", "file-list(s)", "file-drop list(s)", and "copied file(s)". */
+const FILE_LIST_MENTION =
+  /\b(?:file[\s-]*lists?|file[\s-]*drops?(?:\s+lists?)?|copied files?)\b/gi;
 
 /** Verbs that assert support for whatever noun follows them. */
 const CLAIM_VERB =

--- a/scripts/product-page-claims.test.mjs
+++ b/scripts/product-page-claims.test.mjs
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
 import { findFileListHistoryClaims } from './product-page-claims.mjs';
@@ -100,4 +103,41 @@ test('gerund disclaimers are not reported', () => {
     findFileListHistoryClaims('<p>Ignoring file lists since v1.2.4.</p>'),
     []
   );
+});
+
+// SBS-780: the claims that were on main at cf916e9. The weak sentence
+// scan in check-release.mjs misses the README table cell (no verb). The
+// helper missed "file-drop lists" until the mention pattern included it.
+
+test('the original README table cell is a claim even without a verb', () => {
+  const row =
+    '| Text, HTML, RTF, images, and file lists | AES-256-GCM encryption for stored clipboard payloads |';
+  const claims = findFileListHistoryClaims(row);
+  assert.equal(claims.length, 1);
+  assert.match(claims[0], /file lists/);
+});
+
+test('the original SECURITY.md file-drop sentence is a claim', () => {
+  const sentence =
+    'Core Windows clipboard representations are retained together: Unicode text, HTML, RTF, file-drop lists, and images.';
+  const claims = findFileListHistoryClaims(sentence);
+  assert.equal(claims.length, 1);
+  assert.match(claims[0], /file-drop lists/);
+});
+
+test('a negated file-drop sentence is not a claim', () => {
+  assert.deepEqual(
+    findFileListHistoryClaims(
+      'Cubby does not retain file-drop lists as clipboard history.'
+    ),
+    []
+  );
+});
+
+test('live README.md and SECURITY.md do not claim file-list history', async () => {
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  for (const relative of ['README.md', 'SECURITY.md']) {
+    const source = await readFile(path.join(root, relative), 'utf8');
+    assert.deepEqual(findFileListHistoryClaims(source), [], relative);
+  }
 });

--- a/scripts/product-page-claims.test.mjs
+++ b/scripts/product-page-claims.test.mjs
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
-import { findFileListHistoryClaims } from './product-page-claims.mjs';
+import { claimSegments, findFileListHistoryClaims } from './product-page-claims.mjs';
 
 test('a positive support claim is reported', () => {
   const claims = findFileListHistoryClaims(
@@ -140,4 +140,44 @@ test('live README.md and SECURITY.md do not claim file-list history', async () =
     const source = await readFile(path.join(root, relative), 'utf8');
     assert.deepEqual(findFileListHistoryClaims(source), [], relative);
   }
+});
+
+// The mention needs "list" after "drop". A bare "file drop" was both too wide
+// and self-cancelling: NEGATION contains \bdrops\b, so the plural negated its
+// own no-verb cell while the singular reported a false claim.
+
+test('a bare file-drop mention is not a claim', () => {
+  assert.deepEqual(
+    findFileListHistoryClaims(
+      'Windows file-drop (CF_HDROP) is a path list, not clipboard content.'
+    ),
+    []
+  );
+  assert.deepEqual(findFileListHistoryClaims('<p>Use the file drop-down.</p>'), []);
+});
+
+test('a no-verb cell naming file-drop lists is still a claim', () => {
+  const row = '| Text, HTML, RTF, images, and file-drop lists | Encrypted at rest |';
+  const claims = findFileListHistoryClaims(row);
+  assert.equal(claims.length, 1);
+  assert.match(claims[0], /file-drop lists/);
+});
+
+// claimSegments is what the weaker \bfiles?\b scan in check-release.mjs uses.
+// A [.!?] split alone does not break at `.</p>` or `disk.",`, which joined a
+// whole install-steps section into one span.
+
+test('claimSegments breaks at markup and JSON boundaries', () => {
+  const page =
+    '<p>A file will save to your computer.</p>\n<p>This includes a SmartScreen warning.</p>';
+  const found = claimSegments(page).find(
+    (segment) => /\bfiles?\b/i.test(segment) && /\bincludes?\b/i.test(segment)
+  );
+  assert.equal(found, undefined, 'the install steps must not read as one sentence');
+
+  const locale = '{\n  "a": "Leftover files stay on disk.",\n  "b": "This includes the log."\n}';
+  const joined = claimSegments(locale).find(
+    (segment) => /\bfiles?\b/i.test(segment) && /\bincludes?\b/i.test(segment)
+  );
+  assert.equal(joined, undefined, 'two locale strings must not read as one sentence');
 });

--- a/scripts/product-page-claims.test.mjs
+++ b/scripts/product-page-claims.test.mjs
@@ -4,7 +4,11 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
-import { claimSegments, findFileListHistoryClaims } from './product-page-claims.mjs';
+import {
+  claimSegments,
+  findFileListHistoryClaims,
+  findWeakerFileRetentionClaim,
+} from './product-page-claims.mjs';
 
 test('a positive support claim is reported', () => {
   const claims = findFileListHistoryClaims(
@@ -180,4 +184,10 @@ test('claimSegments breaks at markup and JSON boundaries', () => {
     (segment) => /\bfiles?\b/i.test(segment) && /\bincludes?\b/i.test(segment)
   );
   assert.equal(joined, undefined, 'two locale strings must not read as one sentence');
+});
+
+test('weaker file-retention scan treats no/without as negation', () => {
+  assert.equal(findWeakerFileRetentionClaim('No files are retained.'), undefined);
+  assert.equal(findWeakerFileRetentionClaim('Without storing files.'), undefined);
+  assert.match(findWeakerFileRetentionClaim('Cubby stores files.') ?? '', /stores files/);
 });


### PR DESCRIPTION
## Summary
- File-list capture stays unsupported. README and SECURITY.md on main already say copied files are ignored (PR 198). This PR does not restore capture.
- A user who reads README, SECURITY.md, the site, press-kit, or Settings copy still sees text/HTML/RTF/images only. The original claim cannot return without failing release:check.
- findFileListHistoryClaims now treats the two claims from cf916e9 as mentions: a README table cell with no verb, and SECURITY.md file-drop lists. Applied to README, SECURITY.md, public product pages, press-kit, and en.json.
- The weaker sentence scan stays as a second detector. BASELINE_AUDIT.md current-status row no longer claims file-list preservation.

## Quality gate

Required CI is the test job.
Ran: claims tests 16 pass; release metadata consistent; site pages validated; action pins checked; helper tests pass.
Not run: Windows crate suite; JS package-manager jobs. No Rust or frontend files changed.

## Fail without the fix

Restoring the original README table cell fails release-check on README.md.
Reverting only the file-drop mention pattern fails the new SECURITY.md test (0 claims instead of 1).
On main before this PR the weak scan missed the table cell (no verb) and the helper missed file-drop lists.

## Sweep

Searched user-facing docs for file-list / copied-file / file-drop wording.
README and SECURITY already correct on main (PR 198); now gated.
privacy and support already correct (PR 206); now gated with index, start, terms, press-kit, and en.json.
BASELINE_AUDIT current-status row corrected; not added to the release gate (internal snapshot).
CHANGELOG v0.1.0-beta.1 historical Added line left as history; v1.2.4 documents the reversal.
Reliability/probe docs already say files are ignored. In-app file list comments are multi-select gestures.

## What this change makes more likely

The helper now fires on file-drop wording and on table cells with no verb. A disclaimer must still carry a negation or release-check fails. Pointing the gate at CHANGELOG would fail the historical beta Added line; we did not.

## Leftovers / gaps

- Did not restore file-list capture.
- Did not rewrite historical CHANGELOG entries.
- Did not add BASELINE_AUDIT to the release gate.
- Did not add a v1.3.2 changelog bullet (already-released version; user-facing copy fixed in PR 198 and 206).
- Did not run Windows crate tests or JS package-manager jobs.
- Linear SBS-780 stays In Progress / open. Not marked Done. Not merged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent README and SECURITY from claiming file-list history in release checks
> - Extends [check-release.mjs](https://github.com/tsouth89/cubby-clipboard/pull/235/files#diff-14ac66f5d0a1f9e003460f1b27bce6e68f7665390d99e23d897038130d21cdca) to validate README.md, SECURITY.md, product pages, press-kit, and frontend locale strings against two new checks: explicit file-list history claims and weaker generic file-retention claims.
> - Adds `findWeakerFileRetentionClaim` and exports `claimSegments` from [product-page-claims.mjs](https://github.com/tsouth89/cubby-clipboard/pull/235/files#diff-4971434621030568f03454596f791852ca2d50bf85d07a35065be9ffb776a524) to support consistent, HTML/JSON-aware sentence segmentation across all checked documents.
> - Broadens `FILE_LIST_MENTION` to match 'file-drop lists' and 'copied files' while avoiding false positives on bare 'file drop'.
> - Updates [docs/BASELINE_AUDIT.md](https://github.com/tsouth89/cubby-clipboard/pull/235/files#diff-b62360ab656ef927715b6f5d22c70dfe835ffd2da402556b22aa6382d2e676a8) to note that file-list history was added and later removed and that copied files are ignored.
> - Behavioral Change: the release check now fails if any user-facing doc contains a file-list history claim or an unnegated generic file-retention claim.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db58671.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->