### PR TITLE
SBS-978: Back up HTML/RTF and require a 12-character export passphrase

### DIFF
--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -335,6 +335,7 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
   // Which passphrase prompt is open, if any.
   const [backupPrompt, setBackupPrompt] = useState<'export' | 'import' | null>(null);
   const [backupPassphrase, setBackupPassphrase] = useState('');
+  const [backupPassphraseConfirm, setBackupPassphraseConfirm] = useState('');
   const [ocrStatus, setOcrStatus] = useState<OcrQueueStatus | null>(null);
   const [ocrActionBusy, setOcrActionBusy] = useState(false);
   const [storageUsage, setStorageUsage] = useState<StorageUsage | null>(null);
@@ -580,6 +581,7 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
   const closeBackupPrompt = () => {
     setBackupPrompt(null);
     setBackupPassphrase('');
+    setBackupPassphraseConfirm('');
   };
 
   const handleExportBackup = async (passphrase: string) => {
@@ -891,13 +893,31 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
               placeholder="Passphrase"
               className="mt-3 w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-sm outline-none focus:border-primary"
             />
+            {backupPrompt === 'export' && (
+              <>
+                <input
+                  type="password"
+                  value={backupPassphraseConfirm}
+                  onChange={(event) => setBackupPassphraseConfirm(event.target.value)}
+                  placeholder="Confirm passphrase"
+                  className="mt-2 w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-sm outline-none focus:border-primary"
+                />
+                <p className="mt-2 text-[11px] text-muted-foreground">
+                  Use at least 12 characters. Cubby cannot recover a lost passphrase.
+                </p>
+              </>
+            )}
             <div className="mt-4 flex justify-end gap-2">
               <button type="button" onClick={closeBackupPrompt} className={ghostButton}>
                 {t('common.cancel')}
               </button>
               <button
                 type="submit"
-                disabled={backupPassphrase.length === 0}
+                disabled={
+                  backupPrompt === 'export'
+                    ? backupPassphrase.length < 12 || backupPassphrase !== backupPassphraseConfirm
+                    : backupPassphrase.length === 0
+                }
                 className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-white disabled:opacity-40"
               >
                 {backupPrompt === 'export' ? 'Choose location…' : 'Choose file…'}

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -915,7 +915,11 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
                 type="submit"
                 disabled={
                   backupPrompt === 'export'
-                    ? backupPassphrase.length < 12 || backupPassphrase !== backupPassphraseConfirm
+                    ? // Count characters, not UTF-16 units: the backend floor is
+                      // chars().count(), so .length would pass an 11-character
+                      // passphrase with one emoji and then be refused there.
+                      [...backupPassphrase].length < 12 ||
+                      backupPassphrase !== backupPassphraseConfirm
                     : backupPassphrase.length === 0
                 }
                 className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-white disabled:opacity-40"

--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -1459,7 +1459,7 @@ mod tests {
         let path = temp_path("short-pass");
         let error = export_backup(&source, path.to_str().unwrap(), "short")
             .await
-            .expect_err("eleven characters is below the export floor");
+            .expect_err("five characters is below the export floor");
         assert!(error.contains("12"));
         assert!(!path.exists(), "a refused export must not write a file");
     }

--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -87,6 +87,16 @@ struct BackupClip {
     /// already expired, and for bundles written before SBS-919.
     #[serde(default)]
     full_image_b64: Option<String>,
+    /// HTML/RTF (and any other auxiliary) representations. Defaulted so a
+    /// bundle written before SBS-978 still imports; those clips had none.
+    #[serde(default)]
+    formats: Vec<BackupFormat>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct BackupFormat {
+    name: String,
+    content_b64: String,
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -231,6 +241,13 @@ fn derive_key(passphrase: &str, salt: &[u8]) -> Result<[u8; KEY_LEN], String> {
 /// stay thumbnail-only, which is the first-class SOU-244 state rather than
 /// damage.
 pub async fn export_backup(db: &Database, path: &str, passphrase: &str) -> Result<usize, String> {
+    const MIN_EXPORT_PASSPHRASE: usize = 12;
+    if passphrase.chars().count() < MIN_EXPORT_PASSPHRASE {
+        return Err(format!(
+            "Choose a passphrase of at least {MIN_EXPORT_PASSPHRASE} characters"
+        ));
+    }
+
     let rows: Vec<ExportRow> = sqlx::query_as(
         r#"
         SELECT clips.uuid,
@@ -296,7 +313,10 @@ pub async fn export_backup(db: &Database, path: &str, passphrase: &str) -> Resul
             folder,
         ) {
             Ok(clip) => match attach_export_full_image(db, &uuid, clip, full_image_expired).await {
-                Ok(clip) => clips.push(clip),
+                Ok(clip) => match attach_export_formats(db, &uuid, clip).await {
+                    Ok(clip) => clips.push(clip),
+                    Err(fields) => failures.record(&uuid, &fields),
+                },
                 Err(fields) => failures.record(&uuid, &fields),
             },
             Err(fields) => failures.record(&uuid, &fields),
@@ -425,7 +445,61 @@ fn decrypt_export_clip(
         created_at,
         folder,
         full_image_b64: None,
+        formats: Vec::new(),
     })
+}
+
+async fn attach_export_formats(
+    db: &Database,
+    uuid: &str,
+    mut clip: BackupClip,
+) -> Result<BackupClip, Vec<&'static str>> {
+    let rows: Vec<(String, Vec<u8>)> = sqlx::query_as(
+        "SELECT format, content FROM clip_formats WHERE clip_uuid = ? ORDER BY rowid",
+    )
+    .bind(uuid)
+    .fetch_all(&db.pool)
+    .await
+    .map_err(|_| vec!["formats"])?;
+
+    let mut formats = Vec::with_capacity(rows.len());
+    for (name, content) in rows {
+        match db.crypto.decrypt(&content) {
+            Ok(bytes) => formats.push(BackupFormat {
+                name,
+                content_b64: BASE64.encode(bytes),
+            }),
+            Err(error) => {
+                log::warn!("BACKUP: clip {uuid} auxiliary format {name} could not be decrypted: {error}");
+                return Err(vec!["formats"]);
+            }
+        }
+    }
+    clip.formats = formats;
+    Ok(clip)
+}
+
+async fn persist_imported_formats(
+    db: &Database,
+    uuid: &str,
+    formats: &[(String, Vec<u8>)],
+) -> Result<(), String> {
+    for (name, bytes) in formats {
+        let encrypted = db
+            .crypto
+            .encrypt(bytes)
+            .map_err(|error| format!("Could not encrypt restored clip format {name}: {error}"))?;
+        sqlx::query(
+            "INSERT INTO clip_formats (clip_uuid, format, content) VALUES (?, ?, ?)",
+        )
+        .bind(uuid)
+        .bind(name)
+        .bind(encrypted)
+        .execute(&db.pool)
+        .await
+        .map_err(|error| format!("Could not restore clip format {name}: {error}"))?;
+    }
+    Ok(())
 }
 
 fn decrypt_optional_export_field(
@@ -781,13 +855,34 @@ pub async fn import_backup(
             }
         };
 
-        // Capture hashes an image from the full PNG, not the thumbnail. A
-        // restored original has to use the same material or recopying that
-        // screenshot on the new machine stores a duplicate.
+        let mut decoded_formats: Vec<(String, Vec<u8>)> = Vec::new();
+        let mut format_error = false;
+        for format in &clip.formats {
+            match BASE64.decode(format.content_b64.as_bytes()) {
+                Ok(bytes) => decoded_formats.push((format.name.clone(), bytes)),
+                Err(_) => {
+                    result
+                        .errors
+                        .push("A clip's auxiliary format was unreadable".to_string());
+                    format_error = true;
+                    break;
+                }
+            }
+        }
+        if format_error {
+            continue;
+        }
+
+        // Capture hashes an image from the full PNG, not the thumbnail, and
+        // folds HTML/RTF into a text clip's identity. Restore has to use the
+        // same material or recopying that clip on the new machine stores a
+        // duplicate (SBS-978).
         let hash_material = crate::clipboard::build_clip_hash_material(
             &clip.clip_type,
             full_image.as_deref().unwrap_or(&content),
-            std::iter::empty::<(&str, &[u8])>(),
+            decoded_formats
+                .iter()
+                .map(|(name, bytes)| (name.as_str(), bytes.as_slice())),
         );
         let content_hash = db.crypto.keyed_hash(&hash_material);
 
@@ -929,6 +1024,23 @@ pub async fn import_backup(
                         result.errors.push(error);
                         continue;
                     }
+                }
+                if let Err(error) =
+                    persist_imported_formats(db, &new_uuid, &decoded_formats).await
+                {
+                    if let Err(cleanup) = sqlx::query("DELETE FROM clips WHERE uuid = ?")
+                        .bind(&new_uuid)
+                        .execute(&db.pool)
+                        .await
+                    {
+                        log::error!(
+                            "BACKUP: failed to roll back clip {new_uuid} after format insert error: {cleanup}"
+                        );
+                    } else if let Some(file_path) = restored_original {
+                        remove_imported_original(&file_path);
+                    }
+                    result.errors.push(error);
+                    continue;
                 }
                 result.imported += 1;
             }
@@ -1278,7 +1390,7 @@ mod tests {
         insert_clip(&source, "swordfish token 8821", false, None).await;
 
         let path = temp_path("secrecy");
-        export_backup(&source, path.to_str().unwrap(), "right one")
+        export_backup(&source, path.to_str().unwrap(), "right passphrase")
             .await
             .unwrap();
 
@@ -1302,7 +1414,7 @@ mod tests {
         let source = test_database().await;
         insert_clip(&source, "alpha", false, None).await;
         let path = temp_path("tamper");
-        export_backup(&source, path.to_str().unwrap(), "pass")
+        export_backup(&source, path.to_str().unwrap(), "passphrase12x")
             .await
             .unwrap();
 
@@ -1313,7 +1425,7 @@ mod tests {
 
         let target = test_database().await;
         assert!(
-            import_backup(&target, path.to_str().unwrap(), "pass", false)
+            import_backup(&target, path.to_str().unwrap(), "passphrase12x", false)
                 .await
                 .is_err()
         );
@@ -1326,18 +1438,76 @@ mod tests {
         let source = test_database().await;
         insert_clip(&source, "alpha", false, None).await;
         let path = temp_path("dryrun");
-        export_backup(&source, path.to_str().unwrap(), "pass")
+        export_backup(&source, path.to_str().unwrap(), "passphrase12x")
             .await
             .unwrap();
 
         let target = test_database().await;
-        let result = import_backup(&target, path.to_str().unwrap(), "pass", true)
+        let result = import_backup(&target, path.to_str().unwrap(), "passphrase12x", true)
             .await
             .unwrap();
         assert!(result.dry_run);
         assert_eq!(result.imported, 1);
         assert_eq!(clip_texts(&target).await.len(), 0);
 
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn export_refuses_a_short_passphrase() {
+        let source = test_database().await;
+        insert_clip(&source, "alpha", false, None).await;
+        let path = temp_path("short-pass");
+        let error = export_backup(&source, path.to_str().unwrap(), "short")
+            .await
+            .expect_err("eleven characters is below the export floor");
+        assert!(error.contains("12"));
+        assert!(!path.exists(), "a refused export must not write a file");
+    }
+
+    #[tokio::test]
+    async fn html_and_rtf_survive_a_round_trip() {
+        let source = test_database().await;
+        insert_clip(&source, "styled table", false, None).await;
+        let uuid: String = sqlx::query_scalar("SELECT uuid FROM clips")
+            .fetch_one(&source.pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO clip_formats (clip_uuid, format, content) VALUES (?, 'html', ?), (?, 'rtf', ?)",
+        )
+        .bind(&uuid)
+        .bind(source.crypto.encrypt(b"<table>hi</table>").unwrap())
+        .bind(&uuid)
+        .bind(source.crypto.encrypt(b"{\\rtf1 hi}").unwrap())
+        .execute(&source.pool)
+        .await
+        .unwrap();
+
+        let path = temp_path("formats");
+        export_backup(&source, path.to_str().unwrap(), "passphrase12x")
+            .await
+            .unwrap();
+
+        let target = test_database().await;
+        let result = import_backup(&target, path.to_str().unwrap(), "passphrase12x", false)
+            .await
+            .unwrap();
+        assert_eq!(result.imported, 1);
+        assert!(result.errors.is_empty());
+
+        let restored: Vec<(String, Vec<u8>)> =
+            sqlx::query_as("SELECT format, content FROM clip_formats ORDER BY format")
+                .fetch_all(&target.pool)
+                .await
+                .unwrap();
+        assert_eq!(restored.len(), 2);
+        let html = target.crypto.decrypt(&restored[0].1).unwrap();
+        let rtf = target.crypto.decrypt(&restored[1].1).unwrap();
+        assert_eq!(restored[0].0, "html");
+        assert_eq!(html, b"<table>hi</table>");
+        assert_eq!(restored[1].0, "rtf");
+        assert_eq!(rtf, b"{\\rtf1 hi}");
         std::fs::remove_file(&path).ok();
     }
 
@@ -1867,6 +2037,7 @@ mod tests {
             created_at: "2026-05-01 09:00:00".to_string(),
             folder: None,
             full_image_b64: None,
+            formats: Vec::new(),
         };
         let exported = attach_export_full_image(&source, &uuid, clip, false)
             .await
@@ -2007,6 +2178,7 @@ mod tests {
                 created_at: "2026-05-01 09:00:00".to_string(),
                 folder: None,
                 full_image_b64: Some(BASE64.encode(b"not really a screenshot")),
+                formats: Vec::new(),
             }],
         };
         let path = temp_path("full-image-on-text");

--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -470,7 +470,9 @@ async fn attach_export_formats(
                 content_b64: BASE64.encode(bytes),
             }),
             Err(error) => {
-                log::warn!("BACKUP: clip {uuid} auxiliary format {name} could not be decrypted: {error}");
+                log::warn!(
+                    "BACKUP: clip {uuid} auxiliary format {name} could not be decrypted: {error}"
+                );
                 return Err(vec!["formats"]);
             }
         }
@@ -489,15 +491,13 @@ async fn persist_imported_formats(
             .crypto
             .encrypt(bytes)
             .map_err(|error| format!("Could not encrypt restored clip format {name}: {error}"))?;
-        sqlx::query(
-            "INSERT INTO clip_formats (clip_uuid, format, content) VALUES (?, ?, ?)",
-        )
-        .bind(uuid)
-        .bind(name)
-        .bind(encrypted)
-        .execute(&db.pool)
-        .await
-        .map_err(|error| format!("Could not restore clip format {name}: {error}"))?;
+        sqlx::query("INSERT INTO clip_formats (clip_uuid, format, content) VALUES (?, ?, ?)")
+            .bind(uuid)
+            .bind(name)
+            .bind(encrypted)
+            .execute(&db.pool)
+            .await
+            .map_err(|error| format!("Could not restore clip format {name}: {error}"))?;
     }
     Ok(())
 }
