### PR TITLE
SBS-1028: Privacy page must match encrypted backup contents

### DIFF
--- a/product_pages/privacy.html
+++ b/product_pages/privacy.html
@@ -41,7 +41,7 @@
       <p class="eyebrow">Privacy</p>
       <h1>Your clipboard stays yours.</h1>
       <p>Cubby is built to keep clipboard history useful without turning it into a cloud service.</p>
-      <div class="legal-meta">Last updated August 15, 2026</div>
+      <div class="legal-meta">Last updated August 22, 2026</div>
     </header>
     <article class="legal-content">
       <div class="legal-callout"><p><strong>The short version:</strong> Cubby stores clipboard history locally on your Windows PC. The desktop app does not include analytics, advertising, cloud sync, or network-backed AI features. This website collects limited, privacy-preserving visit counts.</p></div>
@@ -51,7 +51,7 @@
       <p>History is stored in Cubby’s local application-data directory. Clipboard payloads are kept in a local SQLite database, and image data is kept in local application files.</p>
 
       <h2>Encrypted local backups</h2>
-      <p>You can export your clip history to a single encrypted file you choose on this PC, and import that file later here or on another machine. The archive holds each clip’s text, your notes, image thumbnails, text recognized in images, and the source app, folder, pin state, and hidden state. It does not hold the HTML and RTF copies of a clip or the full-resolution image files, so those do not come back on import. You choose the passphrase. Cubby does not store it, cannot recover it, and does not upload the file. Export decrypts your local history in memory and re-encrypts it into that portable archive. There is no cloud backup.</p>
+      <p>You can export your clip history to a single encrypted file you choose on this PC, and import that file later here or on another machine. The archive holds each clip’s text, HTML and RTF copies, your notes, image thumbnails, any live full-resolution original, text recognized in images, and the source app, folder, pin state, and hidden state. Export refuses to write the file if a live original or format cannot be read, rather than writing an incomplete backup. An image whose full-resolution original has already been dropped by retention stays thumbnail-only, matching the live history. You choose the passphrase. Cubby does not store it, cannot recover it, and does not upload the file. Export decrypts your local history in memory and re-encrypts it into that portable archive. There is no cloud backup.</p>
 
       <h2>Remote-session clipboard</h2>
       <p>When you copy inside a supported remote-control session, Cubby can rewrite that remote-owned clipboard onto the local clipboard so your other remote viewer sessions pick it up. Cubby only writes to the clipboard on this PC; the remote-control app you are using can then carry that content on to its other sessions and to the remote hosts they connect to. Cubby itself is not a cloud clipboard. The relay is on by default and skips a copy only when the remote viewer process itself (mstsc.exe and similar) is on the ignored list, not the application running on the remote host. The sensitive-content and skip-likely-secrets settings do not stop it. Turn it off in Settings under “Sync clipboard between remote sessions.”</p>

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { checkPrivilegedActionPins } from '../.github/scripts/check-privileged-action-pins.mjs';
 import {
   findFileListHistoryClaims,
+  findStaleBackupOmissionClaims,
   findWeakerFileRetentionClaim,
 } from './product-page-claims.mjs';
 import { extractDefaultSkipLikelySecrets, evaluateSecretHeuristicsDoc, saysDefaultOff } from './release-check-helpers.mjs';
@@ -272,6 +273,36 @@ for (const [docName, doc] of userFacingHistoryDocs) {
       `${docName} claims file clipboard history is retained or supported, which capture policy deliberately ignores: ${fileClaim.trim()}`
     );
   }
+}
+
+// SBS-1028: export_backup attaches HTML/RTF via attach_export_formats and
+// live full-resolution originals via attach_export_full_image, and refuses
+// the export if a live original or format cannot be read. The privacy page
+// once said those were omitted and would not come back on import.
+for (const [docName, doc] of userFacingHistoryDocs) {
+  const [claim] = findStaleBackupOmissionClaims(doc);
+  if (claim) {
+    throw new Error(
+      `${docName} still claims encrypted backups omit HTML/RTF or full-resolution originals: ${claim}`
+    );
+  }
+}
+
+const backupSection = privacyPageDoc.match(
+  /<h2>Encrypted local backups<\/h2>\s*<p>([\s\S]*?)<\/p>/
+)?.[1];
+if (!backupSection) {
+  throw new Error('product_pages/privacy.html must keep an Encrypted local backups section');
+}
+if (!/\bHTML\b/.test(backupSection) || !/\bRTF\b/.test(backupSection)) {
+  throw new Error(
+    'product_pages/privacy.html must say encrypted backups include HTML and RTF copies'
+  );
+}
+if (!/\bfull[\s-]*resolution\b/i.test(backupSection)) {
+  throw new Error(
+    'product_pages/privacy.html must say encrypted backups include live full-resolution originals'
+  );
 }
 
 // SBS-810: a URL the frontend opens but the capability does not allow is

