### PR TITLE
Drop the retired pr-review.yml from the privileged-pin check

### DIFF
--- a/.github/scripts/check-privileged-action-pins.mjs
+++ b/.github/scripts/check-privileged-action-pins.mjs
@@ -2,13 +2,14 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+// Any workflow that runs in the base-repo context with write scopes belongs
+// here, because an unpinned third-party action in one of these executes with
+// those permissions (SBS-984). Every `pull_request_target` workflow qualifies;
+// the test suite enforces that so a new one cannot be added and forgotten.
 export const PRIVILEGED_WORKFLOWS = [
   '.github/workflows/release.yml',
   '.github/workflows/publish-store-packages.yml',
   '.github/workflows/validate-store-submission.yml',
-  // pull_request_target + pull-requests:write. An unpinned third-party
-  // action here runs in the base-repo context with those permissions (SBS-984).
-  '.github/workflows/pr-review.yml',
 ];
 
 const FIRST_PARTY_OWNERS = new Set(['actions']);
@@ -111,7 +112,21 @@ export function violationsOf(findings) {
 export async function checkPrivilegedActionPins(rootDir) {
   const findings = [];
   for (const relativePath of PRIVILEGED_WORKFLOWS) {
-    const text = await readFile(path.join(rootDir, relativePath), 'utf8');
+    let text;
+    try {
+      text = await readFile(path.join(rootDir, relativePath), 'utf8');
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        // A retired or renamed workflow must not surface as a bare ENOENT
+        // stack trace three CI steps deep. Say which entry is stale and what
+        // to do about it.
+        throw new Error(
+          `${relativePath} is listed in PRIVILEGED_WORKFLOWS but does not exist. ` +
+            'Drop the entry if the workflow was retired, or update it if it was renamed.',
+        );
+      }
+      throw error;
+    }
     findings.push(...parseWorkflowUses(text, relativePath));
   }
   return {

--- a/.github/scripts/check-privileged-action-pins.test.mjs
+++ b/.github/scripts/check-privileged-action-pins.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -14,11 +14,52 @@ import {
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
-test('privileged workflow list includes pr-review.yml', () => {
-  assert.ok(
-    PRIVILEGED_WORKFLOWS.includes('.github/workflows/pr-review.yml'),
-    'pr-review.yml is pull_request_target and must be pin-checked (SBS-984)',
+/**
+ * SBS-984, generalized. This used to hardcode pr-review.yml, which meant
+ * retiring that workflow left a stale PRIVILEGED_WORKFLOWS entry and broke
+ * three CI steps with an ENOENT. Assert the invariant the filename stood for
+ * instead: a `pull_request_target` workflow runs in the base-repo context with
+ * write scopes, so every one of them must be pin-checked.
+ */
+test('every pull_request_target workflow is pin-checked', async () => {
+  const workflowDir = path.join(repoRoot, '.github/workflows');
+  const unlisted = [];
+  for (const name of await readdir(workflowDir)) {
+    if (!/\.ya?ml$/.test(name)) continue;
+    const source = await readFile(path.join(workflowDir, name), 'utf8');
+    // Trigger keys sit under `on:`; a `#`-prefixed mention will not match.
+    if (!/^\s*pull_request_target\s*:/m.test(source)) continue;
+    const relativePath = `.github/workflows/${name}`;
+    if (!PRIVILEGED_WORKFLOWS.includes(relativePath)) unlisted.push(relativePath);
+  }
+  assert.deepEqual(
+    unlisted,
+    [],
+    `pull_request_target workflows missing from PRIVILEGED_WORKFLOWS (SBS-984): ${unlisted.join(', ')}`,
   );
+});
+
+/** Every listed workflow must exist, and a stale entry must say so plainly. */
+test('a listed workflow that no longer exists fails with an actionable message', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'sbs-984-'));
+  await mkdir(path.join(root, '.github', 'workflows'), { recursive: true });
+  await assert.rejects(
+    () => checkPrivilegedActionPins(root),
+    (error) => {
+      assert.match(error.message, /listed in PRIVILEGED_WORKFLOWS but does not exist/);
+      assert.match(error.message, /Drop the entry|update it/);
+      return true;
+    },
+  );
+});
+
+test('every listed privileged workflow is present in the repo', async () => {
+  for (const relativePath of PRIVILEGED_WORKFLOWS) {
+    await assert.doesNotReject(
+      () => readFile(path.join(repoRoot, relativePath), 'utf8'),
+      `${relativePath} is listed in PRIVILEGED_WORKFLOWS but missing from the repo`,
+    );
+  }
 });
 
 test('SHA pin with a version comment is accepted', () => {


### PR DESCRIPTION
## Why

`260819d` ("Remove the CodeRev shadow review workflow") deleted `.github/workflows/pr-review.yml` but left it listed in `PRIVILEGED_WORKFLOWS`. `checkPrivilegedActionPins` reads every listed path with no guard, so it now dies on an unhandled `ENOENT`:

```
Error: ENOENT: no such file or directory, open '...\.github\workflows\pr-review.yml'
    at async checkPrivilegedActionPins (.github/scripts/check-privileged-action-pins.mjs:114:18)
    at async scripts/check-release.mjs:525:18
```

That takes out **three steps of the required `test` job** — `pnpm run release:check`, the direct `node .github/scripts/check-privileged-action-pins.mjs` run, and the `node --test` suite (which also asserted the filename was in the list). `main` is red and every open PR inherits it.

This is separate from the Rust 1.98 clippy breakage in #274 — that one is fixed and green on its own; this landed on top of it.

## What

- **Drop the stale entry.** The remaining three workflows are the ones that still run with base-repo write scopes. No workflow in the repo uses `pull_request_target` any more.
- **Replace the brittle test with the invariant it stood for.** `privileged workflow list includes pr-review.yml` hardcoded a filename, which is precisely why retiring that workflow broke CI. The replacement scans `.github/workflows` and asserts every `pull_request_target` workflow is in `PRIVILEGED_WORKFLOWS`. That is what SBS-984 actually cares about, and it survives a workflow being added, renamed, or retired.
- **Cover the other direction too.** Two new tests assert every listed workflow exists, so a stale entry fails as a readable assertion rather than an ENOENT.
- **Make the missing-file case actionable** — name the stale entry and say what to do, instead of a stack trace three CI steps deep.

## Verification

Both new assertions were mutation-tested, because a test that cannot fail is not worth adding:

| Mutation | Result |
|---|---|
| Add an unlisted `pull_request_target` workflow | ✗ `pull_request_target workflows missing from PRIVILEGED_WORKFLOWS (SBS-984): .github/workflows/ZZtemp-mutation.yml` |
| Add a bogus `gone.yml` to the list | ✗ 5 tests fail; checker reports `gone.yml is listed in PRIVILEGED_WORKFLOWS but does not exist. Drop the entry if the workflow was retired, or update it if it was renamed.` |

All three previously-failing steps pass locally:

```
$ node .github/scripts/check-privileged-action-pins.mjs
Privileged workflow pin check passed: 14 SHA-pinned third-party actions, 25 uses scanned.
$ node --test .github/scripts/check-privileged-action-pins.test.mjs
ℹ tests 18   ℹ pass 18   ℹ fail 0
$ node scripts/check-release.mjs
Cubby Clipboard v1.3.2 release metadata is consistent.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to a pin-check allowlist and its tests. No application, auth, or workflow permission changes.
> 
> **Overview**
> Removes the stale `pr-review.yml` entry from `PRIVILEGED_WORKFLOWS` after that workflow was deleted, which was crashing the pin checker (and three required CI steps) on unhandled `ENOENT`.
> 
> The checker now throws an actionable error when a listed workflow is missing. Tests no longer hardcode the filename: they scan workflows and require every `pull_request_target` file to be listed, and that every listed path exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc5c82ad84c68cafc1bbc5eddd0318f7c1bba4e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop `pr-review.yml` from `PRIVILEGED_WORKFLOWS` check
> - Removes the retired `.github/workflows/pr-review.yml` from the `PRIVILEGED_WORKFLOWS` array in [check-privileged-action-pins.mjs](https://github.com/tsouth89/cubby-clipboard/pull/275/files#diff-e501c4e00e4df36f6cef10dc599b0f745e2ff2820b53ed3774302c9f195acf1a).
> - Wraps file reads in a `try/catch` to throw a descriptive error when a listed workflow is missing, replacing raw `ENOENT` failures.
> - Updates tests to verify all `pull_request_target` workflows are listed and that missing files trigger the new error.
> - Behavioral Change: The check script now explicitly fails if a path in `PRIVILEGED_WORKFLOWS` does not exist instead of throwing a raw filesystem error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc5c82a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->