### PR TITLE
SBS-1003: Retry forget-on-clear instead of waiting for a second clear

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -2556,12 +2556,18 @@ async fn process_clipboard_clear(
         return;
     }
 
-    let restore_marker = |recent: RecentCapture| {
+    // Reports whether the marker went back. A newer capture landing while we
+    // held it means this clear no longer describes what is in history, so the
+    // caller must not retry: the retry would take that newer marker and delete
+    // a clip the user never cleared.
+    let restore_marker = |recent: RecentCapture| -> bool {
         let mut lock = LAST_ACCEPTED_CAPTURE.lock();
         // Only restore if nothing newer was captured while we held the marker.
         if lock.is_none() {
             *lock = Some(recent);
+            return true;
         }
+        false
     };
 
     let _guard = CLIPBOARD_SYNC.lock().await;
@@ -2603,8 +2609,9 @@ async fn process_clipboard_clear(
                 "CLIPBOARD: forget-on-clear skipped for sequence {sequence} (clip {}); lookup failed, so the retry marker was restored: {error}",
                 taken.uuid
             );
-            restore_marker(taken);
-            schedule_forget_retry(app, db, sequence, attempts_left);
+            if restore_marker(taken) {
+                schedule_forget_retry(app, db, sequence, attempts_left);
+            }
             return;
         }
     };
@@ -2627,8 +2634,9 @@ async fn process_clipboard_clear(
         Ok(tx) => tx,
         Err(error) => {
             log::error!("CLIPBOARD: Failed to begin clear-forget transaction: {error}");
-            restore_marker(recent);
-            schedule_forget_retry(app, db, sequence, attempts_left);
+            if restore_marker(recent) {
+                schedule_forget_retry(app, db, sequence, attempts_left);
+            }
             return;
         }
     };
@@ -2668,8 +2676,9 @@ async fn process_clipboard_clear(
                 "CLIPBOARD: Failed to forget cleared capture {}: {error}",
                 recent.uuid
             );
-            restore_marker(recent);
-            schedule_forget_retry(app, db, sequence, attempts_left);
+            if restore_marker(recent) {
+                schedule_forget_retry(app, db, sequence, attempts_left);
+            }
             return;
         }
     };
@@ -2690,8 +2699,9 @@ async fn process_clipboard_clear(
             "CLIPBOARD: Failed to commit clear-forget for {}: {error}",
             recent.uuid
         );
-        restore_marker(recent);
-        schedule_forget_retry(app, db, sequence, attempts_left);
+        if restore_marker(recent) {
+            schedule_forget_retry(app, db, sequence, attempts_left);
+        }
         return;
     }
 

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -79,6 +79,11 @@ pub static CLIPBOARD_SYNC: Lazy<Arc<tokio::sync::Mutex<()>>> =
 /// Password-manager extensions typically clear within tens of seconds. Keep this
 /// short so a deliberate later clear does not erase an intentional keep.
 const CLIPBOARD_CLEAR_FORGET_WINDOW: Duration = Duration::from_secs(90);
+/// SQLITE_BUSY during forget-on-clear used to restore the marker and wait for
+/// another clear that never comes. Retry the same clear a few times instead
+/// (SBS-1003).
+const FORGET_ON_CLEAR_ATTEMPTS: u8 = 3;
+const FORGET_ON_CLEAR_RETRY_DELAY: Duration = Duration::from_millis(80);
 /// How long a self-write marker stays valid. The capture of our own write
 /// normally arrives within milliseconds, so this is generous. It exists because
 /// an unbounded marker is never cleaned up when that capture never arrives at
@@ -102,7 +107,7 @@ struct RecentCapture {
 }
 
 mod forget_on_clear;
-use forget_on_clear::ForgetClipLookup;
+use forget_on_clear::{next_forget_attempts, ForgetClipLookup};
 
 /// Pure helper for SOU-316 unit tests: only empty clears within the window
 /// forget the last clip. A later clear must leave history alone.
@@ -269,6 +274,7 @@ pub fn init(app: &AppHandle, db: Arc<Database>) {
                         app_for_consumer.clone(),
                         db_for_consumer.clone(),
                         sequence,
+                        FORGET_ON_CLEAR_ATTEMPTS,
                     )
                     .await;
                 }
@@ -2500,7 +2506,12 @@ async fn process_clipboard_snapshot(
 /// ignored-apps list cannot help) and almost always empty the clipboard a few
 /// seconds later. Only empty/clear events trigger this — never a new non-empty
 /// copy. Pinned items are never removed.
-async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u32) {
+async fn process_clipboard_clear(
+    app: AppHandle,
+    db: Arc<Database>,
+    sequence: u32,
+    attempts_left: u8,
+) {
     use crate::settings_manager::SettingsManager;
     use tauri::Manager;
 
@@ -2593,6 +2604,7 @@ async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u3
                 taken.uuid
             );
             restore_marker(taken);
+            schedule_forget_retry(app, db, sequence, attempts_left);
             return;
         }
     };
