### PR TITLE
SBS-1005: Forget revealed plaintext on delete, hide, and History blur

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -625,6 +625,7 @@ function App() {
       // Cubby has no trash/recovery surface. Delete must therefore remove the
       // persisted payload immediately instead of leaving a hidden soft-delete.
       await invoke('delete_clip', { id: clipId, hardDelete: true });
+      forgetRevealed(clipId);
       setClips((currentClips) => currentClips.filter((clip) => clip.id !== clipId));
       setSelectedClipId(nextSelection);
       // Refresh counts
@@ -717,7 +718,9 @@ function App() {
           // until the reload landed, which is the whole thing being prevented.
           setClips((current) =>
             current.map((clip) =>
-              clip.id === clipId ? { ...clip, is_hidden: true, content: '', preview: '' } : clip
+              clip.id === clipId
+                ? { ...clip, is_hidden: true, content: '', preview: '', notes: null }
+                : clip
             )
           );
         }
@@ -1060,6 +1063,7 @@ function App() {
       if (!clipLoadAnnouncesSuccess(reloaded)) {
         return;
       }
+      clearRevealed();
       toast.success(
         mode === 'unpinned'
           ? t('notifications.clearUnpinnedSuccess', { count: deleted })

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -92,7 +92,8 @@ export function HistoryWindow() {
   useSystemAccent();
   const density = settings?.density ?? 'comfortable';
 
-  const { revealed, toggleReveal, forgetRevealed, updateRevealed } = useRevealedClips();
+  const { revealed, toggleReveal, forgetRevealed, updateRevealed, clearRevealed } =
+    useRevealedClips();
 
   const clipsRef = useRef<ClipboardItem[]>(clips);
   clipsRef.current = clips;
@@ -117,6 +118,24 @@ export function HistoryWindow() {
       unlisten.then((dispose) => dispose()).catch(() => undefined);
     };
   }, []);
+
+  useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    getCurrentWindow()
+      .onFocusChanged(({ payload: focused }) => {
+        if (!focused) clearRevealed();
+      })
+      .then((fn) => {
+        if (disposed) fn();
+        else unlisten = fn;
+      })
+      .catch(() => undefined);
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [clearRevealed]);
 
   // Destructured so the load callback depends on the two stamps rather than a
   // fresh object identity each render, which would reload on every keystroke.
@@ -384,6 +403,7 @@ export function HistoryWindow() {
         ids: selectedIds,
         hardDelete: true,
       });
+      selectedIds.forEach((id) => forgetRevealed(id));
       // A failed reload already speaks: ClipList shows the error panel once
       // these rows are dropped. A superseded reload belongs to a newer load.
       // Either way this handler only withholds its success toast.
@@ -393,7 +413,7 @@ export function HistoryWindow() {
       console.error('Failed to delete clips:', error);
       toast.error('Failed to delete clips');
     }
-  }, [afterBulkChange, selectedIds, selectionCount]);
+  }, [afterBulkChange, forgetRevealed, selectedIds, selectionCount]);
 
   const handleBulkPin = useCallback(
     async (pinned: boolean) => {
@@ -638,6 +658,18 @@ export function HistoryWindow() {
       try {
         const hidden = await invoke<boolean>('toggle_clip_hidden', { id: clipId });
         forgetRevealed(clipId);
+        if (hidden) {
+          // Blank the row immediately. loadClips is the only other writer, and
+          // a failed same-filter reload would otherwise keep the plaintext on
+          // screen with no error toast (SBS-1006).
+          setClips((current) =>
+            current.map((clip) =>
+              clip.id === clipId
+                ? { ...clip, is_hidden: true, content: '', preview: '', notes: null }
+                : clip
+            )
+          );
+        }
         // loadClips reports failure rather than throwing, so a stale list after
         // a failed reload would otherwise be announced as success.
         // Same-filter reload: a failure shows the stale banner over the rows,
@@ -685,6 +717,7 @@ export function HistoryWindow() {
         // Cubby has no trash, so delete removes the payload immediately rather
         // than leaving a hidden soft-delete. Same contract as the flyout.
         await invoke('delete_clip', { id: clipId, hardDelete: true });
+        forgetRevealed(clipId);
         setClips(remaining);
         setSelectedClipId(nextSelection);
         loadFolders();
@@ -695,7 +728,7 @@ export function HistoryWindow() {
         toast.error('Failed to delete clip');
       }
     },
-    [loadFolders, refreshTotalCount]
+    [forgetRevealed, loadFolders, refreshTotalCount]
   );
 
   const handleClose = useCallback(() => {


### PR DESCRIPTION
## Summary

- Flyout and History kept decrypted bodies in the revealed map after delete and after clear.
- History now forgets on single/bulk delete, blanks the row on hide, and clears the map when the window loses focus.

Fixes https://linear.app/southboundsoftware/issue/SBS-1005/revealed-plaintext-survives-deleting-the-clip-in-both-the-flyout-and
Fixes https://linear.app/southboundsoftware/issue/SBS-1006/hiding-a-clip-whose-reload-fails-leaves-the-plaintext-on-screen-with

## Test plan

- [ ] Reveal a hidden clip in History, delete it; the body must not linger in the preview
- [ ] Hide a clip; the row blanks even if reload fails
- [ ] Switch away from History; revealed eye-state is gone

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forget revealed plaintext on clip delete, hide, and history blur in HistoryWindow
> - Calls `forgetRevealed(clipId)` after deleting a single clip (both in `App` and `HistoryWindow`) and iterates `forgetRevealed` over all selected IDs after bulk delete.
> - Calls `clearRevealed()` after clearing history (all or unpinned) and when hiding a clip.
> - Immediately blanks `content`, `preview`, and `notes` in local UI state when a clip is hidden, before the async reload completes.
> - Registers a focus-change listener in `HistoryWindow` via `getCurrentWindow().onFocusChanged` that calls `clearRevealed()` whenever the window loses focus.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1dc08a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->