### PR TITLE
SBS-986: Do not rebuild idx_clips_hash on every launch

### DIFF
--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -322,14 +322,6 @@ impl Database {
 
         sqlx::query(
             r#"
-            CREATE INDEX IF NOT EXISTS idx_clips_hash ON clips(content_hash);
-        "#,
-        )
-        .execute(&self.pool)
-        .await?;
-
-        sqlx::query(
-            r#"
             CREATE INDEX IF NOT EXISTS idx_clips_folder ON clips(folder_id);
         "#,
         )
@@ -1378,6 +1370,30 @@ mod tests {
         .await
         .expect("index lookup should succeed");
         assert!(!old_index, "the old non-unique index should be replaced");
+    }
+
+    #[tokio::test]
+    async fn migrate_does_not_rebuild_the_old_hash_index_after_uniqueness() {
+        let database = migrated_database().await;
+        database
+            .enforce_content_hash_uniqueness()
+            .await
+            .expect("a fresh database has nothing to reconcile");
+        database
+            .migrate()
+            .await
+            .expect("a second migrate on an already-unique database must succeed");
+        let old_index: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_clips_hash')",
+        )
+        .fetch_one(&database.pool)
+        .await
+        .expect("index lookup should succeed");
+        assert!(
+            !old_index,
+            "startup must not rebuild the non-unique index uniqueness just dropped"
+        );
+        assert!(unique_hash_index_exists(&database).await);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- `migrate()` always created the old non-unique hash index; uniqueness then dropped it. After the first upgrade that is wasted work on every start.
- The create is gone. A test asserts a second migrate does not bring the old index back.

Fixes https://linear.app/southboundsoftware/issue/SBS-986/idx-clips-hash-is-rebuilt-and-dropped-again-on-every-single-launch-not

## Test plan

- [x] New migrate-after-uniqueness test
- [ ] Windows CI `cargo test`

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `idx_clips_hash` recreation from database migration on every launch
> The migration schema setup was unconditionally recreating the non-unique `idx_clips_hash` index on `clips(content_hash)` at every app launch. This index was removed from the DDL in [database.rs](https://github.com/tsouth89/cubby-clipboard/pull/246/files#diff-6a8f2d03587850d3f942776b1cf06ca106b6ce46ca2e5eb3bd008d7b728c327f) since a unique hash index already covers this column. A regression test verifies that `idx_clips_hash` is absent and the unique index is present after migration runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6fe31bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->