### PR TITLE
SBS-1004: Close the process handle after clipboard owner lookup

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -27,6 +27,8 @@ use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 #[cfg(target_os = "windows")]
+use windows::Win32::Foundation::CloseHandle;
+#[cfg(target_os = "windows")]
 use windows::Win32::Foundation::MAX_PATH;
 #[cfg(target_os = "windows")]
 use windows::Win32::Graphics::Gdi::{
@@ -2926,6 +2928,18 @@ fn resolve_source_app_info(identity: Option<SourceAppIdentity>) -> SourceAppInfo
             Ok(h) => h,
             Err(_) => return (None, None, None, None, false),
         };
+        // OpenProcess returns a kernel handle. Every other capture path
+        // (paste target, Win+V helper) CloseHandle's it; this one did not, so
+        // each captured clip leaked a process handle until Cubby exited (SBS-1004).
+        struct ProcessHandleGuard(windows::Win32::Foundation::HANDLE);
+        impl Drop for ProcessHandleGuard {
+            fn drop(&mut self) {
+                unsafe {
+                    let _ = CloseHandle(self.0);
+                }
+            }
+        }
+        let _process_guard = ProcessHandleGuard(process_handle);
 
         let mut name_buffer = [0u16; MAX_PATH as usize];
         let name_size = GetModuleBaseNameW(process_handle, None, &mut name_buffer);


### PR DESCRIPTION
## Summary

- `OpenProcess` on the capture owner-lookup path was never `CloseHandle`'d, unlike paste targeting and the Win+V helper.
- A drop guard now closes the handle on every return, including error paths.

Fixes https://linear.app/southboundsoftware/issue/SBS-1004/every-clipboard-capture-leaks-a-process-handle

## Test plan

- [ ] Windows CI `cargo test` / clippy


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix process handle leak in `resolve_source_app_info` after clipboard owner lookup
> Each call to `resolve_source_app_info` in [clipboard.rs](https://github.com/tsouth89/cubby-clipboard/pull/240/files#diff-8b53e1d4014cd55d2bf889ca51d824e6f3c4f2e3775e5b8a5d2670c416a3b984) was leaking a Windows `HANDLE` acquired via `OpenProcess`. Adds a `ProcessHandleGuard` struct with a `Drop` implementation that calls `CloseHandle`, ensuring the handle is released when the function returns.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b367c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->