### PR TITLE
SBS-998: Delete leftover image staging files on open

### DIFF
--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -82,6 +82,9 @@ impl Database {
             encryption_version.as_deref() != Some("1"),
         )?);
 
+        let _ = std::fs::create_dir_all(&image_dir);
+        Self::sweep_stale_image_temps(&image_dir);
+
         Ok((
             Self {
                 pool,
@@ -91,6 +94,31 @@ impl Database {
             },
             notices,
         ))
+    }
+
+    /// Staging writes `{uuid}.cubby.tmp` and only `StagedImageFile::drop` removes
+    /// it. A crash between the write and that drop leaves the encrypted original
+    /// on disk forever — including through Clear all history, which only deletes
+    /// paths recorded in `clip_images` (SBS-998).
+    fn sweep_stale_image_temps(image_dir: &Path) {
+        let Ok(entries) = std::fs::read_dir(image_dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if !name.ends_with(".cubby.tmp") {
+                continue;
+            }
+            match std::fs::remove_file(&path) {
+                Ok(()) => log::info!("IMAGE: removed leftover staging file {}", path.display()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => log::warn!(
+                    "IMAGE: could not remove leftover staging file {}: {error}",
+                    path.display()
+                ),
+            }
+        }
     }
 
     /// Collapse duplicate `content_hash` rows and make the constraint
@@ -2041,6 +2069,19 @@ mod tests {
             !temporary.exists(),
             "a failed copy must not leave partial backup bytes behind"
         );
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    #[test]
+    fn leftover_image_temps_are_removed_on_open() {
+        let directory = temp_dir();
+        let stale = directory.join("abc.cubby.tmp");
+        let keep = directory.join("abc.cubby");
+        std::fs::write(&stale, b"orphaned staging bytes").unwrap();
+        std::fs::write(&keep, b"live original").unwrap();
+        Database::sweep_stale_image_temps(&directory);
+        assert!(!stale.exists(), "a crash-left staging file must not survive");
+        assert!(keep.exists(), "committed originals must be left alone");
         let _ = std::fs::remove_dir_all(directory);
     }
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -2080,7 +2080,10 @@ mod tests {
         std::fs::write(&stale, b"orphaned staging bytes").unwrap();
         std::fs::write(&keep, b"live original").unwrap();
         Database::sweep_stale_image_temps(&directory);
-        assert!(!stale.exists(), "a crash-left staging file must not survive");
+        assert!(
+            !stale.exists(),
+            "a crash-left staging file must not survive"
+        );
         assert!(keep.exists(), "committed originals must be left alone");
         let _ = std::fs::remove_dir_all(directory);
     }


### PR DESCRIPTION
## Summary

- `{uuid}.cubby.tmp` written during staging was only removed by `StagedImageFile::drop`. A crash left the encrypted original forever, including through Clear all history.
- Database open now enumerates the image directory and deletes `*.cubby.tmp`.

Fixes https://linear.app/southboundsoftware/issue/SBS-998/crash-left-uuidcubbytmp-image-files-are-never-swept-and-survive-clear

## Test plan

- [x] Unit test: `.cubby.tmp` is removed, `.cubby` is kept
- [ ] Windows CI `cargo test`

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Delete leftover `.cubby.tmp` image staging files on database open
> On `Database::new`, the images directory is created if missing, then `sweep_stale_image_temps` scans it and deletes any files ending with `.cubby.tmp`. Successful deletions are logged; not-found errors are ignored and other I/O errors are logged as warnings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cba022c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->