### PR TITLE
SBS-995: Reset capture dedup after clearing unpinned clips

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2590,6 +2590,7 @@ pub(crate) fn remove_clip_image_files(image_dir: &std::path::Path, image_paths: 
 pub async fn clear_unpinned_clips(db: tauri::State<'_, Arc<Database>>) -> Result<u64, String> {
     let (deleted, image_paths) = clear_clips_in_pool(&db.pool, true).await?;
     remove_clip_image_files(&db.image_dir, image_paths);
+    crate::clipboard::reset_capture_dedup();
     if deleted > 0 {
         db.search_index.invalidate();
     }


### PR DESCRIPTION
## Summary

- `clear_unpinned_clips` deleted rows but left `LAST_STABLE_HASH` pointing at the just-removed clip.
- It now calls `reset_capture_dedup`, matching `clear_all_clips`.

Fixes https://linear.app/southboundsoftware/issue/SBS-995/clear-unpinned-clips-does-not-reset-the-capture-dedup-marker-so-re

## Test plan

- [ ] Windows: copy text, Clear history (keep pinned), copy the same text again; it should reappear
- [ ] Windows CI `cargo test`

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reset capture dedup state after clearing unpinned clips
> Calls `reset_capture_dedup()` inside the `clear_unpinned_clips` command in [commands.rs](https://github.com/tsouth89/cubby-clipboard/pull/245/files#diff-59f7096c7cd88d5d187e749ca400716cd225f951e78eac3d0081ec6c28ce5dcc) so the dedup state is cleared alongside the clips. Without this, previously seen clipboard content could be incorrectly skipped after a clear.
>
> #### 🖇️ Linked Issues
> [SBS-995](https://linear.app/southboundsoftware/issue/SBS-995) — this PR implements the fix.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb8a9b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->