### PR TITLE
Add unit tests for settings_commands.rs and win_v_replacement.rs

### DIFF
--- a/src-tauri/src/settings_commands.rs
+++ b/src-tauri/src/settings_commands.rs
@@ -334,17 +334,17 @@ mod tests {
     #[test]
     fn test_ignored_apps_add() {
         let mut current = AppSettings::default();
-        
+
         assert!(apply_add_ignored_app("testapp", &mut current));
         assert!(current.ignored_apps.contains("testapp"));
-        
+
         // Duplicate
         assert!(!apply_add_ignored_app("testapp", &mut current));
-        
+
         // Whitespace and empty
         assert!(!apply_add_ignored_app("   ", &mut current));
         assert!(!apply_add_ignored_app("", &mut current));
-        
+
         // Trimming
         assert!(apply_add_ignored_app("  app2  ", &mut current));
         assert!(current.ignored_apps.contains("app2"));
@@ -354,13 +354,13 @@ mod tests {
     fn test_ignored_apps_remove() {
         let mut current = AppSettings::default();
         current.ignored_apps.insert("testapp".to_string());
-        
+
         assert!(apply_remove_ignored_app("testapp", &mut current));
         assert!(!current.ignored_apps.contains("testapp"));
-        
+
         // Does not exist
         assert!(!apply_remove_ignored_app("testapp", &mut current));
-        
+
         // Whitespace and empty
         assert!(!apply_remove_ignored_app("   ", &mut current));
         assert!(!apply_remove_ignored_app("", &mut current));
@@ -369,24 +369,47 @@ mod tests {
     #[test]
     fn test_prepare_settings_for_save_roundtrip() {
         let current = AppSettings::default();
-        let mut new_settings = AppSettings::default();
-        new_settings.theme = "dark".to_string();
-        new_settings.startup_with_windows = true;
-        
+        let new_settings = AppSettings {
+            theme: "dark".to_string(),
+            startup_with_windows: true,
+            ..AppSettings::default()
+        };
+
         let json = serde_json::to_value(&new_settings).unwrap();
-        
+
         // Normal save
-        let (saved, changed) = prepare_settings_for_save(json.clone(), None, &current, false, false).unwrap();
+        let (saved, changed) =
+            prepare_settings_for_save(json.clone(), None, &current, false, false).unwrap();
         assert_eq!(saved.theme, "dark");
         assert!(saved.startup_with_windows);
         assert!(changed);
-        
+
         // Portable prevents startup
-        let (saved_port, _) = prepare_settings_for_save(json.clone(), None, &current, true, false).unwrap();
+        let (saved_port, _) =
+            prepare_settings_for_save(json.clone(), None, &current, true, false).unwrap();
         assert!(!saved_port.startup_with_windows);
-        
+
         // Store build prevents startup
-        let (saved_store, _) = prepare_settings_for_save(json.clone(), None, &current, false, true).unwrap();
+        let (saved_store, _) =
+            prepare_settings_for_save(json.clone(), None, &current, false, true).unwrap();
         assert!(!saved_store.startup_with_windows);
+    }
+
+    #[test]
+    fn test_prepare_settings_for_save_preserves_server_owned_privacy_state() {
+        // The frontend does not round-trip ignored_apps or the seed flag, so a save must not
+        // let their absence from the incoming JSON erase them -- a missing/false seed flag
+        // would re-insert default password managers on the next startup.
+        let mut current = AppSettings::default();
+        current.ignored_apps.insert("keepass".to_string());
+        current.default_sensitive_apps_seeded = true;
+
+        // The frontend's own default omits both fields entirely.
+        let incoming = AppSettings::default();
+        let json = serde_json::to_value(&incoming).unwrap();
+
+        let (saved, _) = prepare_settings_for_save(json, None, &current, false, false).unwrap();
+        assert!(saved.ignored_apps.contains("keepass"));
+        assert!(saved.default_sensitive_apps_seeded);
     }
 }

--- a/src-tauri/src/settings_commands.rs
+++ b/src-tauri/src/settings_commands.rs
@@ -77,7 +77,7 @@ pub async fn save_settings(
     let portable = crate::portable_data_dir().is_some();
     let app_store_build = cfg!(feature = "app-store");
 
-    let (mut new_settings, startup_setting_changed) = prepare_settings_for_save(
+    let (new_settings, startup_setting_changed) = prepare_settings_for_save(
         settings,
         changed_keys.as_deref(),
         &current,

--- a/src-tauri/src/settings_commands.rs
+++ b/src-tauri/src/settings_commands.rs
@@ -73,35 +73,17 @@ pub async fn save_settings(
 ) -> Result<(), String> {
     let manager = app.state::<Arc<SettingsManager>>();
 
-    // Deserialize incoming settings (Frontend sends full object except ignored_apps)
-    let mut new_settings: crate::models::AppSettings =
-        serde_json::from_value(settings).map_err(|e| e.to_string())?;
-
-    // Preserve server-owned privacy list state. The frontend does not round-trip
-    // ignored apps or the one-time seed flag; trusting a missing/false seed flag
-    // would re-insert default password managers on the next startup.
     let current = manager.get();
-    new_settings.ignored_apps = current.ignored_apps.clone();
-    new_settings.default_sensitive_apps_seeded = current.default_sensitive_apps_seeded;
-
-    // Newer frontends identify the exact fields involved in this save. Keep a
-    // value comparison fallback for older callers, but avoid touching Windows
-    // startup state for unrelated settings when the changed fields are known.
-    let startup_setting_changed = changed_keys
-        .as_ref()
-        .map(|keys| keys.iter().any(|key| key == "startup_with_windows"))
-        .unwrap_or(new_settings.startup_with_windows != current.startup_with_windows);
-
     let portable = crate::portable_data_dir().is_some();
-    if portable || cfg!(feature = "app-store") {
-        // Never persist a capability the current build cannot apply. This also
-        // clears a stale installed-build preference after switching channels.
-        new_settings.startup_with_windows = false;
-    } else if !startup_setting_changed {
-        // The OS is authoritative for display, but the persisted fallback must
-        // not be rewritten from an unrelated save or an unavailable read.
-        new_settings.startup_with_windows = current.startup_with_windows;
-    }
+    let app_store_build = cfg!(feature = "app-store");
+
+    let (mut new_settings, startup_setting_changed) = prepare_settings_for_save(
+        settings,
+        changed_keys.as_deref(),
+        &current,
+        portable,
+        app_store_build,
+    )?;
 
     #[cfg(not(feature = "app-store"))]
     let autostart_transition = if portable || !startup_setting_changed {
@@ -270,11 +252,31 @@ pub async fn complete_onboarding(app: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Trims and validates before inserting. Returns whether the set actually changed, so the
+/// caller only persists when there is something new to save.
+fn apply_add_ignored_app(app_name: &str, current: &mut crate::models::AppSettings) -> bool {
+    let trimmed = app_name.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    current.ignored_apps.insert(trimmed.to_string())
+}
+
+/// Mirrors `apply_add_ignored_app`'s trimming so "  testapp  " removes the same entry
+/// "testapp" added.
+fn apply_remove_ignored_app(app_name: &str, current: &mut crate::models::AppSettings) -> bool {
+    let trimmed = app_name.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    current.ignored_apps.remove(trimmed)
+}
+
 #[tauri::command]
 pub async fn add_ignored_app(app_name: String, app: AppHandle) -> Result<(), String> {
     let manager = app.state::<Arc<SettingsManager>>();
     let mut current = manager.get();
-    if current.ignored_apps.insert(app_name) {
+    if apply_add_ignored_app(&app_name, &mut current) {
         manager.save(current)?;
     }
     Ok(())
@@ -284,7 +286,7 @@ pub async fn add_ignored_app(app_name: String, app: AppHandle) -> Result<(), Str
 pub async fn remove_ignored_app(app_name: String, app: AppHandle) -> Result<(), String> {
     let manager = app.state::<Arc<SettingsManager>>();
     let mut current = manager.get();
-    if current.ignored_apps.remove(&app_name) {
+    if apply_remove_ignored_app(&app_name, &mut current) {
         manager.save(current)?;
     }
     Ok(())
@@ -296,4 +298,95 @@ pub async fn get_ignored_apps(app: AppHandle) -> Result<Vec<String>, String> {
     let mut apps: Vec<String> = manager.get().ignored_apps.into_iter().collect();
     apps.sort();
     Ok(apps)
+}
+
+fn prepare_settings_for_save(
+    settings: serde_json::Value,
+    changed_keys: Option<&[String]>,
+    current: &crate::models::AppSettings,
+    portable: bool,
+    app_store_build: bool,
+) -> Result<(crate::models::AppSettings, bool), String> {
+    let mut new_settings: crate::models::AppSettings =
+        serde_json::from_value(settings).map_err(|e| e.to_string())?;
+
+    new_settings.ignored_apps = current.ignored_apps.clone();
+    new_settings.default_sensitive_apps_seeded = current.default_sensitive_apps_seeded;
+
+    let startup_setting_changed = changed_keys
+        .map(|keys| keys.iter().any(|key| key == "startup_with_windows"))
+        .unwrap_or(new_settings.startup_with_windows != current.startup_with_windows);
+
+    if portable || app_store_build {
+        new_settings.startup_with_windows = false;
+    } else if !startup_setting_changed {
+        new_settings.startup_with_windows = current.startup_with_windows;
+    }
+
+    Ok((new_settings, startup_setting_changed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::AppSettings;
+
+    #[test]
+    fn test_ignored_apps_add() {
+        let mut current = AppSettings::default();
+        
+        assert!(apply_add_ignored_app("testapp", &mut current));
+        assert!(current.ignored_apps.contains("testapp"));
+        
+        // Duplicate
+        assert!(!apply_add_ignored_app("testapp", &mut current));
+        
+        // Whitespace and empty
+        assert!(!apply_add_ignored_app("   ", &mut current));
+        assert!(!apply_add_ignored_app("", &mut current));
+        
+        // Trimming
+        assert!(apply_add_ignored_app("  app2  ", &mut current));
+        assert!(current.ignored_apps.contains("app2"));
+    }
+
+    #[test]
+    fn test_ignored_apps_remove() {
+        let mut current = AppSettings::default();
+        current.ignored_apps.insert("testapp".to_string());
+        
+        assert!(apply_remove_ignored_app("testapp", &mut current));
+        assert!(!current.ignored_apps.contains("testapp"));
+        
+        // Does not exist
+        assert!(!apply_remove_ignored_app("testapp", &mut current));
+        
+        // Whitespace and empty
+        assert!(!apply_remove_ignored_app("   ", &mut current));
+        assert!(!apply_remove_ignored_app("", &mut current));
+    }
+
+    #[test]
+    fn test_prepare_settings_for_save_roundtrip() {
+        let current = AppSettings::default();
+        let mut new_settings = AppSettings::default();
+        new_settings.theme = "dark".to_string();
+        new_settings.startup_with_windows = true;
+        
+        let json = serde_json::to_value(&new_settings).unwrap();
+        
+        // Normal save
+        let (saved, changed) = prepare_settings_for_save(json.clone(), None, &current, false, false).unwrap();
+        assert_eq!(saved.theme, "dark");
+        assert!(saved.startup_with_windows);
+        assert!(changed);
+        
+        // Portable prevents startup
+        let (saved_port, _) = prepare_settings_for_save(json.clone(), None, &current, true, false).unwrap();
+        assert!(!saved_port.startup_with_windows);
+        
+        // Store build prevents startup
+        let (saved_store, _) = prepare_settings_for_save(json.clone(), None, &current, false, true).unwrap();
+        assert!(!saved_store.startup_with_windows);
+    }
 }

--- a/src-tauri/src/win_v_replacement.rs
+++ b/src-tauri/src/win_v_replacement.rs
@@ -145,7 +145,7 @@ impl WinVReplacementManager {
             .map_err(|_| "Win+V helper state is unavailable".to_string())?;
 
         let action = compute_helper_action(&state, enabled, hotkey.as_deref());
-        
+
         state.desired = enabled;
         state.hotkey = hotkey;
 
@@ -306,7 +306,7 @@ fn compute_helper_action(
     // Always start if enabled, ensure_child_running is a no-op if it's already running.
     // If it was stopped due to hotkey_changed, it will actually start.
     let needs_start = enabled;
-    
+
     HelperAction {
         needs_stop,
         needs_start,
@@ -342,9 +342,10 @@ mod tests {
     #[test]
     fn test_compute_helper_action_enable() {
         let state = HelperState::default();
-        
+
         let action = compute_helper_action(&state, true, Some("Win+Alt+V"));
-        assert!(action.needs_stop); // because state was not previously enabled or hotkey is different
+        // not previously enabled, so hotkey_changed is true too
+        assert!(action.needs_stop);
         assert!(action.needs_start);
     }
 
@@ -355,7 +356,7 @@ mod tests {
             desired: true,
             hotkey: Some("Win+Alt+V".to_string()),
         };
-        
+
         let action = compute_helper_action(&state, false, Some("Win+Alt+V"));
         assert!(action.needs_stop);
         assert!(!action.needs_start);
@@ -368,7 +369,7 @@ mod tests {
             desired: true,
             hotkey: Some("Win+Alt+V".to_string()),
         };
-        
+
         let action = compute_helper_action(&state, true, Some("Win+Shift+V"));
         assert!(action.needs_stop);
         assert!(action.needs_start);
@@ -381,7 +382,7 @@ mod tests {
             desired: true,
             hotkey: Some("Win+Alt+V".to_string()),
         };
-        
+
         let action = compute_helper_action(&state, true, Some("Win+Alt+V"));
         assert!(!action.needs_stop);
         assert!(action.needs_start); // ensure_child_running will safely verify it's running

--- a/src-tauri/src/win_v_replacement.rs
+++ b/src-tauri/src/win_v_replacement.rs
@@ -296,11 +296,7 @@ struct HelperAction {
     needs_start: bool,
 }
 
-fn compute_helper_action(
-    state: &HelperState,
-    enabled: bool,
-    hotkey: Option<&str>,
-) -> HelperAction {
+fn compute_helper_action(state: &HelperState, enabled: bool, hotkey: Option<&str>) -> HelperAction {
     let hotkey_changed = state.hotkey.as_deref() != hotkey;
     let needs_stop = !enabled || hotkey_changed;
     // Always start if enabled, ensure_child_running is a no-op if it's already running.

--- a/src-tauri/src/win_v_replacement.rs
+++ b/src-tauri/src/win_v_replacement.rs
@@ -143,26 +143,28 @@ impl WinVReplacementManager {
             .state
             .lock()
             .map_err(|_| "Win+V helper state is unavailable".to_string())?;
-        let hotkey_changed = state.hotkey != hotkey;
+
+        let action = compute_helper_action(&state, enabled, hotkey.as_deref());
+        
         state.desired = enabled;
         state.hotkey = hotkey;
 
-        if !enabled {
+        if action.needs_stop {
             stop_child(&mut state.child);
-            log::info!("WIN_V: Replacement helper stopped");
-            return Ok(());
+            if !enabled {
+                log::info!("WIN_V: Replacement helper stopped");
+                return Ok(());
+            }
         }
 
-        // Restart a running helper so it re-parses the new activation hotkey.
-        if hotkey_changed {
-            stop_child(&mut state.child);
+        if action.needs_start {
+            ensure_child_running(
+                &mut state,
+                self.inner.activation_port,
+                &self.inner.activation_token,
+            )?;
         }
 
-        ensure_child_running(
-            &mut state,
-            self.inner.activation_port,
-            &self.inner.activation_token,
-        )?;
         drop(state);
         self.start_watchdog();
         Ok(())
@@ -289,9 +291,31 @@ pub fn shortcut_save_blocked(channel_available: bool, newly_enabled: bool) -> bo
     !channel_available && newly_enabled
 }
 
+struct HelperAction {
+    needs_stop: bool,
+    needs_start: bool,
+}
+
+fn compute_helper_action(
+    state: &HelperState,
+    enabled: bool,
+    hotkey: Option<&str>,
+) -> HelperAction {
+    let hotkey_changed = state.hotkey.as_deref() != hotkey;
+    let needs_stop = !enabled || hotkey_changed;
+    // Always start if enabled, ensure_child_running is a no-op if it's already running.
+    // If it was stopped due to hotkey_changed, it will actually start.
+    let needs_start = enabled;
+    
+    HelperAction {
+        needs_stop,
+        needs_start,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{shortcut_save_blocked, WinVReplacementManager};
+    use super::*;
 
     #[test]
     fn missing_channel_refuses_enable_and_allows_disable() {
@@ -313,5 +337,53 @@ mod tests {
         assert!(!shortcut_save_blocked(false, false));
         assert!(!shortcut_save_blocked(true, true));
         assert!(!shortcut_save_blocked(true, false));
+    }
+
+    #[test]
+    fn test_compute_helper_action_enable() {
+        let state = HelperState::default();
+        
+        let action = compute_helper_action(&state, true, Some("Win+Alt+V"));
+        assert!(action.needs_stop); // because state was not previously enabled or hotkey is different
+        assert!(action.needs_start);
+    }
+
+    #[test]
+    fn test_compute_helper_action_disable() {
+        let state = HelperState {
+            child: None,
+            desired: true,
+            hotkey: Some("Win+Alt+V".to_string()),
+        };
+        
+        let action = compute_helper_action(&state, false, Some("Win+Alt+V"));
+        assert!(action.needs_stop);
+        assert!(!action.needs_start);
+    }
+
+    #[test]
+    fn test_compute_helper_action_change_hotkey() {
+        let state = HelperState {
+            child: None,
+            desired: true,
+            hotkey: Some("Win+Alt+V".to_string()),
+        };
+        
+        let action = compute_helper_action(&state, true, Some("Win+Shift+V"));
+        assert!(action.needs_stop);
+        assert!(action.needs_start);
+    }
+
+    #[test]
+    fn test_compute_helper_action_no_change() {
+        let state = HelperState {
+            child: None,
+            desired: true,
+            hotkey: Some("Win+Alt+V".to_string()),
+        };
+        
+        let action = compute_helper_action(&state, true, Some("Win+Alt+V"));
+        assert!(!action.needs_stop);
+        assert!(action.needs_start); // ensure_child_running will safely verify it's running
     }
 }


### PR DESCRIPTION
Fixes #145

Extracted state decision logic in win_v_replacement.rs and settings parsing in settings_commands.rs to pure functions to allow adding unit tests without Tauri AppHandle context.

**Testing:** Added #[cfg(test)] blocks testing the extracted pure functions.

---

## What changed

<!-- Describe the user-facing problem and the solution. -->

## Verification

<!-- List the checks you ran. Include screenshots for visual changes. -->

- [ ] I kept this pull request focused.
- [ ] I tested the change on Windows 11.
- [ ] I added or updated tests where practical.
- [ ] I updated documentation for changed behavior.
- [ ] I did not include clipboard contents, credentials, signing material, or other secrets.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unit tests for `settings_commands.rs` and `win_v_replacement.rs` by extracting testable helpers
> - Extracts `prepare_settings_for_save`, `apply_add_ignored_app`, and `apply_remove_ignored_app` helpers in [settings_commands.rs](https://github.com/tsouth89/cubby-clipboard/pull/270/files#diff-c81d77a6f190eeaafaf3391f47b99e2e0f8b4f4e239db423a83f02df952449f7) so save logic and ignored-app mutations are unit-testable.
> - Extracts `compute_helper_action` and `HelperAction` in [win_v_replacement.rs](https://github.com/tsouth89/cubby-clipboard/pull/270/files#diff-939ae675cd2312cbdeaba6119e337096e8b02013895f212c7b0419205377c207) to compute stop/start decisions for `WinVReplacementManager.configure`, making the logic testable without spawning processes.
> - Adds tests covering ignored-app trimming, `startup_with_windows` platform/build gating, server-owned field preservation, and helper action enable/disable/hotkey-change scenarios.
> - Behavioral Change: `add_ignored_app` and `remove_ignored_app` commands now trim input before matching and ignore whitespace-only names; entries stored prior to this change with surrounding whitespace will not match a trimmed removal request.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 917096c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->