### PR TITLE
SBS-991: Start Cubby even when the Win+V UDP channel cannot bind

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -318,10 +318,10 @@ pub fn run_app() {
                 SettingsManager::new(app.handle(), &db_for_settings).await
             });
             app.manage(Arc::new(settings_manager));
-            let shortcut_manager =
-                win_v_replacement::WinVReplacementManager::new(app.handle().clone())
-                    .map_err(std::io::Error::other)?;
-            app.manage(Arc::new(shortcut_manager));
+            let shortcut_manager = Arc::new(win_v_replacement::WinVReplacementManager::new(
+                app.handle().clone(),
+            ));
+            app.manage(shortcut_manager);
 
             let handle = app.handle().clone();
             let db_for_clipboard = db_arc.clone();

--- a/src-tauri/src/win_v_replacement.rs
+++ b/src-tauri/src/win_v_replacement.rs
@@ -40,7 +40,30 @@ pub struct WinVReplacementManager {
 }
 
 impl WinVReplacementManager {
-    pub fn new(app: AppHandle) -> Result<Self, String> {
+    pub fn new(app: AppHandle) -> Self {
+        match Self::bind_channel(app) {
+            Ok(manager) => manager,
+            Err(error) => {
+                log::error!(
+                    "WIN_V: Shortcut channel unavailable; Win+V replacement is off this session: {error}"
+                );
+                Self::without_channel()
+            }
+        }
+    }
+
+    fn without_channel() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                state: Mutex::new(HelperState::default()),
+                watchdog_started: AtomicBool::new(false),
+                activation_port: 0,
+                activation_token: String::new(),
+            }),
+        }
+    }
+
+    fn bind_channel(app: AppHandle) -> Result<Self, String> {
         // Fail closed if we cannot mint a token: an unauthenticated bind is
         // the SBS-809 bug. Do not bind first and "add a token later".
         let activation_token = crate::win_v_activation::generate_token()?;
@@ -106,6 +129,9 @@ impl WinVReplacementManager {
     }
 
     pub fn configure(&self, enabled: bool, hotkey: Option<String>) -> Result<(), String> {
+        if enabled && self.inner.activation_port == 0 {
+            return Err("Cubby shortcut channel is unavailable this session".to_string());
+        }
         let mut state = self
             .inner
             .state
@@ -243,5 +269,20 @@ fn stop_child(child: &mut Option<Child>) {
     if let Some(mut running) = child.take() {
         let _ = running.kill();
         let _ = running.wait();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WinVReplacementManager;
+
+    #[test]
+    fn missing_channel_refuses_enable_and_allows_disable() {
+        let manager = WinVReplacementManager::without_channel();
+        assert!(
+            manager.configure(true, None).is_err(),
+            "Win+V replacement must not start without a shortcut channel"
+        );
+        assert!(manager.configure(false, None).is_ok());
     }
 }


### PR DESCRIPTION
## Summary

- `WinVReplacementManager::new` was called with `?` during setup. A bind or token failure panics the GUI process with no window, including when Win+V replacement is off.
- Setup now always keeps a manager. If the channel cannot be created, Win+V replacement stays off for the session, the error is logged, and existing startup-notice handling can surface it when replacement is enabled.
- Enabling replacement without a channel returns an error instead of spawning a helper that nobody can hear.

Fixes https://linear.app/southboundsoftware/issue/SBS-991/a-failed-activation-socket-bind-aborts-cubby-at-launch-with-no-message

## Test plan

- [x] `missing_channel_refuses_enable_and_allows_disable`
- [ ] Windows CI `cargo test` / clippy


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Start Cubby when the Win+V UDP channel cannot bind
> - `WinVReplacementManager::new` in [win_v_replacement.rs](https://github.com/tsouth89/cubby-clipboard/pull/238/files#diff-939ae675cd2312cbdeaba6119e337096e8b02013895f212c7b0419205377c207) now always returns `Self` instead of `Result<Self, String>`. On bind failure it logs the error and falls back to a `without_channel` state (`activation_port = 0`).
> - `configure` rejects `enabled=true` with an error when `activation_port` is 0, so the feature is silently disabled for the session rather than crashing startup.
> - [lib.rs](https://github.com/tsouth89/cubby-clipboard/pull/238/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c) removes the `map_err(...)?` propagation so app setup continues even when the shortcut channel is unavailable.
> - Behavioral Change: users whose UDP bind fails will no longer see a startup error; the Win+V replacement feature will be inactive for that session with no other indication beyond a log entry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9bcaeb1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->