--- a/scripts/product-page-claims.mjs
+++ b/scripts/product-page-claims.mjs
@@ -130,19 +130,28 @@ export function findFileListHistoryClaims(source) {
  * the privacy.html lie this helper exists to keep off the public pages.
  */
 const OMIT_HOLD =
-  /\b(?:does\s+not|doesn[’']t|do\s+not|don[’']t)\s+(?:hold|include|contain|store|keep)\b/i;
+  /\b(?:(?:does\s+not|doesn[’']t|do\s+not|don[’']t)\s+(?:hold|include|contain|store|keep)|omits?|omitted)\b/i;
 const DO_NOT_COME_BACK =
   /\b(?:do\s+not|does\s+not|don[’']t|doesn[’']t|never)\s+come\s+back\b/i;
 const HTML_AND_RTF = /\bHTML\b/i;
 const RTF = /\bRTF\b/i;
 const FULL_RESOLUTION = /\bfull[\s-]*resolution\b/i;
+/** Current or previous sentence names the archive so anaphoric "It" still counts. */
+const BACKUP_CONTEXT = /\b(?:archives?|backups?|import(?:s|ed|ing)?)\b/i;
 
 export function findStaleBackupOmissionClaims(source) {
   const claims = [];
-  for (const segment of segments(source)) {
+  const pieces = segments(source);
+  for (let i = 0; i < pieces.length; i++) {
+    const segment = pieces[i];
     const mentionsFormats = HTML_AND_RTF.test(segment) && RTF.test(segment);
     const mentionsFullRes = FULL_RESOLUTION.test(segment);
     if (!mentionsFormats && !mentionsFullRes) {
+      continue;
+    }
+
+    const previous = i > 0 ? pieces[i - 1] : '';
+    if (!BACKUP_CONTEXT.test(segment) && !BACKUP_CONTEXT.test(previous)) {
       continue;
     }
 

--- a/scripts/product-page-claims.mjs
+++ b/scripts/product-page-claims.mjs
@@ -152,12 +152,11 @@ export function findStaleBackupOmissionClaims(source) {
     }
 
     const previous = i > 0 ? pieces[i - 1] : '';
-    if (!BACKUP_CONTEXT.test(segment) && !BACKUP_CONTEXT.test(previous)) {
-      continue;
-    }
+    const currentBackup = BACKUP_CONTEXT.test(segment);
+    const nearbyBackup = currentBackup || BACKUP_CONTEXT.test(previous);
 
     const omit = segment.match(OMIT_HOLD);
-    if (omit) {
+    if (omit && nearbyBackup) {
       const before = segment.slice(0, omit.index);
       const negatedOmit =
         /^omit(?:s|ted)?$/i.test(omit[0]) &&
@@ -174,7 +173,8 @@ export function findStaleBackupOmissionClaims(source) {
       }
     }
 
-    if (DO_NOT_COME_BACK.test(segment)) {
+    // Come-back wording is only the backup lie if this sentence names the archive.
+    if (DO_NOT_COME_BACK.test(segment) && currentBackup) {
       claims.push(segment);
     }
   }

--- a/scripts/product-page-claims.mjs
+++ b/scripts/product-page-claims.mjs
@@ -137,7 +137,8 @@ const HTML_AND_RTF = /\bHTML\b/i;
 const RTF = /\bRTF\b/i;
 const FULL_RESOLUTION = /\bfull[\s-]*resolution\b/i;
 /** Current or previous sentence names the archive so anaphoric "It" still counts. */
-const BACKUP_CONTEXT = /\b(?:archives?|backups?|import(?:s|ed|ing)?)\b/i;
+const BACKUP_CONTEXT =
+  /\b(?:archives?|backups?|import(?:s|ed|ing)?|export(?:s|ed|ing)?)\b/i;
 
 export function findStaleBackupOmissionClaims(source) {
   const claims = [];
@@ -157,13 +158,19 @@ export function findStaleBackupOmissionClaims(source) {
 
     const omit = segment.match(OMIT_HOLD);
     if (omit) {
-      const after = segment.slice(omit.index + omit[0].length);
-      if (
-        (mentionsFormats && HTML_AND_RTF.test(after) && RTF.test(after)) ||
-        (mentionsFullRes && FULL_RESOLUTION.test(after))
-      ) {
-        claims.push(segment);
-        continue;
+      const before = segment.slice(0, omit.index);
+      const negatedOmit =
+        /^omit(?:s|ted)?$/i.test(omit[0]) &&
+        lastMatchIndex(NEGATION, before.slice(lastClauseStart(before))) !== -1;
+      if (!negatedOmit) {
+        const after = segment.slice(omit.index + omit[0].length);
+        if (
+          (mentionsFormats && HTML_AND_RTF.test(after) && RTF.test(after)) ||
+          (mentionsFullRes && FULL_RESOLUTION.test(after))
+        ) {
+          claims.push(segment);
+          continue;
+        }
       }
     }
 

--- a/scripts/product-page-claims.mjs
+++ b/scripts/product-page-claims.mjs
@@ -124,6 +124,48 @@ export function findFileListHistoryClaims(source) {
 }
 
 /**
+ * SBS-1028: encrypted backups include HTML/RTF (`attach_export_formats`) and
+ * live full-resolution originals (`attach_export_full_image`). A sentence that
+ * says the archive omits those, or that they do not come back on import, is
+ * the privacy.html lie this helper exists to keep off the public pages.
+ */
+const OMIT_HOLD =
+  /\b(?:does\s+not|doesn[’']t|do\s+not|don[’']t)\s+(?:hold|include|contain|store|keep)\b/i;
+const DO_NOT_COME_BACK =
+  /\b(?:do\s+not|does\s+not|don[’']t|doesn[’']t|never)\s+come\s+back\b/i;
+const HTML_AND_RTF = /\bHTML\b/i;
+const RTF = /\bRTF\b/i;
+const FULL_RESOLUTION = /\bfull[\s-]*resolution\b/i;
+
+export function findStaleBackupOmissionClaims(source) {
+  const claims = [];
+  for (const segment of segments(source)) {
+    const mentionsFormats = HTML_AND_RTF.test(segment) && RTF.test(segment);
+    const mentionsFullRes = FULL_RESOLUTION.test(segment);
+    if (!mentionsFormats && !mentionsFullRes) {
+      continue;
+    }
+
+    const omit = segment.match(OMIT_HOLD);
+    if (omit) {
+      const after = segment.slice(omit.index + omit[0].length);
+      if (
+        (mentionsFormats && HTML_AND_RTF.test(after) && RTF.test(after)) ||
+        (mentionsFullRes && FULL_RESOLUTION.test(after))
+      ) {
+        claims.push(segment);
+        continue;
+      }
+    }
+
+    if (DO_NOT_COME_BACK.test(segment)) {
+      claims.push(segment);
+    }
+  }
+  return claims;
+}
+
+/**
  * Weaker scan used by the release check: a sentence that says files are
  * retained or supported without also negating that. Broader than
  * `findFileListHistoryClaims` so "Cubby stores files" still fails even when

--- a/scripts/product-page-claims.test.mjs
+++ b/scripts/product-page-claims.test.mjs
@@ -239,6 +239,51 @@ test('an unrelated does-not-include sentence is not reported', () => {
   );
 });
 
+test('omit-verb restatements about the archive are claims', () => {
+  assert.equal(
+    findStaleBackupOmissionClaims('The archive omits HTML and RTF copies').length,
+    1
+  );
+  assert.equal(
+    findStaleBackupOmissionClaims('The archive omits HTML and RTF copies of a clip.').length,
+    1
+  );
+  assert.equal(
+    findStaleBackupOmissionClaims(
+      'Encrypted backups omitted the full-resolution originals.'
+    ).length,
+    1
+  );
+});
+
+test('privacy denials that are not about the archive are not claims', () => {
+  assert.deepEqual(
+    findStaleBackupOmissionClaims('Cubby does not store HTML and RTF on our servers'),
+    []
+  );
+  assert.deepEqual(
+    findStaleBackupOmissionClaims('Cubby does not include HTML and RTF in telemetry.'),
+    []
+  );
+});
+
+test('expired originals that do not come back are not a backup claim', () => {
+  assert.deepEqual(
+    findStaleBackupOmissionClaims(
+      'Full-resolution originals do not come back after retention drops them.'
+    ),
+    []
+  );
+});
+
+test('anaphoric archive omission is a claim', () => {
+  const source =
+    'The archive is a local encrypted file. It does not hold the HTML and RTF copies of a clip or the full-resolution image files.';
+  const claims = findStaleBackupOmissionClaims(source);
+  assert.equal(claims.length, 1);
+  assert.match(claims[0], /does not hold the HTML and RTF/);
+});
+
 test('live privacy.html does not claim backups omit formats', async () => {
   const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   const source = await readFile(path.join(root, 'product_pages/privacy.html'), 'utf8');

--- a/scripts/product-page-claims.test.mjs
+++ b/scripts/product-page-claims.test.mjs
@@ -284,6 +284,41 @@ test('anaphoric archive omission is a claim', () => {
   assert.match(claims[0], /does not hold the HTML and RTF/);
 });
 
+test('negated omit verbs are not claims', () => {
+  assert.deepEqual(
+    findStaleBackupOmissionClaims('The archive does not omit HTML and RTF copies.'),
+    []
+  );
+  assert.deepEqual(
+    findStaleBackupOmissionClaims(
+      'Encrypted backups never omit the full-resolution originals.'
+    ),
+    []
+  );
+});
+
+test('export restatements of the omission are claims', () => {
+  assert.equal(
+    findStaleBackupOmissionClaims('The export omits HTML and RTF copies of a clip.')
+      .length,
+    1
+  );
+  assert.equal(
+    findStaleBackupOmissionClaims(
+      'Exported archives do not include the full-resolution originals.'
+    ).length,
+    1
+  );
+});
+
+test('anaphoric export omission is a claim', () => {
+  const source =
+    'Export writes a local encrypted file. It does not hold the HTML and RTF copies of a clip or the full-resolution image files.';
+  const claims = findStaleBackupOmissionClaims(source);
+  assert.equal(claims.length, 1);
+  assert.match(claims[0], /does not hold the HTML and RTF/);
+});
+
 test('live privacy.html does not claim backups omit formats', async () => {
   const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   const source = await readFile(path.join(root, 'product_pages/privacy.html'), 'utf8');

--- a/scripts/product-page-claims.test.mjs
+++ b/scripts/product-page-claims.test.mjs
@@ -276,6 +276,15 @@ test('expired originals that do not come back are not a backup claim', () => {
   );
 });
 
+test('a prior export sentence does not flag retention come-back wording', () => {
+  assert.deepEqual(
+    findStaleBackupOmissionClaims(
+      'Export writes a local encrypted file. Full-resolution originals do not come back after retention drops them.'
+    ),
+    []
+  );
+});
+
 test('anaphoric archive omission is a claim', () => {
   const source =
     'The archive is a local encrypted file. It does not hold the HTML and RTF copies of a clip or the full-resolution image files.';

--- a/scripts/product-page-claims.test.mjs
+++ b/scripts/product-page-claims.test.mjs
@@ -7,6 +7,7 @@ import test from 'node:test';
 import {
   claimSegments,
   findFileListHistoryClaims,
+  findStaleBackupOmissionClaims,
   findWeakerFileRetentionClaim,
 } from './product-page-claims.mjs';
 
@@ -190,4 +191,56 @@ test('weaker file-retention scan treats no/without as negation', () => {
   assert.equal(findWeakerFileRetentionClaim('No files are retained.'), undefined);
   assert.equal(findWeakerFileRetentionClaim('Without storing files.'), undefined);
   assert.match(findWeakerFileRetentionClaim('Cubby stores files.') ?? '', /stores files/);
+});
+
+// SBS-1028: privacy.html said encrypted backups omit HTML/RTF and
+// full-resolution originals after export_backup started including them.
+
+test('the original privacy.html backup omission is a claim', () => {
+  const sentence =
+    'It does not hold the HTML and RTF copies of a clip or the full-resolution image files, so those do not come back on import.';
+  const claims = findStaleBackupOmissionClaims(sentence);
+  assert.equal(claims.length, 1);
+  assert.match(claims[0], /does not hold the HTML and RTF/);
+});
+
+test('a restated backup omission is a claim', () => {
+  assert.equal(
+    findStaleBackupOmissionClaims(
+      'The archive does not include HTML and RTF copies of a clip.'
+    ).length,
+    1
+  );
+  assert.equal(
+    findStaleBackupOmissionClaims(
+      'Encrypted backups do not contain the full-resolution originals.'
+    ).length,
+    1
+  );
+});
+
+test('accurate backup copy is not reported', () => {
+  for (const sentence of [
+    'The archive holds each clip’s text, HTML and RTF copies, and any live full-resolution original.',
+    'Export refuses to write the file if a live original or format cannot be read.',
+    'An image whose full-resolution original has already been dropped by retention stays thumbnail-only.',
+    'Cubby does not store the passphrase. The archive holds HTML and RTF copies.',
+  ]) {
+    assert.deepEqual(findStaleBackupOmissionClaims(sentence), [], sentence);
+  }
+});
+
+test('an unrelated does-not-include sentence is not reported', () => {
+  assert.deepEqual(
+    findStaleBackupOmissionClaims(
+      'Update checks do not include clipboard content or product-usage events.'
+    ),
+    []
+  );
+});
+
+test('live privacy.html does not claim backups omit formats', async () => {
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const source = await readFile(path.join(root, 'product_pages/privacy.html'), 'utf8');
+  assert.deepEqual(findStaleBackupOmissionClaims(source), []);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

SBS-1028: `privacy.html` still said encrypted backups omit HTML/RTF and full-resolution originals. That stopped being true when `export_backup` started attaching them.

Contradicting code (unchanged by this PR):

- `src-tauri/src/backup.rs` `export_backup` → `attach_export_formats` (SBS-978): every `clip_formats` row, including HTML and RTF, is decrypted into the bundle. An unreadable format fails the export.
- `src-tauri/src/backup.rs` `export_backup` → `attach_export_full_image` (SBS-919): a live `{uuid}.cubby` original is included as `full_image_b64`. If that file cannot be read, the export fails closed the same way an unreadable field does (SBS-772). Already-expired images stay thumbnail-only.

The public backup paragraph now says the archive holds HTML and RTF copies and any live full-resolution original, refuses an incomplete file, and still describes expired screenshots as thumbnail-only. Export behavior is not changed.

`scripts/check-release.mjs` now fails if a public doc restates the old omission, and requires the Encrypted local backups section to mention HTML, RTF, and full-resolution originals.

## Grep for remaining stale claims

Searched `*.{html,md,tsx,ts,json,txt,mjs}` for the old wording and close variants (`does not hold` / `do not come back` / omit HTML|RTF|full-resolution).

**Fixed**

- `product_pages/privacy.html` — the only public surface that stated the lie.

**Checked, no stale claim**

- `product_pages/support.html`, `index.html`, `start.html`, `terms.html`
- `README.md`, `SECURITY.md`, `docs/press-kit/description.txt`
- Settings backup copy in `frontend/src/components/SettingsPanel.tsx` (generic passphrase wording; does not enumerate omitted formats)
- `CHANGELOG.md` already describes SBS-919 as including live originals

**Not a contradiction (left as-is)**

- Bundles written before SBS-919/978 still import without those fields (`BackupClip` serde defaults). That is restore compatibility for old files, not what export writes today.
- Internal `backup.rs` comments describe the current include-or-fail behavior.

## Verification

- [x] I kept this pull request focused.
- [ ] I tested the change on Windows 11.
- [x] I added or updated tests where practical.
- [x] I updated documentation for changed behavior.
- [x] I did not include clipboard contents, credentials, signing material, or other secrets.

- `node --test scripts/product-page-claims.test.mjs` — 25 passed, including the original privacy.html sentence as a claim and the live page as clean
- `node scripts/check-release.mjs` — pass
- Detector confirmed to flag the pre-fix sentence, not only pass on the new copy

Do not merge. Docs-only; no export/import behavior change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a317029-b0bc-4216-b6f9-2dfbb66f187b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a317029-b0bc-4216-b6f9-2dfbb66f187b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update privacy page to state encrypted backups include HTML, RTF, and full-resolution originals
> - Rewrites the Encrypted local backups section in [privacy.html](https://github.com/tsouth89/cubby-clipboard/pull/277/files#diff-c9d4b5077587a9c3753be84f19d211791e5993b7643fa2747aa2123ab4cb3726) to state that backups now include HTML and RTF copies and any live full-resolution original, that export refuses to write if a live original or format cannot be read, and that images whose originals were already dropped by retention remain thumbnail-only on import.
> - Adds `findStaleBackupOmissionClaims` in [product-page-claims.mjs](https://github.com/tsouth89/cubby-clipboard/pull/277/files#diff-4971434621030568f03454596f791852ca2d50bf85d07a35065be9ffb776a524) to detect sentences that still claim backups omit HTML/RTF or full-resolution originals.
> - Extends [check-release.mjs](https://github.com/tsouth89/cubby-clipboard/pull/277/files#diff-14ac66f5d0a1f9e003460f1b27bce6e68f7665390d99e23d897038130d21cdca) to scan user-facing history docs for stale omission claims and to assert the privacy page backup section mentions HTML, RTF, and full-resolution originals.
> - Adds a test suite in [product-page-claims.test.mjs](https://github.com/tsouth89/cubby-clipboard/pull/277/files#diff-668efb0f3739cf201e3e5fe1f34bff1160df9b35d068eba2d93119420b1eacfc) covering omission detection, negation handling, anaphora, and a live check against privacy.html.
> - Risk: the release script now throws on any user-facing doc that claims backups omit these formats, or if the privacy page backup section omits any of the three required mentions — review all user-facing history docs for stale wording.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7362863.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->