### PR TITLE
SBS-999: Parse CF_HTML offsets without aborting on a malformed header

### DIFF
--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -196,7 +196,7 @@ for (const encryptedStorageGate of [
 
 for (const clipboardFormatGate of [
   'clip_formats',
-  'get_html()',
+  'clipboard_html_document(',
   'get_rich_text()',
   'ClipboardContent::Html',
   'ClipboardContent::Rtf',

--- a/src-tauri/src/cf_html.rs
+++ b/src-tauri/src/cf_html.rs
@@ -1,14 +1,19 @@
-//! CF_HTML assembly for clipboard writes.
+//! CF_HTML assembly and capture parsing.
 //!
-//! Capture stores the *document* part of a CF_HTML payload (clipboard-rs
-//! `get_html` returns the StartHTML..EndHTML slice, header stripped). Writing
-//! that document back raw produces an invalid "HTML Format" entry that
-//! Office-class apps reject, so every restore must re-attach a header with
-//! correct byte offsets.
+//! Capture stores the *document* part of a CF_HTML payload (the StartHTML..EndHTML
+//! slice, header stripped). Writing that document back raw produces an invalid
+//! "HTML Format" entry that Office-class apps reject, so every restore must
+//! re-attach a header with correct byte offsets.
 //!
 //! Restores must hash the exact bytes a re-capture of our own write will read
 //! back, so [`document`] (the normalized StartHTML..EndHTML slice) feeds the
 //! ignore-hash material and [`to_cf_html`] produces the clipboard payload.
+//!
+//! Capture must not call clipboard-rs `get_html`: that helper slices the
+//! StartHTML..EndHTML range with `str[]` after only checking that
+//! `end - start <= len`, so a header whose `EndHTML` is past the payload
+//! panics. Release builds `panic = "abort"`, so that kills the process
+//! (SBS-999). [`html_document_from_cf_html`] reads raw bytes and uses `get`.
 
 const START_FRAGMENT_MARKER: &str = "<!--StartFragment-->";
 const END_FRAGMENT_MARKER: &str = "<!--EndFragment-->";
@@ -17,6 +22,39 @@ const END_FRAGMENT_MARKER: &str = "<!--EndFragment-->";
 /// should, but never double-wrap if one slips through.
 fn is_cf_html(payload: &str) -> bool {
     payload.starts_with("Version:") && payload.contains("StartHTML:")
+}
+
+/// Document slice from a raw CF_HTML clipboard payload.
+///
+/// Offsets are byte indexes from the start of the payload. Out-of-range,
+/// inverted, or non-UTF-8 ranges are discarded instead of sliced.
+pub(crate) fn html_document_from_cf_html(payload: &[u8]) -> Option<String> {
+    let start = cf_html_offset(payload, "StartHTML").unwrap_or(0);
+    let end = cf_html_offset(payload, "EndHTML").unwrap_or(payload.len());
+    let document = payload.get(start..end)?;
+    String::from_utf8(document.to_vec()).ok()
+}
+
+fn cf_html_offset(payload: &[u8], key: &str) -> Option<usize> {
+    let header_end = payload
+        .iter()
+        .position(|&byte| byte == b'<')
+        .unwrap_or(payload.len());
+    let header = std::str::from_utf8(payload.get(..header_end)?).ok()?;
+    for line in header.lines() {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if name != key {
+            continue;
+        }
+        let digits = value.trim();
+        if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+            return None;
+        }
+        return digits.parse().ok();
+    }
+    None
 }
 
 /// Normalize stored HTML into the document that will sit between StartHTML and
@@ -77,7 +115,7 @@ pub(crate) fn to_cf_html(html: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{document, to_cf_html};
+    use super::{document, html_document_from_cf_html, to_cf_html};
 
     fn header_offset(payload: &str, key: &str) -> usize {
         payload
@@ -136,5 +174,47 @@ mod tests {
         let end_fragment = header_offset(&payload, "EndFragment");
         // No markers: the whole document is the fragment.
         assert_eq!(&payload[start_fragment..end_fragment], doc);
+    }
+
+    #[test]
+    fn html_document_from_cf_html_reads_a_well_formed_payload() {
+        let fragment = "<b>héllo</b>";
+        let payload = to_cf_html(fragment);
+        let parsed = html_document_from_cf_html(payload.as_bytes()).expect("valid CF_HTML");
+        assert_eq!(parsed, document(fragment));
+    }
+
+    #[test]
+    fn html_document_from_cf_html_rejects_the_sbs_999_oversize_end_offset() {
+        // Difference EndHTML-StartHTML is 60, payload is 83 bytes: clipboard-rs
+        // 0.2.4 treats that as valid, then panics on data[60..120].
+        let payload = concat!(
+            "Version:0.9\r\n",
+            "StartHTML:0000000060\r\n",
+            "EndHTML:0000000120\r\n",
+            "<html><body>hi</body></html>"
+        );
+        assert_eq!(payload.len(), 83);
+        assert!(html_document_from_cf_html(payload.as_bytes()).is_none());
+    }
+
+    #[test]
+    fn html_document_from_cf_html_rejects_inverted_offsets() {
+        let payload = concat!(
+            "Version:0.9\r\n",
+            "StartHTML:0000000080\r\n",
+            "EndHTML:0000000040\r\n",
+            "<html></html>"
+        );
+        assert!(html_document_from_cf_html(payload.as_bytes()).is_none());
+    }
+
+    #[test]
+    fn html_document_from_cf_html_rejects_a_slice_that_is_not_utf8() {
+        let header = "Version:0.9\r\nStartHTML:0000000055\r\nEndHTML:0000000057\r\n";
+        assert_eq!(header.len(), 55);
+        let mut payload = header.as_bytes().to_vec();
+        payload.extend_from_slice(&[0x80, 0x80]);
+        assert!(html_document_from_cf_html(&payload).is_none());
     }
 }

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -981,10 +981,8 @@ fn clipboard_is_cleared() -> bool {
             }
             // Empty plain text must not count as a clear if HTML/RTF still hold
             // content. Those copies are stored as rich clips (SBS-924).
-            if let Ok(html) = ctx.get_html() {
-                if !html.is_empty() {
-                    return false;
-                }
+            if clipboard_html_document(&ctx).is_some_and(|html| !html.is_empty()) {
+                return false;
             }
             if let Ok(rtf) = ctx.get_rich_text() {
                 if !rtf.is_empty() {
@@ -1192,7 +1190,7 @@ fn materialize_clipboard_content_once(attempt: u32) -> MaterializeOnce {
 
     if let Ok(ctx) = ClipboardContext::new() {
         let text = ctx.get_text().ok();
-        let html = ctx.get_html().ok();
+        let html = clipboard_html_document(&ctx);
         let rtf = ctx.get_rich_text().ok();
         let text_read = observed_payload(&text, clipboard_has_unicode_text_format());
         let html_read = observed_payload(&html, clipboard_has_html_format());
@@ -1276,6 +1274,17 @@ fn clipboard_has_html_format() -> bool {
     format != 0
         && unsafe { windows::Win32::System::DataExchange::IsClipboardFormatAvailable(format) }
             .is_ok()
+}
+
+/// HTML document from the clipboard, parsed without clipboard-rs `get_html`.
+///
+/// `get_html` slices StartHTML..EndHTML with `str[]` after only checking that
+/// `end - start <= len`. A header whose EndHTML is past the payload panics, and
+/// release builds abort the process (SBS-999). Raw bytes plus
+/// [`crate::cf_html::html_document_from_cf_html`] drop the format instead.
+fn clipboard_html_document(ctx: &ClipboardContext) -> Option<String> {
+    let bytes = ctx.get_buffer("HTML Format").ok()?;
+    crate::cf_html::html_document_from_cf_html(&bytes)
 }
 
 #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## Summary

- Capture no longer calls clipboard-rs `get_html`, which slices `StartHTML..EndHTML` after only checking that `end - start` fits in the payload. A local process can put `HTML Format` on the clipboard with `EndHTML` past the bytes; that panics, and release builds abort the process.
- Raw `HTML Format` bytes are parsed with `get`. Out-of-range, inverted, or non-UTF-8 ranges drop the format instead of taking down Cubby.
- Regression test uses the 83-byte payload from the ticket (`end - start = 60`, `EndHTML = 120`).

Fixes https://linear.app/southboundsoftware/issue/SBS-999/any-local-process-can-abort-cubby-with-one-malformed-html-format

## Test plan

- [x] `rustc --test src-tauri/src/cf_html.rs`: 8 passed, including the SBS-999 oversize EndHTML case
- [ ] Windows CI `cargo test --all-targets` / clippy (crate does not compile on this Linux box)


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parse CF_HTML offsets without aborting on malformed headers
> - Adds `html_document_from_cf_html` in [`cf_html.rs`](https://github.com/tsouth89/cubby-clipboard/pull/237/files#diff-76a0cba31523a6b7dc748bf714e73a8697675e65f1ef7edf6cc0899712437c01) to safely extract the HTML document slice from a raw CF_HTML payload using `StartHTML`/`EndHTML` byte offsets, returning `None` for out-of-range, inverted, or non-UTF-8 slices instead of panicking.
> - Adds `cf_html_offset` helper to parse numeric offsets from CF_HTML headers, returning `None` on invalid or missing values.
> - Replaces `ctx.get_html()` calls in [`clipboard.rs`](https://github.com/tsouth89/cubby-clipboard/pull/237/files#diff-8b53e1d4014cd55d2bf889ca51d824e6f3c4f2e3775e5b8a5d2670c416a3b984) with a new `clipboard_html_document` helper that reads raw bytes via `ctx.get_buffer` and delegates to `html_document_from_cf_html`, bypassing clipboard-rs behavior that aborts on malformed input.
> - Updates the release check gate string in [`scripts/check-release.mjs`](https://github.com/tsouth89/cubby-clipboard/pull/237/files#diff-14ac66f5d0a1f9e003460f1b27bce6e68f7665390d99e23d897038130d21cdca) from `get_html()` to `clipboard_html_document(` to reflect the new call site.
> - Behavioral Change: malformed CF_HTML on the clipboard is now treated as absent rather than causing a process abort in `clipboard_is_cleared` and `materialize_clipboard_content_once`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3f197f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->