@@ -2616,6 +2628,7 @@ async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u3
         Err(error) => {
             log::error!("CLIPBOARD: Failed to begin clear-forget transaction: {error}");
             restore_marker(recent);
+            schedule_forget_retry(app, db, sequence, attempts_left);
             return;
         }
     };
@@ -2656,6 +2669,7 @@ async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u3
                 recent.uuid
             );
             restore_marker(recent);
+            schedule_forget_retry(app, db, sequence, attempts_left);
             return;
         }
     };
@@ -2677,6 +2691,7 @@ async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u3
             recent.uuid
         );
         restore_marker(recent);
+        schedule_forget_retry(app, db, sequence, attempts_left);
         return;
     }
 
@@ -2700,6 +2715,20 @@ async fn process_clipboard_clear(app: AppHandle, db: Arc<Database>, sequence: u3
         }),
     );
 }
+
+/// SBS-1003: a password manager clears once. Restoring the marker without a
+/// follow-up attempt left the password in history whenever SQLITE_BUSY won
+/// that single SELECT/DELETE.
+fn schedule_forget_retry(app: AppHandle, db: Arc<Database>, sequence: u32, attempts_left: u8) {
+    let Some(remaining) = next_forget_attempts(attempts_left) else {
+        return;
+    };
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(FORGET_ON_CLEAR_RETRY_DELAY).await;
+        process_clipboard_clear(app, db, sequence, remaining).await;
+    });
+}
+
 pub(crate) fn calculate_hash(content: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(content);

--- a/src-tauri/src/clipboard/forget_on_clear.rs
+++ b/src-tauri/src/clipboard/forget_on_clear.rs
@@ -27,6 +27,12 @@ impl<T, M, E> ForgetClipLookup<T, M, E> {
     }
 }
 
+/// Remaining attempts after this one failed. `None` means stop restoring and
+/// waiting — a password manager only clears once (SBS-1003).
+pub(crate) fn next_forget_attempts(attempts_left: u8) -> Option<u8> {
+    attempts_left.checked_sub(1).filter(|left| *left > 0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::ForgetClipLookup;
@@ -59,5 +65,13 @@ mod tests {
             ForgetClipLookup::Found { row: (0, 0), taken } => assert_eq!(taken, "clip-uuid"),
             other => panic!("found row must keep the marker for the delete path, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn a_failed_forget_retries_twice_then_stops() {
+        assert_eq!(super::next_forget_attempts(3), Some(2));
+        assert_eq!(super::next_forget_attempts(2), Some(1));
+        assert_eq!(super::next_forget_attempts(1), None);
+        assert_eq!(super::next_forget_attempts(0), None);
     }
 }


### PR DESCRIPTION
## Summary

- `process_clipboard_clear` restored the capture marker on SQLITE_BUSY so a later clear could retry, but a password manager only clears once.
- Failed lookup / begin / DELETE / commit now restore the marker and re-run the same clear after 80ms, up to three attempts.

Fixes https://linear.app/southboundsoftware/issue/SBS-1003/sbs-831-restores-the-forget-on-clear-retry-marker-but-nothing-ever

## Test plan

- [x] Unit test: three attempts then stop
- [ ] Windows: copy a password with forget-on-clear on; force a busy DB during the clear and confirm the clip is gone after retries
- [ ] Windows CI `cargo test`

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry forget-on-clear up to 3 times on transient failures instead of dropping the operation
> - `process_clipboard_clear` in [clipboard.rs](https://github.com/tsouth89/cubby-clipboard/pull/243/files#diff-8b53e1d4014cd55d2bf889ca51d824e6f3c4f2e3775e5b8a5d2670c416a3b984) now accepts an `attempts_left` counter and schedules a retry via `schedule_forget_retry` when a transient error occurs (e.g., locked DB or failed transaction).
> - Retries are capped at 3 attempts (`FORGET_ON_CLEAR_ATTEMPTS`) with an 80ms delay (`FORGET_ON_CLEAR_RETRY_DELAY`) between each attempt.
> - `next_forget_attempts` in [forget_on_clear.rs](https://github.com/tsouth89/cubby-clipboard/pull/243/files#diff-d847f1e6a544f67702a7437ef290edf9bfb814e4980abd1ecd59d6b7975cd851) safely decrements the counter and returns `None` when exhausted, stopping further retries.
> - Retries are skipped if a newer clipboard capture has superseded the marker, preventing stale operations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6dab3be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->