@@ -1001,11 +1001,11 @@ pub async fn import_backup(
 
         match insert {
             Ok(_) => {
-                if let Some(file_path) = restored_original {
+                if let Some(file_path) = restored_original.as_ref() {
                     if let Err(error) = index_imported_original(
                         db,
                         &new_uuid,
-                        &file_path,
+                        file_path,
                         full_image.as_ref().map(Vec::len).unwrap_or(0) as i64,
                     )
                     .await
@@ -1019,14 +1019,13 @@ pub async fn import_backup(
                                 "BACKUP: failed to roll back clip {new_uuid} after image index error: {cleanup}"
                             );
                         } else {
-                            remove_imported_original(&file_path);
+                            remove_imported_original(file_path);
                         }
                         result.errors.push(error);
                         continue;
                     }
                 }
-                if let Err(error) =
-                    persist_imported_formats(db, &new_uuid, &decoded_formats).await
+                if let Err(error) = persist_imported_formats(db, &new_uuid, &decoded_formats).await
                 {
                     if let Err(cleanup) = sqlx::query("DELETE FROM clips WHERE uuid = ?")
                         .bind(&new_uuid)
@@ -1036,8 +1035,8 @@ pub async fn import_backup(
                         log::error!(
                             "BACKUP: failed to roll back clip {new_uuid} after format insert error: {cleanup}"
                         );
-                    } else if let Some(file_path) = restored_original {
-                        remove_imported_original(&file_path);
+                    } else if let Some(file_path) = restored_original.as_ref() {
+                        remove_imported_original(file_path);
                     }
                     result.errors.push(error);
                     continue;
@@ -1045,8 +1044,8 @@ pub async fn import_backup(
                 result.imported += 1;
             }
             Err(error) => {
-                if let Some(file_path) = restored_original {
-                    remove_imported_original(&file_path);
+                if let Some(file_path) = restored_original.as_ref() {
+                    remove_imported_original(file_path);
                 }
                 result.errors.push(format!("insert failed: {error}"));
             }

--- a/src-tauri/src/path_grant.rs
+++ b/src-tauri/src/path_grant.rs
@@ -377,7 +377,7 @@ mod tests {
         let path_str = path.to_string_lossy().to_string();
         grant_picker_path(PathGrantPurpose::BackupSave, path_str.clone()).unwrap();
 
-        let count = export_granted_backup(&db, path_str.clone(), "passphrase".into())
+        let count = export_granted_backup(&db, path_str.clone(), "correct horse".into())
             .await
             .expect("export_backup must accept a granted save path");
         assert_eq!(count, 1);


### PR DESCRIPTION
## Summary

- Encrypted backups now export and restore `clip_formats`, and import hashes with those bytes so recopying a restored rich clip does not duplicate it.
- Export rejects passphrases shorter than 12 characters. Import still accepts older short-passphrase bundles. The export prompt asks for confirmation.

Fixes https://linear.app/southboundsoftware/issue/SBS-978/encrypted-backup-drops-htmlrtf-clip-formats-so-restored-rich-clips
Fixes https://linear.app/southboundsoftware/issue/SBS-979/backup-export-enforces-no-passphrase-floor-derive-key-rejects-only-the

## Test plan

- [x] Round-trip test for html/rtf rows
- [x] Export with a 5-character passphrase is refused
- [ ] Settings: export button stays disabled until 12 matching characters
- [ ] Import a pre-existing short-passphrase backup still works

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Back up HTML/RTF clip formats and require a 12-character export passphrase
> - Export backup now rejects passphrases shorter than 12 Unicode characters (counted by code points); the frontend also requires a matching confirmation field before enabling submission.
> - Import backup restores auxiliary formats (HTML/RTF) stored in `clip_formats`, includes them in deduplication hashing, and rolls back the clip row if persisting formats fails.
> - New `formats` field on `BackupClip` carries auxiliary representations as base64-encoded entries; existing backups without this field default to an empty list.
> - Behavioral Change: export passphrases under 12 characters now return an error and write no file; import passphrases remain only required to be non-empty.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65ed84f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->