### PR TITLE
SBS-1007: Id-based Shift-click, IME Escape, and confirmed bulk delete

### DIFF
--- a/frontend/src/components/ClipPreview.tsx
+++ b/frontend/src/components/ClipPreview.tsx
@@ -432,14 +432,13 @@ export function ClipPreview({
               if (next !== (revealed?.notes ?? clip.notes ?? '')) void onSaveNotes(clip.id, next);
             }}
             onKeyDown={(event) => {
-              // While an IME is composing, Enter and Escape belong to the
-              // candidate window, not to this field: Enter accepts a candidate
-              // and Escape abandons one. Acting on either would commit or
-              // discard a note the user is still in the middle of typing.
+              // Escape must not bubble even while composing: HistoryWindow
+              // would close the window before this handler's early return
+              // (SBS-1008).
+              if (event.key === 'Escape') event.stopPropagation();
               if (event.nativeEvent.isComposing) return;
               if (event.key === 'Enter') event.currentTarget.blur();
               if (event.key === 'Escape') {
-                event.stopPropagation();
                 noteCancelled.current = true;
                 event.currentTarget.blur();
               }

--- a/frontend/src/utils/flyoutSearch.test.ts
+++ b/frontend/src/utils/flyoutSearch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isImeKey, shouldCaptureTypeToSearch } from './flyoutSearch';
+import { isImeKey, shortcutsSuspended, shouldCaptureTypeToSearch } from './flyoutSearch';
 
 function key(
   partial: Partial<{
@@ -48,5 +48,26 @@ describe('shouldCaptureTypeToSearch', () => {
     expect(shouldCaptureTypeToSearch(key({ metaKey: true }))).toBe(false);
     expect(shouldCaptureTypeToSearch(key({ key: 'Enter' }))).toBe(false);
     expect(shouldCaptureTypeToSearch(key({ key: 'Escape' }))).toBe(false);
+  });
+});
+
+describe('shortcutsSuspended', () => {
+  it('stands down while a modal confirm owns the keyboard', () => {
+    // ConfirmDialog listens on window, which runs after document, so a
+    // History shortcut that keeps acting answers the confirm for the user:
+    // Delete hard-deletes the previewed clip mid-question (SBS-1007).
+    expect(shortcutsSuspended(key({ key: 'Delete' }), true)).toBe(true);
+    expect(shortcutsSuspended(key({ key: 'Escape' }), true)).toBe(true);
+    expect(shortcutsSuspended(key({ key: 'Enter' }), true)).toBe(true);
+  });
+
+  it('lets shortcuts through with no modal open', () => {
+    expect(shortcutsSuspended(key({ key: 'Delete' }), false)).toBe(false);
+    expect(shortcutsSuspended(key({ key: 'Escape' }), false)).toBe(false);
+  });
+
+  it('still stands down for IME composition with no modal open', () => {
+    expect(shortcutsSuspended(key({ isComposing: true, key: 'Enter' }), false)).toBe(true);
+    expect(shortcutsSuspended(key({ keyCode: 229, key: 'Process' }), false)).toBe(true);
   });
 });

--- a/frontend/src/utils/flyoutSearch.ts
+++ b/frontend/src/utils/flyoutSearch.ts
@@ -7,6 +7,22 @@ export function isImeKey(event: { isComposing: boolean; key: string; keyCode?: n
   return event.isComposing || event.key === 'Process' || event.keyCode === 229;
 }
 
+/**
+ * Whether a window-level shortcut handler should stand down for this event.
+ *
+ * Composition belongs to the IME candidate window. A modal confirm owns the
+ * keyboard outright: ConfirmDialog listens on `window`, which runs after
+ * `document`, so a document handler that keeps acting beats the dialog and
+ * answers the question on the user's behalf -- Delete hard-deleting the
+ * previewed clip while the bulk confirm is still up (SBS-1007).
+ */
+export function shortcutsSuspended(
+  event: { isComposing: boolean; key: string; keyCode?: number },
+  modalOpen: boolean
+): boolean {
+  return isImeKey(event) || modalOpen;
+}
+
 /** Printable keys that should steal focus into the flyout search box. */
 export function shouldCaptureTypeToSearch(event: {
   isComposing: boolean;

--- a/frontend/src/utils/multiSelect.test.ts
+++ b/frontend/src/utils/multiSelect.test.ts
@@ -46,23 +46,23 @@ describe('applySelectionClick', () => {
     expect(ids(grown)).toEqual(['b', 'c', 'd', 'e']);
     // Shrinking back from the same anchor: previously-added rows stay selected
     // (this is additive extension), but the anchor has not walked to row 4.
-    expect(grown.anchorIndex).toBe(1);
+    expect(grown.anchorId).toBe('b');
   });
 
   it('falls back to a plain toggle when shift arrives with no anchor', () => {
     const state = applySelectionClick(EMPTY_SELECTION, ORDER, 2, shift);
     expect(ids(state)).toEqual(['c']);
-    expect(state.anchorIndex).toBe(2);
+    expect(state.anchorId).toBe('c');
   });
 
   it('re-anchors when the anchor row is deselected', () => {
     const state = select([1, 3, 3], [plain, ctrl, ctrl]);
     expect(ids(state)).toEqual(['b']);
-    expect(state.anchorIndex).toBe(3);
+    expect(state.anchorId).toBe('d');
   });
 
   it('drops the anchor once nothing is selected', () => {
-    expect(select([1, 1]).anchorIndex).toBeNull();
+    expect(select([1, 1]).anchorId).toBeNull();
   });
 
   it('ignores a click on an index that is not rendered', () => {
@@ -102,7 +102,17 @@ describe('pruneSelection', () => {
 
   it('clears the anchor when the last selected row disappears', () => {
     const state = select([0]);
-    expect(pruneSelection(state, ['b', 'c']).anchorIndex).toBeNull();
+    expect(pruneSelection(state, ['b', 'c']).anchorId).toBeNull();
+  });
+
+  it('keeps the Shift origin on the same clip after a reorder', () => {
+    const state = applySelectionClick(EMPTY_SELECTION, ORDER, 2, plain);
+    expect(state.anchorId).toBe('c');
+    const reordered = ['c', 'a', 'b', 'd', 'e'];
+    const pruned = pruneSelection(state, reordered);
+    expect(pruned.anchorId).toBe('c');
+    const extended = applySelectionClick(pruned, reordered, 3, shift);
+    expect(ids(extended).sort()).toEqual(['a', 'b', 'c', 'd'].sort());
   });
 });
 

--- a/frontend/src/utils/multiSelect.ts
+++ b/frontend/src/utils/multiSelect.ts
@@ -80,8 +80,7 @@ export function toggleSelectAll(state: SelectionState, order: readonly string[])
 export function pruneSelection(state: SelectionState, order: readonly string[]): SelectionState {
   const present = new Set(order);
   const ids = new Set([...state.ids].filter((id) => present.has(id)));
-  const anchorId =
-    state.anchorId !== null && present.has(state.anchorId) ? state.anchorId : null;
+  const anchorId = state.anchorId !== null && present.has(state.anchorId) ? state.anchorId : null;
   if (ids.size === state.ids.size && anchorId === state.anchorId) return state;
   return { ids, anchorId: ids.size === 0 ? null : anchorId };
 }

--- a/frontend/src/utils/multiSelect.ts
+++ b/frontend/src/utils/multiSelect.ts
@@ -5,8 +5,9 @@
  * plain click on the checkbox toggles one row, Ctrl+click toggles without
  * disturbing the rest, and Shift+click extends from the last row you touched.
  *
- * Kept pure and index-based so the rules can be tested without a DOM: the
- * caller owns the rendered order and passes it in.
+ * The Shift origin is a clip id, not a row index. Pinning or deleting remaps
+ * indices, and an index-based origin would select rows the user never swept
+ * (SBS-1007).
  */
 
 export interface SelectionGesture {
@@ -17,11 +18,11 @@ export interface SelectionGesture {
 
 export interface SelectionState {
   ids: ReadonlySet<string>;
-  /** Row the next Shift+click extends from; null once the set is emptied. */
-  anchorIndex: number | null;
+  /** Clip the next Shift+click extends from; null once the set is emptied. */
+  anchorId: string | null;
 }
 
-export const EMPTY_SELECTION: SelectionState = { ids: new Set(), anchorIndex: null };
+export const EMPTY_SELECTION: SelectionState = { ids: new Set(), anchorId: null };
 
 /**
  * Apply a click on `index` to the current selection.
@@ -39,31 +40,28 @@ export function applySelectionClick(
   const id = order[index];
   if (id === undefined) return state;
 
-  // Shift extends from the anchor. With no anchor yet there is nothing to
-  // extend from, so it behaves as a plain toggle and sets one.
-  if (gesture.shiftKey && state.anchorIndex !== null) {
-    const from = Math.min(state.anchorIndex, index);
-    const to = Math.max(state.anchorIndex, index);
+  const anchorIndex = state.anchorId === null ? -1 : order.indexOf(state.anchorId);
+  // Shift extends from the anchor. With no anchor yet, or after the anchored
+  // clip left the list, there is nothing to extend from, so it behaves as a
+  // plain toggle and sets one.
+  if (gesture.shiftKey && anchorIndex >= 0) {
+    const from = Math.min(anchorIndex, index);
+    const to = Math.max(anchorIndex, index);
     const ids = new Set(state.ids);
     for (let cursor = from; cursor <= to; cursor += 1) {
       const rangeId = order[cursor];
       if (rangeId !== undefined) ids.add(rangeId);
     }
-    // The anchor stays put, so dragging the shift end around keeps growing and
-    // shrinking from the same origin instead of walking away from it.
-    return { ids, anchorIndex: state.anchorIndex };
+    return { ids, anchorId: state.anchorId };
   }
 
   const ids = new Set(state.ids);
   if (ids.has(id)) {
     ids.delete(id);
-    // Deselecting the anchor leaves the next Shift+click without a sensible
-    // origin, so re-anchor here rather than extending from a row the user just
-    // removed.
-    return { ids, anchorIndex: ids.size === 0 ? null : index };
+    return { ids, anchorId: ids.size === 0 ? null : id };
   }
   ids.add(id);
-  return { ids, anchorIndex: index };
+  return { ids, anchorId: id };
 }
 
 /** Select every currently rendered row, or clear if they are all selected. */
@@ -71,19 +69,21 @@ export function toggleSelectAll(state: SelectionState, order: readonly string[])
   if (order.length > 0 && order.every((id) => state.ids.has(id))) {
     return EMPTY_SELECTION;
   }
-  return { ids: new Set(order), anchorIndex: order.length > 0 ? order.length - 1 : null };
+  return { ids: new Set(order), anchorId: order[order.length - 1] ?? null };
 }
 
 /**
  * Drop ids that are no longer rendered. Selection is over loaded rows, so a
  * filter change or a delete must not leave the count claiming rows that are
- * gone.
+ * gone. The Shift origin follows the clip, not the slot it used to occupy.
  */
 export function pruneSelection(state: SelectionState, order: readonly string[]): SelectionState {
   const present = new Set(order);
   const ids = new Set([...state.ids].filter((id) => present.has(id)));
-  if (ids.size === state.ids.size) return state;
-  return { ids, anchorIndex: ids.size === 0 ? null : state.anchorIndex };
+  const anchorId =
+    state.anchorId !== null && present.has(state.anchorId) ? state.anchorId : null;
+  if (ids.size === state.ids.size && anchorId === state.anchorId) return state;
+  return { ids, anchorId: ids.size === 0 ? null : anchorId };
 }
 
 /** Selected ids in rendered order, which is the order bulk actions apply in. */

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -8,12 +8,14 @@ import { Toaster, toast } from 'sonner';
 import { ClipboardItem, FolderItem, Settings } from '../types';
 import { ClipList } from '../components/ClipList';
 import { ClipPreview } from '../components/ClipPreview';
+import { ConfirmDialog } from '../components/ConfirmDialog';
 import { ContentFilter } from '../components/FlyoutHeader';
 import { useTheme } from '../hooks/useTheme';
 import { useLanguage } from '../hooks/useLanguage';
 import { useSystemAccent } from '../hooks/useSystemAccent';
 import { useRevealedClips } from '../hooks/useRevealedClips';
 import { collectBulkCopyText } from '../utils/bulkCopy';
+import { isImeKey } from '../utils/flyoutSearch';
 import { ClipDetails } from '../utils/clipPreviewState';
 import { customRange, DATE_PRESET_LABELS, DatePreset, presetRange } from '../utils/dateRange';
 import { folderSelectionAfterReload } from '../utils/folderSelection';
@@ -70,6 +72,7 @@ export function HistoryWindow() {
   const [loadError, setLoadError] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const [totalClipCount, setTotalClipCount] = useState(0);
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [settings, setSettings] = useState<Settings | null>(null);
   const [sourceApps, setSourceApps] = useState<SourceAppCount[]>([]);
   const [sourceApp, setSourceApp] = useState<string | null>(null);
@@ -739,11 +742,18 @@ export function HistoryWindow() {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      if (isImeKey(event) || event.isComposing) return;
       const target = event.target as HTMLElement | null;
       const isEditing =
         target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || target?.isContentEditable;
 
       if (event.key === 'Escape') {
+        // Search is an INPUT, so isEditing is true there; Escape still clears
+        // the query / closes. Notes and other fields must not close the window
+        // even if they forget to stopPropagation (SBS-1008).
+        const isSearch =
+          target?.getAttribute('data-el') === 'history-search-input';
+        if (isEditing && !isSearch) return;
         if (searchQuery) {
           setSearchQuery('');
           return;
@@ -989,7 +999,7 @@ export function HistoryWindow() {
           className="flex shrink-0 flex-wrap items-center gap-1.5 border-b border-border bg-primary/[0.08] px-4 py-2"
         >
           <span className="mr-1 text-[11px] font-medium text-foreground">
-            {selectionCount} of {totalClipCount.toLocaleString()} selected
+            {selectionCount} of {clips.length.toLocaleString()} selected
           </span>
           <button type="button" className={bulkActionClass} onClick={handleBulkCopy}>
             <Copy size={12} />
@@ -1023,7 +1033,7 @@ export function HistoryWindow() {
           <button
             type="button"
             className={`${bulkActionClass} text-destructive`}
-            onClick={handleBulkDelete}
+            onClick={() => setBulkDeleteOpen(true)}
           >
             <Trash2 size={12} />
             Delete
@@ -1105,6 +1115,17 @@ export function HistoryWindow() {
         </div>
       </footer>
       <Toaster richColors position="bottom-center" theme={effectiveTheme} />
+      <ConfirmDialog
+        isOpen={bulkDeleteOpen}
+        title={selectionCount === 1 ? 'Delete this clip?' : `Delete ${selectionCount} clips?`}
+        message="Cubby has no trash. Deleted clips cannot be recovered."
+        confirmText={selectionCount === 1 ? 'Delete clip' : `Delete ${selectionCount} clips`}
+        onConfirm={() => {
+          setBulkDeleteOpen(false);
+          void handleBulkDelete();
+        }}
+        onCancel={() => setBulkDeleteOpen(false)}
+      />
     </div>
   );
 }

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -15,7 +15,7 @@ import { useLanguage } from '../hooks/useLanguage';
 import { useSystemAccent } from '../hooks/useSystemAccent';
 import { useRevealedClips } from '../hooks/useRevealedClips';
 import { collectBulkCopyText } from '../utils/bulkCopy';
-import { isImeKey } from '../utils/flyoutSearch';
+import { shortcutsSuspended } from '../utils/flyoutSearch';
 import { ClipDetails } from '../utils/clipPreviewState';
 import { customRange, DATE_PRESET_LABELS, DatePreset, presetRange } from '../utils/dateRange';
 import { folderSelectionAfterReload } from '../utils/folderSelection';
@@ -742,7 +742,12 @@ export function HistoryWindow() {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (isImeKey(event) || event.isComposing) return;
+      // While the bulk-delete confirm is up, every shortcut here is wrong:
+      // Delete would hard-delete the previewed clip mid-question, Escape would
+      // close the whole window, and Enter would preventDefault the dialog's own
+      // buttons. App.tsx stands down the same way with useKeyboard's disabled
+      // flag.
+      if (shortcutsSuspended(event, bulkDeleteOpen)) return;
       const target = event.target as HTMLElement | null;
       const isEditing =
         target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || target?.isContentEditable;
@@ -794,7 +799,7 @@ export function HistoryWindow() {
 
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
-  }, [handleClose, handleCopy, handleDelete, searchQuery, selectedClipId]);
+  }, [bulkDeleteOpen, handleClose, handleCopy, handleDelete, searchQuery, selectedClipId]);
 
   const hasNarrowingFilter =
     Boolean(sourceApp) || dateFrom !== null || dateTo !== null || contentFilter !== 'all';

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -751,8 +751,7 @@ export function HistoryWindow() {
         // Search is an INPUT, so isEditing is true there; Escape still clears
         // the query / closes. Notes and other fields must not close the window
         // even if they forget to stopPropagation (SBS-1008).
-        const isSearch =
-          target?.getAttribute('data-el') === 'history-search-input';
+        const isSearch = target?.getAttribute('data-el') === 'history-search-input';
         if (isEditing && !isSearch) return;
         if (searchQuery) {
           setSearchQuery('');


### PR DESCRIPTION
## Summary

- Shift range now follows clip id, so pin/reorder no longer selects neighbors the user never swept.
- Note-field Escape stops bubbling even while composing; History ignores IME keys before close.
- Bulk Delete asks for confirmation and counts against the loaded list, not all of history.

Fixes https://linear.app/southboundsoftware/issue/SBS-1007/stale-shift-click-anchor-after-a-reorder-or-delete-selects-rows-the
Fixes https://linear.app/southboundsoftware/issue/SBS-1008/escape-during-ime-composition-in-the-note-field-closes-the-whole
Fixes https://linear.app/southboundsoftware/issue/SBS-1009/bulk-delete-is-irreversible-one-click-from-select-all-with-no

## Test plan

- [ ] Pin a later row, Shift-click from the original origin; range is the clips you swept
- [ ] IME Escape in a note does not close History
- [ ] Bulk Delete opens a confirm dialog; cancel leaves clips in place

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add confirmation dialog for bulk delete, fix IME Escape handling, and switch shift-click to id-based anchoring in HistoryWindow
> - Bulk delete in `HistoryWindow` now requires confirmation via a modal dialog; all window-level shortcuts are suspended while the modal is open.
> - Shift+click range selection in [`multiSelect.ts`](https://github.com/tsouth89/cubby-clipboard/pull/248/files#diff-90833093326281ec811c4ef05be20cd53f59019da0ed4cf0238e0a255b517105) now tracks the anchor by clip id instead of index, so the selection origin survives reorders (e.g. pinning or deleting clips).
> - Escape in the note `<textarea>` ([`ClipPreview.tsx`](https://github.com/tsouth89/cubby-clipboard/pull/248/files#diff-ed0726bc8395c70c54f5b99a27709cae1a85bd2ece5df8f7d7b172a35babc130)) always stops propagation before the IME composition guard, preventing the History window from closing during IME input.
> - Added `shortcutsSuspended(event, modalOpen)` in [`flyoutSearch.ts`](https://github.com/tsouth89/cubby-clipboard/pull/248/files#diff-445788fd2b28b63b016dfcf5e3a354815648befff721efbccbb8439c6e037e13) as a single predicate that disables window-level shortcuts during IME composition or while a modal is open.
> - Behavioral Change: the selection summary denominator now shows the count of loaded clips instead of the total available count.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8140c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->