### PR TITLE
SBS-1003: Carry the capture into the forget-on-clear retry

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -107,7 +107,9 @@ struct RecentCapture {
 }
 
 mod forget_on_clear;
-use forget_on_clear::{next_forget_attempts, ForgetClipLookup};
+use forget_on_clear::{
+    next_forget_attempts, select_forget_attempt, ForgetAttempt, ForgetClipLookup,
+};
 
 /// Pure helper for SOU-316 unit tests: only empty clears within the window
 /// forget the last clip. A later clear must leave history alone.
@@ -275,6 +277,7 @@ pub fn init(app: &AppHandle, db: Arc<Database>) {
                         db_for_consumer.clone(),
                         sequence,
                         FORGET_ON_CLEAR_ATTEMPTS,
+                        None,
                     )
                     .await;
                 }
@@ -2582,6 +2585,7 @@ async fn process_clipboard_clear(
     db: Arc<Database>,
     sequence: u32,
     attempts_left: u8,
+    pinned: Option<RecentCapture>,
 ) {
     use crate::settings_manager::SettingsManager;
     use tauri::Manager;
@@ -2592,21 +2596,28 @@ async fn process_clipboard_clear(
         return;
     }
 
+    // A retry carries the capture its first attempt was scheduled for, and
+    // deletes exactly that row. Re-reading the marker would delete whatever
+    // copy landed while SQLITE_BUSY held the first attempt, and re-checking the
+    // 90s window would drop a forget that only missed it because the retry
+    // itself took time -- a capture 89.9s old would age out during the delay.
+    let took_marker = pinned.is_none();
     let recent = {
         let mut lock = LAST_ACCEPTED_CAPTURE.lock();
-        let should_forget = lock.as_ref().is_some_and(|recent| {
+        let within_window = lock.as_ref().is_some_and(|recent| {
             should_forget_recent_capture(
                 recent.captured_at,
                 Instant::now(),
                 CLIPBOARD_CLEAR_FORGET_WINDOW,
             )
         });
-        if should_forget {
-            lock.take()
-        } else {
-            // Outside the window (or nothing tracked): drop any stale marker.
-            lock.take();
-            None
+        // A first attempt consumes the marker either way: in the window it is
+        // the target, outside it is stale and must not linger.
+        let marker = if took_marker { lock.take() } else { None };
+        drop(lock);
+        match select_forget_attempt(pinned, marker, within_window) {
+            ForgetAttempt::Pinned(capture) | ForgetAttempt::FromMarker(capture) => Some(capture),
+            ForgetAttempt::Nothing => None,
         }
     };
 
@@ -2627,18 +2638,18 @@ async fn process_clipboard_clear(
         return;
     }
 
-    // Reports whether the marker went back. A newer capture landing while we
-    // held it means this clear no longer describes what is in history, so the
-    // caller must not retry: the retry would take that newer marker and delete
-    // a clip the user never cleared.
-    let restore_marker = |recent: RecentCapture| -> bool {
-        let mut lock = LAST_ACCEPTED_CAPTURE.lock();
-        // Only restore if nothing newer was captured while we held the marker.
-        if lock.is_none() {
-            *lock = Some(recent);
-            return true;
+    // Every failure below leaves the clip in history, so the attempt has to be
+    // repeatable. The retry carries the capture, so it no longer matters
+    // whether the marker could go back; putting it back is only so a later
+    // clear can still forget the clip if the retries run out (SBS-831).
+    let requeue = |app: AppHandle, db: Arc<Database>, recent: RecentCapture| {
+        if took_marker {
+            let mut lock = LAST_ACCEPTED_CAPTURE.lock();
+            if lock.is_none() {
+                *lock = Some(recent.clone());
+            }
         }
-        false
+        schedule_forget_retry(app, db, sequence, attempts_left, recent);
     };
 
     let _guard = CLIPBOARD_SYNC.lock().await;
@@ -2677,12 +2688,10 @@ async fn process_clipboard_clear(
         }
         ForgetClipLookup::Failed { error, taken } => {
             log::error!(
-                "CLIPBOARD: forget-on-clear skipped for sequence {sequence} (clip {}); lookup failed, so the retry marker was restored: {error}",
+                "CLIPBOARD: forget-on-clear lookup failed for sequence {sequence} (clip {}); queueing another attempt at that clip: {error}",
                 taken.uuid
             );
-            if restore_marker(taken) {
-                schedule_forget_retry(app, db, sequence, attempts_left);
-            }
+            requeue(app, db, taken);
             return;
         }
     };
@@ -2705,9 +2714,7 @@ async fn process_clipboard_clear(
         Ok(tx) => tx,
         Err(error) => {
             log::error!("CLIPBOARD: Failed to begin clear-forget transaction: {error}");
-            if restore_marker(recent) {
-                schedule_forget_retry(app, db, sequence, attempts_left);
-            }
+            requeue(app, db, recent);
             return;
         }
     };
@@ -2747,9 +2754,7 @@ async fn process_clipboard_clear(
                 "CLIPBOARD: Failed to forget cleared capture {}: {error}",
                 recent.uuid
             );
-            if restore_marker(recent) {
-                schedule_forget_retry(app, db, sequence, attempts_left);
-            }
+            requeue(app, db, recent);
             return;
         }
     };
@@ -2770,10 +2775,18 @@ async fn process_clipboard_clear(
             "CLIPBOARD: Failed to commit clear-forget for {}: {error}",
             recent.uuid
         );
-        if restore_marker(recent) {
-            schedule_forget_retry(app, db, sequence, attempts_left);
-        }
+        requeue(app, db, recent);
         return;
+    }
+
+    // A retry never took the marker, so it can still point at the row that was
+    // just deleted. Clear it only in that case: a newer copy owns the slot now
+    // and must keep its own forget-on-clear window.
+    {
+        let mut lock = LAST_ACCEPTED_CAPTURE.lock();
+        if lock.as_ref().is_some_and(|held| held.uuid == recent.uuid) {
+            lock.take();
+        }
     }
 
     crate::commands::remove_clip_image_files(&db.image_dir, file_path.into_iter().collect());
@@ -2800,13 +2813,29 @@ async fn process_clipboard_clear(
 /// SBS-1003: a password manager clears once. Restoring the marker without a
 /// follow-up attempt left the password in history whenever SQLITE_BUSY won
 /// that single SELECT/DELETE.
-fn schedule_forget_retry(app: AppHandle, db: Arc<Database>, sequence: u32, attempts_left: u8) {
+///
+/// The capture travels with the retry. The first attempt holds CLIPBOARD_SYNC
+/// across its lookup, so snapshots queue behind it and land the moment it
+/// fails; a retry that re-read the marker would delete one of those instead of
+/// the password this clear was about.
+fn schedule_forget_retry(
+    app: AppHandle,
+    db: Arc<Database>,
+    sequence: u32,
+    attempts_left: u8,
+    recent: RecentCapture,
+) {
     let Some(remaining) = next_forget_attempts(attempts_left) else {
+        log::warn!(
+            "CLIPBOARD: forget-on-clear gave up on {} after {} attempts",
+            recent.uuid,
+            FORGET_ON_CLEAR_ATTEMPTS
+        );
         return;
     };
     tauri::async_runtime::spawn(async move {
         tokio::time::sleep(FORGET_ON_CLEAR_RETRY_DELAY).await;
-        process_clipboard_clear(app, db, sequence, remaining).await;
+        process_clipboard_clear(app, db, sequence, remaining, Some(recent)).await;
     });
 }
 

--- a/src-tauri/src/clipboard/forget_on_clear.rs
+++ b/src-tauri/src/clipboard/forget_on_clear.rs
@@ -27,6 +27,39 @@ impl<T, M, E> ForgetClipLookup<T, M, E> {
     }
 }
 
+/// Which capture a forget-on-clear attempt acts on.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ForgetAttempt<T> {
+    /// A retry deletes the capture it was scheduled for, full stop.
+    Pinned(T),
+    /// A first attempt takes the marker, but only inside the forget window.
+    FromMarker(T),
+    /// Nothing to forget.
+    Nothing,
+}
+
+/// Pick the capture for this attempt.
+///
+/// A pinned capture wins outright. The first attempt holds CLIPBOARD_SYNC
+/// across its lookup, so queued snapshots land the moment it fails and
+/// overwrite the marker; a retry that re-read the marker would delete one of
+/// those copies instead of the password the clear was about. Re-checking the
+/// window is wrong for the same reason: a capture 89.9s old would age past 90s
+/// during the retry delay and escape a forget it had already earned.
+pub(crate) fn select_forget_attempt<T>(
+    pinned: Option<T>,
+    marker: Option<T>,
+    marker_within_window: bool,
+) -> ForgetAttempt<T> {
+    if let Some(capture) = pinned {
+        return ForgetAttempt::Pinned(capture);
+    }
+    match marker {
+        Some(capture) if marker_within_window => ForgetAttempt::FromMarker(capture),
+        _ => ForgetAttempt::Nothing,
+    }
+}
+
 /// Remaining attempts after this one failed. `None` means stop restoring and
 /// waiting — a password manager only clears once (SBS-1003).
 pub(crate) fn next_forget_attempts(attempts_left: u8) -> Option<u8> {
@@ -73,5 +106,41 @@ mod tests {
         assert_eq!(super::next_forget_attempts(2), Some(1));
         assert_eq!(super::next_forget_attempts(1), None);
         assert_eq!(super::next_forget_attempts(0), None);
+    }
+    #[test]
+    fn a_retry_deletes_its_own_capture_not_whatever_landed_since() {
+        // SQLITE_BUSY holds the first attempt with CLIPBOARD_SYNC taken, so a
+        // queued copy overwrites the marker the moment it fails. The retry must
+        // still delete the password, not that copy.
+        assert_eq!(
+            super::select_forget_attempt(Some("password"), Some("later-copy"), true),
+            super::ForgetAttempt::Pinned("password")
+        );
+    }
+
+    #[test]
+    fn a_retry_ignores_the_forget_window() {
+        // A capture 89.9s old ages past 90s during the retry delay. It earned
+        // the forget on the first attempt and must not lose it to the clock.
+        assert_eq!(
+            super::select_forget_attempt(Some("password"), None, false),
+            super::ForgetAttempt::Pinned("password")
+        );
+    }
+
+    #[test]
+    fn a_first_attempt_takes_the_marker_only_inside_the_window() {
+        assert_eq!(
+            super::select_forget_attempt(None, Some("recent"), true),
+            super::ForgetAttempt::FromMarker("recent")
+        );
+        assert_eq!(
+            super::select_forget_attempt(None, Some("stale"), false),
+            super::ForgetAttempt::Nothing
+        );
+        assert_eq!(
+            super::select_forget_attempt::<&str>(None, None, true),
+            super::ForgetAttempt::Nothing
+        );
     }
 }


### PR DESCRIPTION
Follow-up to #243, which CodeRev reviewed after it merged. Three findings, verified against the code before fixing.

### The retry could delete the wrong clip

`schedule_forget_retry` re-entered `process_clipboard_clear`, which read `LAST_ACCEPTED_CAPTURE` from scratch. The first attempt holds `CLIPBOARD_SYNC` across its lookup and sqlx waits out its default 5s busy timeout, so Content events queue behind it and land the instant it fails. The retry then took whatever copy had just claimed the marker, and if that copy was credential-shaped it was deleted -- while the password the clear was actually about stayed in history.

Gating the retry on a successful marker restore (the first pass at this) only closed the failure moment itself. The marker could still be replaced during the 80ms delay.

The capture now travels with the retry, and `select_forget_attempt` states the rule in one place.

### The window was re-checked on every attempt

A capture 89.9s old passed the 90s check, failed with `SQLITE_BUSY`, and then aged past the window during the 80ms delay -- so the retry returned early and the password stayed. A retry no longer re-checks the window: it deletes the capture it was scheduled for.

### The failure log was wrong

It said the retry marker was restored before the restore was attempted, and the restore is declined when a newer copy owns the slot. Triage read a restore that never happened.

Also: a successful forget now clears the marker when it still points at the row just deleted, which the retry path did not take.

### Tests

`select_forget_attempt` is a pure helper, tested for all three rules: a retry keeps its own capture when a later copy claimed the marker, a retry ignores the window, and a first attempt takes the marker only inside it.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix forget-on-clear retries to carry the original capture across attempts
> - `process_clipboard_clear` now accepts an optional `pinned: Option<RecentCapture>` and delegates target selection to a new `select_forget_attempt` helper in [forget_on_clear.rs](https://github.com/tsouth89/cubby-clipboard/pull/253/files#diff-d847f1e6a544f67702a7437ef290edf9bfb814e4980abd1ecd59d6b7975cd851), which prefers the pinned capture, falls back to the marker only if within the forget window, or selects nothing.
> - `schedule_forget_retry` now carries the specific `RecentCapture` into the rescheduled call so retries always target the same capture instead of re-reading the current marker.
> - First attempts take the marker only if it is still within the forget window; after a successful delete, `LAST_ACCEPTED_CAPTURE` is cleared only if it still points to the deleted capture's UUID.
> - Behavioral Change: retries no longer re-evaluate the marker or the forget window — they always act on the capture that was originally targeted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 063e62b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->