### PR TITLE
Release v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable Cubby Clipboard changes are documented here. PastePaw entries below Cubby's first beta are retained as upstream history and attribution.
 
-## Unreleased
+## v1.3.3
 
 ### Security
 - An abandoned backup or Ditto file-dialog pick is no longer writable for the rest of the process: the grant expires after 60 seconds or when Settings closes (SBS-1015)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cubby-clipboard",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A native-feeling clipboard history replacement for Windows 11",
   "license": "GPL-3.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "cubby"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubby"
-version = "1.3.2"
+version = "1.3.3"
 description = "A native-feeling clipboard history replacement for Windows 11"
 authors = ["SouthForge AI", "PastePaw contributors"]
 license = "GPL-3.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "Cubby Clipboard",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "identifier": "ai.southforge.cubbyclipboard",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump and changelog cut for **v1.3.3**. No product code changes.

## Why now

56 commits since `v1.3.2` — the same volume as that release was (`v1.3.1..v1.3.2` was also 56). 7 security fixes and 16 bug fixes, no new features, so a patch bump matches how `v1.3.2` was numbered for a comparable batch.

The security set is the argument against waiting:

- unauthenticated bundle could exhaust memory before its AEAD tag was checked (SBS-981)
- content-hash dedup could delete a file outside the managed image directory (SBS-987)
- search shipped full decrypted clip bodies on every keystroke (SBS-912)
- an abandoned backup/Ditto file-dialog pick stayed writable for the life of the process (SBS-1015)

## What changed here

| Place | 1.3.2 → 1.3.3 |
|---|---|
| `package.json` | ✔ |
| `src-tauri/Cargo.toml` | ✔ |
| `src-tauri/tauri.conf.json` | ✔ |
| `src-tauri/Cargo.lock` (`cubby` stanza) | ✔ via `cargo update -p cubby` |
| `CHANGELOG.md` | `## Unreleased` → `## v1.3.3` |

The changelog rename is required, not cosmetic: the tag path awk-extracts release notes from a `## v<version>` heading and fails the build if it is missing.

## Verified

- `release:check` reports **v1.3.3 metadata is consistent**
- `cargo tree --locked` resolves, so the lockfile is not stale — that is the check `audit-rust.ps1` runs in the required `test` job, and the one `release:check` does *not* cover
- the notes extraction finds the `## v1.3.3` section

## Not done here, deliberately

**No tag.** Per `docs/RELEASE_CHECKLIST.md`, pushing `v*` publishes the GitHub release *and* submits and publishes to the Microsoft Store, with "no checkpoint between build and the public has it". `MICROSOFT_STORE_SUBMISSION_ENABLED` is `true`.

The plan is to run the Release workflow via **`workflow_dispatch`** after this merges. That produces a draft prerelease, skips the Store, and — importantly — is the only thing that exercises `cargo test`/`clippy --features dev-harness` (`release.yml:62-63`), which `ci.yml` never runs. Those four dev-harness bins have had no lint or test coverage across all 56 commits, including the Rust 1.98 toolchain jump that broke `main` twice.

The manual packaged-install smoke on a clean Windows 11 VM is still owed before tagging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump and changelog heading change; no runtime, auth, or data-handling code is modified.
> 
> **Overview**
> Bumps the app from **1.3.2** to **1.3.3** in `package.json`, `Cargo.toml`, `Cargo.lock`, and `tauri.conf.json`, and retitles the changelog `## Unreleased` section to `## v1.3.3` so release-note extraction can find it.
> 
> No application logic is changed in this PR. The heading rename is required for the tag/notes pipeline, not a rewrite of the notes themselves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2cd92c0abb6a887dfba1d0af292c621bb49ada1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release version v1.3.3
> Bumps the version field to 1.3.3 across [package.json](https://github.com/tsouth89/cubby-clipboard/pull/276/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), [src-tauri/Cargo.toml](https://github.com/tsouth89/cubby-clipboard/pull/276/files#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39), and [src-tauri/tauri.conf.json](https://github.com/tsouth89/cubby-clipboard/pull/276/files#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7). Renames the 'Unreleased' heading in [CHANGELOG.md](https://github.com/tsouth89/cubby-clipboard/pull/276/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) to 'v1.3.3'.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2cd92c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->