### PR TITLE
SBS-989: Keep the Win+V listener alive after an oversized UDP datagram

### DIFF
--- a/src-tauri/src/win_v_activation.rs
+++ b/src-tauri/src/win_v_activation.rs
@@ -102,6 +102,25 @@ pub fn token_matches(payload: &[u8], token: &str) -> bool {
     constant_time_eq(payload, &expected)
 }
 
+/// Whether a `recv_from` failure should stop the shortcut listener.
+///
+/// On Windows, a datagram larger than the recv buffer is `WSAEMSGSIZE`
+/// (10040), not a truncated `Ok`. Treating that as fatal killed the only
+/// reader thread for the rest of the session (SBS-989). Oversized packets
+/// and the usual transient socket errors are discarded; a dead socket is not.
+pub fn activation_recv_error_is_fatal(error: &std::io::Error) -> bool {
+    if matches!(
+        error.kind(),
+        std::io::ErrorKind::WouldBlock
+            | std::io::ErrorKind::Interrupted
+            | std::io::ErrorKind::TimedOut
+    ) {
+        return false;
+    }
+    // WSAEMSGSIZE. Matched by raw code so Linux tests can construct it.
+    error.raw_os_error() != Some(10040)
+}
+
 pub fn decide_activation(
     payload: &[u8],
     source: SocketAddr,
@@ -276,5 +295,34 @@ mod tests {
         assert_eq!(token_from_args(["--activation-token", "activate"]), None);
         assert_eq!(token_from_args(["--activation-port", "1234"]), None);
         assert_eq!(token_from_args(["--activation-token"]), None);
+    }
+
+    #[test]
+    fn oversized_datagram_does_not_kill_the_listener() {
+        let error = std::io::Error::from_raw_os_error(10040);
+        assert!(
+            !activation_recv_error_is_fatal(&error),
+            "WSAEMSGSIZE must keep the shortcut listener running"
+        );
+    }
+
+    #[test]
+    fn interrupted_and_would_block_are_not_fatal() {
+        assert!(!activation_recv_error_is_fatal(&std::io::Error::new(
+            std::io::ErrorKind::Interrupted,
+            "interrupted"
+        )));
+        assert!(!activation_recv_error_is_fatal(&std::io::Error::new(
+            std::io::ErrorKind::WouldBlock,
+            "would block"
+        )));
+    }
+
+    #[test]
+    fn a_dead_socket_is_still_fatal() {
+        assert!(activation_recv_error_is_fatal(&std::io::Error::new(
+            std::io::ErrorKind::ConnectionAborted,
+            "closed"
+        )));
     }
 }

--- a/src-tauri/src/win_v_replacement.rs
+++ b/src-tauri/src/win_v_replacement.rs
@@ -82,6 +82,12 @@ impl WinVReplacementManager {
                         }
                     }
                     Err(error) => {
+                        if !crate::win_v_activation::activation_recv_error_is_fatal(&error) {
+                            log::debug!(
+                                "WIN_V: Ignored oversized or transient shortcut datagram: {error}"
+                            );
+                            continue;
+                        }
                         log::error!("WIN_V: Shortcut activation listener failed: {error}");
                         return;
                     }


### PR DESCRIPTION
## Summary

- On Windows, `recv_from` into a 57-byte buffer returns `WSAEMSGSIZE` for a larger datagram instead of truncating. The listener treated any `Err` as fatal and returned, so one oversized localhost packet killed Win+V for the rest of the session.
- Oversized and transient socket errors are now ignored. A dead socket still stops the thread.
- Unit tests cover `WSAEMSGSIZE` (raw 10040), `Interrupted`, `WouldBlock`, and a still-fatal abort.

Fixes https://linear.app/southboundsoftware/issue/SBS-989/one-oversized-udp-datagram-from-any-local-process-permanently-kills

## Test plan

- [x] Tests added next to the existing activation-token cases
- [ ] Windows CI `cargo test` / clippy (crate does not compile on this Linux box)


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep the Win+V UDP listener alive after an oversized datagram
> The listener thread in `WinVReplacementManager` previously exited on any `recv_from` error, including the transient Windows error `WSAEMSGSIZE` (10040) triggered by oversized UDP datagrams. A new helper `activation_recv_error_is_fatal` in [win_v_activation.rs](https://github.com/tsouth89/cubby-clipboard/pull/239/files#diff-65cc0848986ff23d5302c331d6622b8b1fa964de794e420007434219c29e26ea) classifies errors: `WouldBlock`, `Interrupted`, `TimedOut`, and `WSAEMSGSIZE` are non-fatal (loop continues), all others are fatal (thread exits). [win_v_replacement.rs](https://github.com/tsouth89/cubby-clipboard/pull/239/files#diff-939ae675cd2312cbdeaba6119e337096e8b02013895f212c7b0419205377c207) now calls this helper on each error to decide whether to continue or return.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f128676.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->