### PR TITLE
SBS-990: Clear the flyout worker latch on panic

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -687,30 +687,40 @@ fn kick_flyout_worker() {
     {
         return;
     }
-    std::thread::spawn(|| loop {
-        let job = pending_flyout().lock().unwrap().take();
-        let Some((window, request)) = job else {
-            FLYOUT_WORKER_LIVE.store(false, Ordering::SeqCst);
-            if pending_flyout().lock().unwrap().is_some()
-                && FLYOUT_WORKER_LIVE
-                    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-                    .is_ok()
-            {
-                continue;
+    std::thread::spawn(|| {
+        // Clear the latch on panic as well as on a normal drain, then start a
+        // replacement if a request arrived during unwind (SBS-990).
+        struct FlyoutWorkerGuard;
+        impl Drop for FlyoutWorkerGuard {
+            fn drop(&mut self) {
+                FLYOUT_WORKER_LIVE.store(false, Ordering::SeqCst);
+                if pending_flyout()
+                    .lock()
+                    .map(|slot| slot.is_some())
+                    .unwrap_or(false)
+                {
+                    kick_flyout_worker();
+                }
             }
-            return;
-        };
-        let Some(guard) = AnimationGuard::acquire()
-            .or_else(|| AnimationGuard::acquire_within(ANIMATION_LOCK_WAIT))
-        else {
-            log::warn!("WINDOW: Flyout request dropped, animation lock still held after 1s");
-            continue;
-        };
-        match request {
-            FlyoutRequest::Show(anchor) => run_window_show(window, anchor, guard),
-            FlyoutRequest::Hide => {
-                let _ = window.hide();
-                drop(guard);
+        }
+        let _guard = FlyoutWorkerGuard;
+        loop {
+            let job = pending_flyout().lock().unwrap().take();
+            let Some((window, request)) = job else {
+                return;
+            };
+            let Some(guard) = AnimationGuard::acquire()
+                .or_else(|| AnimationGuard::acquire_within(ANIMATION_LOCK_WAIT))
+            else {
+                log::warn!("WINDOW: Flyout request dropped, animation lock still held after 1s");
+                continue;
+            };
+            match request {
+                FlyoutRequest::Show(anchor) => run_window_show(window, anchor, guard),
+                FlyoutRequest::Hide => {
+                    let _ = window.hide();
+                    drop(guard);
+                }
             }
         }
     });


### PR DESCRIPTION
## Summary

- `FLYOUT_WORKER_LIVE` was only cleared on the normal empty-queue path. A panic in the worker left it true for the session.
- A drop guard now stores false and re-kicks if a request arrived during unwind.

Fixes https://linear.app/southboundsoftware/issue/SBS-990/flyout-worker-live-has-no-drop-guard-so-a-panic-in-the-flyout-worker

## Test plan

- [ ] Windows: hotkey still opens/hides the flyout
- [ ] Windows CI `cargo test`

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clear the flyout worker latch on panic in `kick_flyout_worker`
> Wraps the flyout worker thread body in a `FlyoutWorkerGuard` drop guard that clears `FLYOUT_WORKER_LIVE` and conditionally restarts the worker if a pending request exists. Previously, a panic in the worker thread would leave the latch set, preventing future flyout requests from spawning a new worker. The restart check also uses a non-panicking mutex lock pattern to avoid a secondary panic on a poisoned mutex.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ef2da5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->