### PR TITLE
SBS-991: Let a hotkey save survive a dead shortcut channel

### DIFF
--- a/src-tauri/src/settings_commands.rs
+++ b/src-tauri/src/settings_commands.rs
@@ -130,12 +130,31 @@ pub async fn save_settings(
     // changes, so the remote-session trigger tracks the current hotkey.
     if shortcut_settings_changed {
         let replacement = app.state::<Arc<crate::win_v_replacement::WinVReplacementManager>>();
-        if let Err(error) = replacement.configure(
-            new_settings.replace_win_v,
-            Some(new_settings.hotkey.clone()),
+        // replace_win_v defaults to true and persists, so a hotkey-only save on
+        // a session whose shortcut channel failed to bind still arrives here as
+        // enabled=true. Rolling the save back for that left the user unable to
+        // change their hotkey until they switched replacement off, and that off
+        // value would then stick on the next good launch (SBS-991).
+        let newly_enabled = new_settings.replace_win_v && !current.replace_win_v;
+        if crate::win_v_replacement::shortcut_save_blocked(
+            replacement.is_available(),
+            newly_enabled,
         ) {
             restore_shortcut_settings(&app, &current);
-            return Err(error);
+            return Err("Cubby shortcut channel is unavailable this session".to_string());
+        }
+        if replacement.is_available() {
+            if let Err(error) = replacement.configure(
+                new_settings.replace_win_v,
+                Some(new_settings.hotkey.clone()),
+            ) {
+                restore_shortcut_settings(&app, &current);
+                return Err(error);
+            }
+        } else {
+            log::warn!(
+                "SETTINGS: Saved shortcut settings without the Win+V helper; the shortcut channel is unavailable this session"
+            );
         }
     }
 

--- a/src-tauri/src/win_v_replacement.rs
+++ b/src-tauri/src/win_v_replacement.rs
@@ -128,6 +128,12 @@ impl WinVReplacementManager {
         })
     }
 
+    /// Whether the shortcut channel bound this session. False means the helper
+    /// cannot be started at all until Cubby restarts.
+    pub fn is_available(&self) -> bool {
+        self.inner.activation_port != 0
+    }
+
     pub fn configure(&self, enabled: bool, hotkey: Option<String>) -> Result<(), String> {
         if enabled && self.inner.activation_port == 0 {
             return Err("Cubby shortcut channel is unavailable this session".to_string());
@@ -272,9 +278,20 @@ fn stop_child(child: &mut Option<Child>) {
     }
 }
 
+/// Whether a settings save must fail because Win+V replacement cannot start.
+///
+/// Only a fresh "turn it on" is worth refusing a save for. When the preference
+/// is already on from a previous session, a dead channel must not block an
+/// unrelated hotkey edit: the user would have to switch replacement off to
+/// save a hotkey, and that off value is a real preference that would then
+/// stick on the next good launch (SBS-991).
+pub fn shortcut_save_blocked(channel_available: bool, newly_enabled: bool) -> bool {
+    !channel_available && newly_enabled
+}
+
 #[cfg(test)]
 mod tests {
-    use super::WinVReplacementManager;
+    use super::{shortcut_save_blocked, WinVReplacementManager};
 
     #[test]
     fn missing_channel_refuses_enable_and_allows_disable() {
@@ -284,5 +301,17 @@ mod tests {
             "Win+V replacement must not start without a shortcut channel"
         );
         assert!(manager.configure(false, None).is_ok());
+        assert!(!manager.is_available());
+    }
+
+    #[test]
+    fn a_dead_channel_only_blocks_a_fresh_enable() {
+        // replace_win_v defaults to true and persists, so a hotkey-only save on
+        // a session whose channel failed to bind still arrives as enabled=true.
+        // Refusing it left the user unable to change their hotkey all session.
+        assert!(shortcut_save_blocked(false, true));
+        assert!(!shortcut_save_blocked(false, false));
+        assert!(!shortcut_save_blocked(true, true));
+        assert!(!shortcut_save_blocked(true, false));
     }
 }


### PR DESCRIPTION
Follow-up to #238, reviewed by CodeRev after it merged.

When the UDP bind or token mint fails, `configure(true)` returns `Err` before it touches state. `replace_win_v` defaults to true and lives in `settings.json`, and nothing writes it false, so it is still true on the next save. A hotkey-only edit therefore arrives as `configure(true, new_hotkey)` and rolls the whole `save_settings` back.

The result: on a session where the shortcut channel could not bind, the user cannot change their hotkey at all unless they first switch Win+V replacement off -- and that off value is a real preference that would then stick on the next good launch.

Only a fresh turn-it-on is worth refusing a save for. `shortcut_save_blocked(channel_available, newly_enabled)` states that rule, `save_settings` skips the helper call when the channel is unavailable rather than failing, and the persisted preference is never rewritten.

Tests cover `is_available()` on a channel-less manager and all four cases of `shortcut_save_blocked`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Let hotkey saves succeed when the Win+V shortcut channel is unavailable
> - `save_settings` previously failed whenever the Win+V shortcut channel was unavailable, even for saves that only adjusted an already-enabled shortcut setting.
> - Introduces `shortcut_save_blocked` in [win_v_replacement.rs](https://github.com/tsouth89/cubby-clipboard/pull/254/files#diff-939ae675cd2312cbdeaba6119e337096e8b02013895f212c7b0419205377c207) to gate saves only when the channel is unavailable **and** `replace_win_v` is being newly enabled; all other saves proceed.
> - When the channel is unavailable and replacement was already enabled, `save_settings` skips `configure`, logs a warning, and returns success instead of an error.
> - Adds `WinVReplacementManager.is_available()` to expose whether the shortcut channel was bound this session.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 87fb14c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->