### PR TITLE
SBS-1025: Make the shipped-Windows matrix a real merge gate

### DIFF
--- a/.github/scripts/check-shipped-windows-ci.mjs
+++ b/.github/scripts/check-shipped-windows-ci.mjs
@@ -12,6 +12,10 @@ export const REQUIRED_LEGS = [
   { arch: 'arm64', target: 'aarch64-pc-windows-msvc', features: 'app-store' },
 ];
 
+/** SBS-1025: stable check name for branch protection; aggregates the matrix. */
+export const AGGREGATOR_JOB_ID = 'shipped-windows';
+export const AGGREGATOR_CHECK_NAME = 'shipped-windows';
+
 function stripQuote(value) {
   const trimmed = (value ?? '').trim();
   if (
@@ -137,6 +141,83 @@ function classifyLeg(item) {
   return { arch, target, features, extraArgs, issues, ok: issues.length === 0 };
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function jobNeeds(body, id) {
+  const escaped = escapeRegExp(id);
+  if (new RegExp(`^\\s+needs:\\s*${escaped}\\s*$`, 'm').test(body)) {
+    return true;
+  }
+  if (new RegExp(`^\\s+needs:\\s*\\[[^\\]]*\\b${escaped}\\b`, 'm').test(body)) {
+    return true;
+  }
+  const lines = body.split('\n');
+  let inNeeds = false;
+  let needsIndent = 0;
+  for (const line of lines) {
+    const header = line.match(/^(\s+)needs:\s*$/);
+    if (header) {
+      inNeeds = true;
+      needsIndent = header[1].length;
+      continue;
+    }
+    if (inNeeds) {
+      const indent = lineIndent(line);
+      if (line.trim() && indent <= needsIndent) {
+        inNeeds = false;
+      } else if (new RegExp(`^\\s+-\\s+${escaped}\\s*$`).test(line)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * SBS-1025: the matrix cannot be the required check (four generated names).
+ * A job named `shipped-windows` must always run and fail when any leg fails.
+ */
+export function evaluateShippedWindowsAggregator(jobs, checkJobs) {
+  const problems = [];
+  const job = jobs.find((item) => item.id === AGGREGATOR_JOB_ID);
+  if (!job) {
+    return [`missing ${AGGREGATOR_JOB_ID} aggregator job`];
+  }
+
+  const body = job.lines.filter((line) => !line.trim().startsWith('#')).join('\n');
+  const name = stripQuote(firstMatch(job.lines, /^\s+name:\s*(.+)$/));
+  if (name !== AGGREGATOR_CHECK_NAME) {
+    problems.push(
+      `${AGGREGATOR_JOB_ID}: job name must be ${AGGREGATOR_CHECK_NAME} (the stable required-check name), got ${name || 'empty'}`,
+    );
+  }
+  if (!/if:\s*(?:\$\{\{\s*)?always\(\)/.test(body)) {
+    problems.push(
+      `${AGGREGATOR_JOB_ID}: must use if: always() so a failed matrix reports failure instead of a skipped check`,
+    );
+  }
+
+  const checkJobIds = checkJobs.map((item) => item.id);
+  if (checkJobIds.length === 0) {
+    problems.push(`${AGGREGATOR_JOB_ID}: no cargo-check matrix job to aggregate`);
+    return problems;
+  }
+  if (!checkJobIds.some((id) => jobNeeds(body, id))) {
+    problems.push(
+      `${AGGREGATOR_JOB_ID}: must need the cargo-check matrix job (${checkJobIds.join(', ')})`,
+    );
+  }
+  if (!checkJobIds.some((id) => new RegExp(`needs\\.${id}\\.result`).test(body))) {
+    problems.push(`${AGGREGATOR_JOB_ID}: must inspect needs.<matrix-job>.result`);
+  }
+  if (!/\bsuccess\b/.test(body)) {
+    problems.push(`${AGGREGATOR_JOB_ID}: must fail when the matrix result is not success`);
+  }
+  return problems;
+}
+
 function jobProblems(job) {
   const body = job.lines.filter((line) => !line.trim().startsWith('#')).join('\n');
   const problems = [];
@@ -205,7 +286,10 @@ export function evaluateShippedWindowsCi(text) {
       reason: 'no CI job runs cargo check',
       missing: REQUIRED_LEGS,
       matched,
-      jobLevelProblems: ['no CI job runs cargo check'],
+      jobLevelProblems: [
+        'no CI job runs cargo check',
+        ...evaluateShippedWindowsAggregator(jobs, checkJobs),
+      ],
     };
   }
 
@@ -223,6 +307,8 @@ export function evaluateShippedWindowsCi(text) {
       matched.push({ job: job.id, ...classifyLeg(item) });
     }
   }
+
+  jobLevelProblems.push(...evaluateShippedWindowsAggregator(jobs, checkJobs));
 
   const missing = REQUIRED_LEGS.filter(
     (required) =>

--- a/.github/scripts/check-shipped-windows-ci.test.mjs
+++ b/.github/scripts/check-shipped-windows-ci.test.mjs
@@ -7,6 +7,8 @@ import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
 import {
+  AGGREGATOR_CHECK_NAME,
+  AGGREGATOR_JOB_ID,
   CI_WORKFLOW,
   REQUIRED_LEGS,
   checkShippedWindowsCi,
@@ -56,13 +58,24 @@ jobs:
           key: \${{ runner.os }}-cargo-check-\${{ matrix.target }}-\${{ matrix.features }}-lock
       - run: mkdir dist
       - run: cargo check --manifest-path src-tauri/Cargo.toml --target \${{ matrix.target }} --all-targets \${{ matrix.extra_args }}
+  shipped-windows:
+    name: shipped-windows
+    if: always()
+    needs:
+      - check-shipped-windows
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - env:
+          MATRIX_RESULT: \${{ needs.check-shipped-windows.result }}
+        run: if [ "$MATRIX_RESULT" != "success" ]; then exit 1; fi
 `;
 
 test('parser splits top-level jobs and ignores deeper keys', () => {
   const jobs = parseTopLevelJobs(VALID_JOB);
   assert.deepEqual(
     jobs.map((job) => job.id),
-    ['test', 'check-shipped-windows'],
+    ['test', 'check-shipped-windows', 'shipped-windows'],
   );
 });
 
@@ -225,6 +238,64 @@ test('a valid four-leg cargo check matrix passes', () => {
   assert.equal(result.matched.length, 4);
 });
 
+/** Pins SBS-1025: the matrix alone is not a merge gate; the aggregator must exist. */
+test('a complete matrix without the shipped-windows aggregator is rejected', () => {
+  const result = evaluateShippedWindowsCi(
+    VALID_JOB.replace(
+      `
+  shipped-windows:
+    name: shipped-windows
+    if: always()
+    needs:
+      - check-shipped-windows
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - env:
+          MATRIX_RESULT: \${{ needs.check-shipped-windows.result }}
+        run: if [ "$MATRIX_RESULT" != "success" ]; then exit 1; fi
+`,
+      '',
+    ),
+  );
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.jobLevelProblems.some((problem) => problem.includes('missing shipped-windows')),
+    result.jobLevelProblems.join('; '),
+  );
+});
+
+test('an aggregator that skips when the matrix fails is rejected', () => {
+  const result = evaluateShippedWindowsCi(VALID_JOB.replace('if: always()', 'if: success()'));
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.jobLevelProblems.some((problem) => problem.includes('if: always()')),
+    result.jobLevelProblems.join('; '),
+  );
+});
+
+test('an aggregator that does not need the matrix job is rejected', () => {
+  const result = evaluateShippedWindowsCi(
+    VALID_JOB.replace('      - check-shipped-windows\n', '      - test\n'),
+  );
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.jobLevelProblems.some((problem) => problem.includes('must need')),
+    result.jobLevelProblems.join('; '),
+  );
+});
+
+test('an aggregator whose check name is not shipped-windows is rejected', () => {
+  const result = evaluateShippedWindowsCi(
+    VALID_JOB.replace('    name: shipped-windows\n', '    name: windows-matrix\n'),
+  );
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.jobLevelProblems.some((problem) => problem.includes(AGGREGATOR_CHECK_NAME)),
+    result.jobLevelProblems.join('; '),
+  );
+});
+
 test('unparseable workflow fails closed instead of reporting full coverage', () => {
   const result = evaluateShippedWindowsCi('name: CI\n');
   assert.equal(result.ok, false);
@@ -247,6 +318,15 @@ test('ci.yml runs the shipped-Windows checker and its tests', async () => {
   const source = await readFile(path.join(repoRoot, CI_WORKFLOW), 'utf8');
   assert.match(source, /check-shipped-windows-ci\.mjs/);
   assert.match(source, /check-shipped-windows-ci\.test\.mjs/);
+});
+
+/** Pins SBS-1025: ci.yml must expose the stable aggregator check name. */
+test('ci.yml aggregates the shipped-Windows matrix as shipped-windows', async () => {
+  const source = await readFile(path.join(repoRoot, CI_WORKFLOW), 'utf8');
+  assert.match(source, new RegExp(`^  ${AGGREGATOR_JOB_ID}:\\s*$`, 'm'));
+  assert.match(source, /^\s+name:\s+shipped-windows\s*$/m);
+  assert.match(source, /^\s+if:\s+always\(\)\s*$/m);
+  assert.match(source, /needs\.check-shipped-windows\.result/);
 });
 
 test('checker fails a temp repo whose ci.yml still only tests the host default', async () => {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,3 +154,29 @@ jobs:
       - run: mkdir dist
 
       - run: cargo check --manifest-path src-tauri/Cargo.toml --target ${{ matrix.target }} --all-targets ${{ matrix.extra_args }}
+
+  # SBS-1025: one stable check name for branch protection. The matrix
+  # publishes Check <arch> <features> (four names); GitHub required
+  # checks on main currently list only `test`, so a red matrix leg does
+  # not block merge by itself. This job needs the matrix, uses
+  # if: always() so a failed leg reports failure instead of a skip, and
+  # exits non-zero unless every leg succeeded. A repo admin still has to
+  # add `shipped-windows` under Settings → Branches; this workflow cannot
+  # change protection.
+  shipped-windows:
+    name: shipped-windows
+    if: always()
+    needs:
+      - check-shipped-windows
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fail unless every Check <arch> <features> leg succeeded
+        env:
+          MATRIX_RESULT: ${{ needs.check-shipped-windows.result }}
+        run: |
+          echo "check-shipped-windows result: $MATRIX_RESULT"
+          if [ "$MATRIX_RESULT" != "success" ]; then
+            echo "::error::shipped-windows gate failed (matrix result: $MATRIX_RESULT). A Check <arch> <features> leg failed, was cancelled, or was skipped."
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable Cubby Clipboard changes are documented here. PastePaw entries below Cubby's first beta are retained as upstream history and attribution.
 
+## Unreleased
+
+### Fixed
+- CI now publishes a stable `shipped-windows` check that fails when any SBS-779 `Check <arch> <features>` cargo-check fails. Branch protection on main still requires only `test` until a repo admin adds that name; the docs no longer claim the matrix legs already block merge (SBS-1025)
+
 ## v1.3.3
 
 ### Security

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -184,7 +184,7 @@ When Dependabot opens an actions pin update:
 5. Merge the pin update. Do not retarget the `uses:` ref back to a floating
    tag such as `@v3` or `@stable`.
 
-## Pre-merge Windows compile matrix (SBS-779)
+## Pre-merge Windows compile matrix (SBS-779, SBS-1025)
 
 Pull-request CI cargo-checks four shipped configurations on `windows-latest`:
 
@@ -193,10 +193,48 @@ Pull-request CI cargo-checks four shipped configurations on `windows-latest`:
 - ARM64 default
 - ARM64 `app-store`
 
-That is a `cargo check --all-targets` per leg, not a bundle. Release still owns
-NSIS packaging, signing, and the Store installer. `.github/scripts/check-shipped-windows-ci.mjs`
-fails the required CI job if a leg is removed or renamed into an opaque matrix.
+Each leg is a `cargo check --all-targets` named `Check <arch> <features>`, not a
+bundle. Release still owns NSIS packaging, signing, and the Store installer.
+`.github/scripts/check-shipped-windows-ci.mjs` fails the required `test` job if a
+leg is removed, renamed into an opaque matrix, or the `shipped-windows`
+aggregator is dropped.
 
-A configuration-specific compile break should now fail the PR (`Check <arch> <features>`)
-instead of the first tag/release build that exercises that pair.
+### What actually blocks merge
+
+GitHub branch protection on `main` requires the `test` job. It does not require
+the four `Check <arch> <features>` names. A red matrix leg fails that check run
+and fails the `shipped-windows` aggregator; it does not, by itself, block merge.
+
+`shipped-windows` in `.github/workflows/ci.yml` is the stable aggregator: it
+`needs: check-shipped-windows`, uses `if: always()` so a failed leg reports
+failure instead of a skipped check, and exits non-zero unless the matrix result
+is `success`. That job name is what branch protection should require.
+
+This repository's automation cannot update protection (the GitHub token is not
+an admin; `GET/PUT .../branches/main/protection` returns 403; rulesets are
+empty). A repo admin still has to add the check after it has run once:
+
+1. Wait until a commit shows a `shipped-windows` check run so GitHub's search
+   box can find the name.
+2. Open **Settings → Branches → Branch protection rules → `main`**. This repo
+   uses classic branch protection, not rulesets.
+3. Keep **Require status checks to pass before merging** enabled.
+4. Search for and add `shipped-windows`. Keep `test`. Do not add the four
+   `Check <arch> <features>` names as the required set — those names change if
+   a leg is renamed, and a fifth shipped pair would not be required.
+5. Save the rule.
+
+The classic API, if an admin token is available later:
+
+```http
+PUT /repos/tsouth89/cubby-clipboard/branches/main/protection/required_status_checks
+```
+
+with `strict` left as it is today and `contexts` including both `test` and
+`shipped-windows`. Prefer the UI if you are unsure whether other required
+contexts already exist; replacing the list blindly can drop them.
+
+A configuration-specific compile break fails `Check <arch> <features>` and
+`shipped-windows` on the pull request. It blocks merge only after
+`shipped-windows` is a required check.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

SBS-779 shipped a four-leg Windows `cargo check` matrix (`Check <arch> <features>` for x64/ARM64 × default/`app-store`) and the changelog / `docs/RELEASE_CHECKLIST.md` treated a red leg as a PR failure that blocks merge.

GitHub branch protection on `main` only requires the `test` job. A red matrix leg is visible on the PR and does **not** block merge. That left SBS-779 incomplete / bypassable.

## What this PR does

Branch protection cannot be changed from this token. `GET /repos/tsouth89/cubby-clipboard/branches/main/protection` returns **403** (`Resource not accessible by integration`). Repo permissions on this automation identity are `admin: false`, `maintain: false`. Rulesets list as `[]`; `main` is classically protected (`protected: true`).

So this PR takes the fallback the ticket allows:

1. Add a **stable aggregator job** named `shipped-windows` in `.github/workflows/ci.yml`.
2. Align the docs with that reality. They no longer claim the four matrix names already gate merge.
3. Pin the aggregator in `.github/scripts/check-shipped-windows-ci.mjs` so dropping it fails the already-required `test` job.

### Gate path (proven on this PR)

```
check-shipped-windows (matrix)
  name: Check ${{ matrix.arch }} ${{ matrix.features }}
  → Check x64 default          SUCCESS
  → Check x64 app-store        SUCCESS
  → Check arm64 default        SUCCESS
  → Check arm64 app-store      SUCCESS

shipped-windows                SUCCESS
  if: always()
  needs: check-shipped-windows
  fails unless needs.check-shipped-windows.result == success

test                           SUCCESS  (still the only required check today)
```

Run: https://github.com/tsouth89/cubby-clipboard/actions/runs/32602563569

GitHub treats a `needs:` of a matrix job as the aggregate of every include row. `if: always()` is required so a failed leg reports **failure** on `shipped-windows` instead of skipping the aggregator (a skipped check is easy to miss, and is the wrong signal once the name is required).

The existing `test` job still runs the policy checker. That checker still requires the four legs, and now also requires:

- job id / check name `shipped-windows`
- `if: always()`
- `needs` the cargo-check matrix job
- inspect `needs.check-shipped-windows.result` and fail when it is not `success`

`test` and the matrix stay parallel. `shipped-windows` is a cheap `ubuntu-latest` rollup.

## Human step (required — this PR cannot do it)

`shipped-windows` has now run on this PR, so GitHub’s search box can see the name.

1. Open **Settings → Branches → Branch protection rules → `main`**.
2. Keep **Require status checks to pass before merging**.
3. Search for and add **`shipped-windows`**.
4. Keep **`test`**.
5. Do **not** add the four `Check <arch> <features>` names as the required set. Those names change if a leg is renamed, and a fifth shipped pair would not be required.
6. Save.

Until that click, a red `shipped-windows` / `Check <arch> <features>` run is informational. Merge is still gated only by `test`.

If an admin token is available later, the classic API is:

```http
PUT /repos/tsouth89/cubby-clipboard/branches/main/protection/required_status_checks
```

with `contexts` including both `test` and `shipped-windows`. Prefer the UI if other required contexts already exist; replacing the list blindly can drop them.

## Docs

- `docs/RELEASE_CHECKLIST.md` — describes the matrix (SBS-779), the aggregator, what actually blocks merge today, and the admin click / API.
- `CHANGELOG.md` — Unreleased entry. The shipped v1.3.2 SBS-779 line is left as history.

## Verification

- [x] `node --test .github/scripts/check-shipped-windows-ci.test.mjs` — 24/24 pass
- [x] `node .github/scripts/check-shipped-windows-ci.mjs` — 4 cargo-check legs
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
- [x] `node scripts/check-release.mjs` — v1.3.3 metadata consistent
- [x] GitHub Actions on this PR: `test`, four `Check <arch> <features>` legs, and `shipped-windows` all green
- [ ] Repo admin adds `shipped-windows` under branch protection (cannot be done from this PR)

`github-advanced-security` (`Code scanning AI findings on PR`) failed with `You are not licensed to use Copilot`. That is GitHub’s dynamic Copilot Autofix workflow, not this repo’s CI, and not a required check. CodeQL itself succeeded.

## References

- [SBS-1025](https://linear.app/southboundsoftware/issue/SBS-1025)
- [SBS-779](https://linear.app/southboundsoftware/issue/SBS-779) / #221

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eeb6478e-0f8a-44cc-a314-6cd34148f02f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eeb6478e-0f8a-44cc-a314-6cd34148f02f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `shipped-windows` aggregator job and checker to enforce Windows CI merge gate
> - Adds a new `shipped-windows` job in [ci.yml](https://github.com/tsouth89/cubby-clipboard/pull/278/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) that runs with `if: always()`, depends on the `check-shipped-windows` matrix, and fails unless `needs.check-shipped-windows.result` equals `success`.
> - Adds `evaluateShippedWindowsAggregator` in [check-shipped-windows-ci.mjs](https://github.com/tsouth89/cubby-clipboard/pull/278/files#diff-2489ad2a8afc6f86f1acbccfe7fc1475d06b44d5f6209bf905f5d92bddd9f35a) to validate the aggregator job exists with the correct id, name, `if: always()`, matrix dependency, and failure logic.
> - Updates [docs/RELEASE_CHECKLIST.md](https://github.com/tsouth89/cubby-clipboard/pull/278/files#diff-01a313e7e929db25ac2e0b129ffdc941def6ada896f29c12dfc1f38fee77a321) and [CHANGELOG.md](https://github.com/tsouth89/cubby-clipboard/pull/278/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) to document the new merge gate and manual branch-protection steps.
> - Risk: repos that remove, rename, or drop the aggregator job will now fail the CI checker; repo admins must manually add the `shipped-windows` check to branch protection rules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90752d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->