### PR TITLE
SBS-1032: Bound the clipboard snapshot queue

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -107,6 +107,7 @@ struct RecentCapture {
 }
 
 mod forget_on_clear;
+mod snapshot_channel;
 mod snapshot_queue;
 use forget_on_clear::{
     next_forget_attempts, select_forget_attempt, ForgetAttempt, ForgetClipLookup,
@@ -260,7 +261,7 @@ pub fn init(app: &AppHandle, db: Arc<Database>) {
     crate::ocr_queue::init(app.clone(), db.clone());
     // SBS-1032: snapshots carry full PNG/HTML/RTF bytes. The queue is
     // bounded (drop-oldest); see `snapshot_queue` for the policy.
-    let (event_tx, event_rx) = snapshot_queue::channel();
+    let (event_tx, event_rx) = snapshot_channel::channel();
     let app_for_consumer = app.clone();
     let db_for_consumer = db.clone();
 
@@ -386,7 +387,7 @@ impl ClipboardSnapshot {
 }
 
 fn enqueue_listener_event(
-    event_tx: &snapshot_queue::Sender<ClipboardListenerEvent>,
+    event_tx: &snapshot_channel::Sender<ClipboardListenerEvent>,
     event: ClipboardListenerEvent,
 ) -> Result<(), ()> {
     match event_tx.send(event) {
@@ -737,7 +738,7 @@ fn deferral_decision(
 #[cfg(target_os = "windows")]
 fn capture_clipboard_update(
     mut sequence: u32,
-    event_tx: &snapshot_queue::Sender<ClipboardListenerEvent>,
+    event_tx: &snapshot_channel::Sender<ClipboardListenerEvent>,
 ) -> Result<CaptureAttempt, ()> {
     let read_sequence =
         || unsafe { windows::Win32::System::DataExchange::GetClipboardSequenceNumber() };
@@ -785,7 +786,7 @@ impl From<SequenceBindError> for BoundCaptureFailure {
 fn capture_one_bound_sequence(
     mut sequence: u32,
     read_sequence: &impl Fn() -> u32,
-    event_tx: &snapshot_queue::Sender<ClipboardListenerEvent>,
+    event_tx: &snapshot_channel::Sender<ClipboardListenerEvent>,
 ) -> Result<CaptureAttempt, BoundCaptureFailure> {
     let started = Instant::now();
     let live = read_sequence();
@@ -1073,7 +1074,7 @@ fn clipboard_has_image_format() -> bool {
 #[cfg(target_os = "windows")]
 fn run_listener_session(
     monitor: &mut Monitor,
-    event_tx: &snapshot_queue::Sender<ClipboardListenerEvent>,
+    event_tx: &snapshot_channel::Sender<ClipboardListenerEvent>,
 ) -> ListenerSessionExit {
     loop {
         match monitor.recv() {
@@ -1209,7 +1210,7 @@ fn clipboard_only_has_placeholder_text_formats() -> bool {
 ///   those copies are ingested late rather than lost.
 /// - Consumer channel close stops the supervisor (process teardown).
 #[cfg(target_os = "windows")]
-fn run_native_listener(event_tx: snapshot_queue::Sender<ClipboardListenerEvent>) {
+fn run_native_listener(event_tx: snapshot_channel::Sender<ClipboardListenerEvent>) {
     spawn_listener_watchdog();
 
     let mut backoff = INITIAL_LISTENER_BACKOFF;
@@ -1285,7 +1286,7 @@ fn run_native_listener(event_tx: snapshot_queue::Sender<ClipboardListenerEvent>)
 }
 
 #[cfg(not(target_os = "windows"))]
-fn run_native_listener(_event_tx: snapshot_queue::Sender<ClipboardListenerEvent>) {
+fn run_native_listener(_event_tx: snapshot_channel::Sender<ClipboardListenerEvent>) {
     set_capture_state(CAPTURE_STATE_STOPPED);
     record_capture_error("clipboard capture requires Windows");
 }

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -107,9 +107,11 @@ struct RecentCapture {
 }
 
 mod forget_on_clear;
+mod snapshot_queue;
 use forget_on_clear::{
     next_forget_attempts, select_forget_attempt, ForgetAttempt, ForgetClipLookup,
 };
+use snapshot_queue::SizedPayload;
 
 /// Pure helper for SOU-316 unit tests: only empty clears within the window
 /// forget the last clip. A later clear must leave history alone.
@@ -256,7 +258,9 @@ pub fn get_clipboard_capture_status() -> ClipboardCaptureStatus {
 
 pub fn init(app: &AppHandle, db: Arc<Database>) {
     crate::ocr_queue::init(app.clone(), db.clone());
-    let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
+    // SBS-1032: snapshots carry full PNG/HTML/RTF bytes. The queue is
+    // bounded (drop-oldest); see `snapshot_queue` for the policy.
+    let (event_tx, event_rx) = snapshot_queue::channel();
     let app_for_consumer = app.clone();
     let db_for_consumer = db.clone();
 
@@ -347,6 +351,57 @@ enum ClipboardListenerEvent {
     Cleared {
         sequence: u32,
     },
+}
+
+impl SizedPayload for ClipboardListenerEvent {
+    fn payload_bytes(&self) -> usize {
+        match self {
+            Self::Cleared { .. } => 0,
+            Self::Content(snapshot) => snapshot.payload_bytes(),
+        }
+    }
+}
+
+impl ClipboardSnapshot {
+    /// Bytes that sit in RAM while this snapshot waits on the consumer.
+    /// HTML and RTF live in `formats`; PNG lives in `content`.
+    fn payload_bytes(&self) -> usize {
+        let content = match &self.content {
+            CapturedContent::Text {
+                content,
+                preview,
+                hash,
+            } => content.len() + preview.len() + hash.len(),
+            CapturedContent::Image {
+                png_bytes, hash, ..
+            } => png_bytes.len() + hash.len(),
+        };
+        let formats = self
+            .formats
+            .iter()
+            .map(|format| format.content.len())
+            .sum::<usize>();
+        content + formats
+    }
+}
+
+fn enqueue_listener_event(
+    event_tx: &snapshot_queue::Sender<ClipboardListenerEvent>,
+    event: ClipboardListenerEvent,
+) -> Result<(), ()> {
+    match event_tx.send(event) {
+        Ok(snapshot_queue::EnqueueOutcome::QueuedAfterDrop {
+            dropped,
+            dropped_bytes,
+        }) => {
+            log::warn!(
+                "CLIPBOARD: Snapshot queue evicted {dropped} older pending capture(s) ({dropped_bytes} bytes) under flood (SBS-1032)"
+            );
+            Ok(())
+        }
+        Ok(snapshot_queue::EnqueueOutcome::Queued) => Ok(()),
+        Err(()) => Err(()),
+    }
 }
 
 /// Which do-not-retain markers the current clipboard contents carry.
@@ -682,7 +737,7 @@ fn deferral_decision(
 #[cfg(target_os = "windows")]
 fn capture_clipboard_update(
     mut sequence: u32,
-    event_tx: &tokio::sync::mpsc::UnboundedSender<ClipboardListenerEvent>,
+    event_tx: &snapshot_queue::Sender<ClipboardListenerEvent>,
 ) -> Result<CaptureAttempt, ()> {
     let read_sequence =
         || unsafe { windows::Win32::System::DataExchange::GetClipboardSequenceNumber() };
@@ -730,7 +785,7 @@ impl From<SequenceBindError> for BoundCaptureFailure {
 fn capture_one_bound_sequence(
     mut sequence: u32,
     read_sequence: &impl Fn() -> u32,
-    event_tx: &tokio::sync::mpsc::UnboundedSender<ClipboardListenerEvent>,
+    event_tx: &snapshot_queue::Sender<ClipboardListenerEvent>,
 ) -> Result<CaptureAttempt, BoundCaptureFailure> {
     let started = Instant::now();
     let live = read_sequence();
@@ -800,8 +855,7 @@ fn capture_one_bound_sequence(
             materialize_ms: started.elapsed().as_millis(),
             sensitive,
         };
-        return event_tx
-            .send(ClipboardListenerEvent::Content(snapshot))
+        return enqueue_listener_event(event_tx, ClipboardListenerEvent::Content(snapshot))
             .map(|_| CaptureAttempt::Handled)
             .map_err(|_| BoundCaptureFailure::ConsumerGone);
     }
@@ -813,8 +867,7 @@ fn capture_one_bound_sequence(
         if clipboard_is_cleared() {
             persist_if_sequence_holds(sequence, read_sequence(), ())?;
             note_clipboard_event(sequence);
-            return event_tx
-                .send(ClipboardListenerEvent::Cleared { sequence })
+            return enqueue_listener_event(event_tx, ClipboardListenerEvent::Cleared { sequence })
                 .map(|_| CaptureAttempt::Handled)
                 .map_err(|_| BoundCaptureFailure::ConsumerGone);
         }
@@ -845,8 +898,7 @@ fn capture_one_bound_sequence(
         // the password-manager auto-clear signal; never treat a new
         // non-empty copy as a clear.
         note_clipboard_event(sequence);
-        return event_tx
-            .send(ClipboardListenerEvent::Cleared { sequence })
+        return enqueue_listener_event(event_tx, ClipboardListenerEvent::Cleared { sequence })
             .map(|_| CaptureAttempt::Handled)
             .map_err(|_| BoundCaptureFailure::ConsumerGone);
     }
@@ -1021,7 +1073,7 @@ fn clipboard_has_image_format() -> bool {
 #[cfg(target_os = "windows")]
 fn run_listener_session(
     monitor: &mut Monitor,
-    event_tx: &tokio::sync::mpsc::UnboundedSender<ClipboardListenerEvent>,
+    event_tx: &snapshot_queue::Sender<ClipboardListenerEvent>,
 ) -> ListenerSessionExit {
     loop {
         match monitor.recv() {
@@ -1157,7 +1209,7 @@ fn clipboard_only_has_placeholder_text_formats() -> bool {
 ///   those copies are ingested late rather than lost.
 /// - Consumer channel close stops the supervisor (process teardown).
 #[cfg(target_os = "windows")]
-fn run_native_listener(event_tx: tokio::sync::mpsc::UnboundedSender<ClipboardListenerEvent>) {
+fn run_native_listener(event_tx: snapshot_queue::Sender<ClipboardListenerEvent>) {
     spawn_listener_watchdog();
 
     let mut backoff = INITIAL_LISTENER_BACKOFF;
@@ -1233,7 +1285,7 @@ fn run_native_listener(event_tx: tokio::sync::mpsc::UnboundedSender<ClipboardLis
 }
 
 #[cfg(not(target_os = "windows"))]
-fn run_native_listener(_event_tx: tokio::sync::mpsc::UnboundedSender<ClipboardListenerEvent>) {
+fn run_native_listener(_event_tx: snapshot_queue::Sender<ClipboardListenerEvent>) {
     set_capture_state(CAPTURE_STATE_STOPPED);
     record_capture_error("clipboard capture requires Windows");
 }
@@ -3380,11 +3432,47 @@ mod tests {
         is_remote_client_owner, is_remote_client_process, likely_secret_decision,
         next_listener_backoff, relayed_clip_hash, rgba_to_cf_dib, set_ignore_hash,
         should_forget_recent_capture, should_relay_capture, should_skip_sensitive_capture,
-        CapturedContent, CapturedFormat, LikelySecretDecision, SensitiveMarkers,
-        CAPTURE_STATE_LISTENING, CAPTURE_STATE_RESTARTING, CAPTURE_STATE_STOPPED,
-        CLIPBOARD_CLEAR_FORGET_WINDOW, IGNORE_HASH, IGNORE_HASH_TTL,
+        CapturedContent, CapturedFormat, ClipboardListenerEvent, ClipboardSnapshot,
+        LikelySecretDecision, SensitiveMarkers, SizedPayload, CAPTURE_STATE_LISTENING,
+        CAPTURE_STATE_RESTARTING, CAPTURE_STATE_STOPPED, CLIPBOARD_CLEAR_FORGET_WINDOW,
+        IGNORE_HASH, IGNORE_HASH_TTL,
     };
     use std::time::{Duration, Instant};
+
+    /// SBS-1032: the queue's RAM budget must count the PNG/HTML/RTF bytes
+    /// that used to sit on the unbounded channel, not just a slot count.
+    #[test]
+    fn snapshot_payload_bytes_count_png_html_and_rtf() {
+        let event = ClipboardListenerEvent::Content(ClipboardSnapshot {
+            sequence: 1,
+            source_app_identity: None,
+            content: CapturedContent::Image {
+                png_bytes: vec![0; 1000],
+                width: 2,
+                height: 2,
+                hash: "h".repeat(64),
+                decode_ms: 0,
+                source_type: "png",
+            },
+            formats: vec![
+                CapturedFormat {
+                    name: "html",
+                    content: vec![0; 200],
+                },
+                CapturedFormat {
+                    name: "rtf",
+                    content: vec![0; 50],
+                },
+            ],
+            materialize_ms: 0,
+            sensitive: SensitiveMarkers::default(),
+        });
+        assert_eq!(event.payload_bytes(), 1000 + 64 + 200 + 50);
+        assert_eq!(
+            ClipboardListenerEvent::Cleared { sequence: 2 }.payload_bytes(),
+            0
+        );
+    }
 
     #[cfg(target_os = "windows")]
     #[test]

--- a/src-tauri/src/clipboard/snapshot_channel.rs
+++ b/src-tauri/src/clipboard/snapshot_channel.rs
@@ -1,0 +1,164 @@
+//! Async transport for the SBS-1032 bounded snapshot queue.
+//!
+//! The drop-oldest policy lives in [`super::snapshot_queue`] so it can be
+//! proven with `rustc --test` on Linux. This wrapper is the production
+//! sender/receiver that replaced `tokio::sync::mpsc::unbounded_channel`.
+
+use super::snapshot_queue::{
+    dequeue, enqueue, EnqueueOutcome, SizedPayload, SNAPSHOT_QUEUE_CAPACITY,
+    SNAPSHOT_QUEUE_MAX_BYTES,
+};
+use parking_lot::Mutex;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use tokio::sync::Notify;
+
+struct Inner<T> {
+    items: VecDeque<T>,
+    bytes: usize,
+    receiver_gone: bool,
+    senders_gone: bool,
+}
+
+struct Shared<T> {
+    inner: Mutex<Inner<T>>,
+    notify: Notify,
+}
+
+pub(super) struct Sender<T> {
+    shared: Arc<Shared<T>>,
+}
+
+pub(super) struct Receiver<T> {
+    shared: Arc<Shared<T>>,
+}
+
+pub(super) fn channel<T: SizedPayload>() -> (Sender<T>, Receiver<T>) {
+    let shared = Arc::new(Shared {
+        inner: Mutex::new(Inner {
+            items: VecDeque::new(),
+            bytes: 0,
+            receiver_gone: false,
+            senders_gone: false,
+        }),
+        notify: Notify::new(),
+    });
+    (
+        Sender {
+            shared: Arc::clone(&shared),
+        },
+        Receiver { shared },
+    )
+}
+
+impl<T: SizedPayload> Sender<T> {
+    pub(super) fn send(&self, item: T) -> Result<EnqueueOutcome, ()> {
+        let mut inner = self.shared.inner.lock();
+        if inner.receiver_gone {
+            return Err(());
+        }
+        let outcome = enqueue(
+            &mut inner.items,
+            &mut inner.bytes,
+            item,
+            SNAPSHOT_QUEUE_CAPACITY,
+            SNAPSHOT_QUEUE_MAX_BYTES,
+        );
+        drop(inner);
+        self.shared.notify.notify_one();
+        Ok(outcome)
+    }
+}
+
+impl<T> Drop for Sender<T> {
+    fn drop(&mut self) {
+        self.shared.inner.lock().senders_gone = true;
+        self.shared.notify.notify_one();
+    }
+}
+
+impl<T: SizedPayload> Receiver<T> {
+    pub(super) async fn recv(&self) -> Option<T> {
+        loop {
+            {
+                let mut inner = self.shared.inner.lock();
+                if let Some(item) = dequeue(&mut inner.items, &mut inner.bytes) {
+                    return Some(item);
+                }
+                if inner.senders_gone {
+                    return None;
+                }
+            }
+            self.shared.notify.notified().await;
+        }
+    }
+}
+
+impl<T> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        self.shared.inner.lock().receiver_gone = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::snapshot_queue::{EnqueueOutcome, SizedPayload, SNAPSHOT_QUEUE_CAPACITY};
+    use super::channel;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct FakeSnapshot {
+        id: u32,
+        bytes: usize,
+    }
+
+    impl SizedPayload for FakeSnapshot {
+        fn payload_bytes(&self) -> usize {
+            self.bytes
+        }
+    }
+
+    fn fake(id: u32, bytes: usize) -> FakeSnapshot {
+        FakeSnapshot { id, bytes }
+    }
+
+    #[test]
+    fn send_fails_after_the_receiver_is_dropped() {
+        let (tx, rx) = channel::<FakeSnapshot>();
+        drop(rx);
+        assert_eq!(tx.send(fake(1, 1)), Err(()));
+    }
+
+    #[tokio::test]
+    async fn recv_delivers_enqueued_items_in_order() {
+        let (tx, rx) = channel();
+        assert_eq!(tx.send(fake(1, 4)), Ok(EnqueueOutcome::Queued));
+        assert_eq!(tx.send(fake(2, 4)), Ok(EnqueueOutcome::Queued));
+        assert_eq!(rx.recv().await, Some(fake(1, 4)));
+        assert_eq!(rx.recv().await, Some(fake(2, 4)));
+    }
+
+    #[tokio::test]
+    async fn recv_ends_when_the_sender_is_dropped() {
+        let (tx, rx) = channel::<FakeSnapshot>();
+        drop(tx);
+        assert_eq!(rx.recv().await, None);
+    }
+
+    #[tokio::test]
+    async fn the_channel_keeps_the_newest_items_after_a_count_flood() {
+        let (tx, rx) = channel();
+        let flood = SNAPSHOT_QUEUE_CAPACITY + 5;
+        for id in 0..flood {
+            tx.send(fake(id as u32, 1))
+                .expect("receiver is still alive");
+        }
+        let first = rx.recv().await.expect("the newest window must remain");
+        assert_eq!(first.id, 5);
+        drop(tx);
+        let mut last = first;
+        while let Some(item) = rx.recv().await {
+            last = item;
+        }
+        assert_eq!(last.id, flood as u32 - 1);
+    }
+}

--- a/src-tauri/src/clipboard/snapshot_channel.rs
+++ b/src-tauri/src/clipboard/snapshot_channel.rs
@@ -20,6 +20,24 @@ struct Inner<T> {
     senders_gone: bool,
 }
 
+impl<T: SizedPayload> Inner<T> {
+    // Methods take `&mut self` so we do not split-borrow a MutexGuard
+    // (parking_lot's DerefMut is not disjoint-field aware).
+    fn push(&mut self, item: T) -> EnqueueOutcome {
+        enqueue(
+            &mut self.items,
+            &mut self.bytes,
+            item,
+            SNAPSHOT_QUEUE_CAPACITY,
+            SNAPSHOT_QUEUE_MAX_BYTES,
+        )
+    }
+
+    fn pop(&mut self) -> Option<T> {
+        dequeue(&mut self.items, &mut self.bytes)
+    }
+}
+
 struct Shared<T> {
     inner: Mutex<Inner<T>>,
     notify: Notify,
@@ -57,13 +75,7 @@ impl<T: SizedPayload> Sender<T> {
         if inner.receiver_gone {
             return Err(());
         }
-        let outcome = enqueue(
-            &mut inner.items,
-            &mut inner.bytes,
-            item,
-            SNAPSHOT_QUEUE_CAPACITY,
-            SNAPSHOT_QUEUE_MAX_BYTES,
-        );
+        let outcome = inner.push(item);
         drop(inner);
         self.shared.notify.notify_one();
         Ok(outcome)
@@ -82,7 +94,7 @@ impl<T: SizedPayload> Receiver<T> {
         loop {
             {
                 let mut inner = self.shared.inner.lock();
-                if let Some(item) = dequeue(&mut inner.items, &mut inner.bytes) {
+                if let Some(item) = inner.pop() {
                     return Some(item);
                 }
                 if inner.senders_gone {

--- a/src-tauri/src/clipboard/snapshot_queue.rs
+++ b/src-tauri/src/clipboard/snapshot_queue.rs
@@ -268,9 +268,13 @@ mod tests {
 
     #[test]
     fn the_shipped_capacity_covers_the_100_copy_reliability_burst() {
-        assert!(
-            SNAPSHOT_QUEUE_CAPACITY >= 100,
-            "the reliability contract captures a 100-copy burst; the queue must hold it"
-        );
+        // Both sides are constants, so this is a compile-time fact.
+        // `const {}` satisfies clippy::assertions_on_constants.
+        const {
+            assert!(
+                SNAPSHOT_QUEUE_CAPACITY >= 100,
+                "the reliability contract captures a 100-copy burst; the queue must hold it"
+            )
+        };
     }
 }

--- a/src-tauri/src/clipboard/snapshot_queue.rs
+++ b/src-tauri/src/clipboard/snapshot_queue.rs
@@ -1,0 +1,400 @@
+//! Bounded in-process snapshot queue (SBS-1032).
+//!
+//! The native listener materializes full PNG/HTML/RTF payloads and used to
+//! hand them to the async consumer over an unbounded channel. A copy flood
+//! then held every pending snapshot in RAM until persist caught up.
+//!
+//! Policy (drop-oldest):
+//! - At most [`SNAPSHOT_QUEUE_CAPACITY`] events may wait.
+//! - Those events may hold at most [`SNAPSHOT_QUEUE_MAX_BYTES`] of payload.
+//! - A new event that would exceed either bound evicts the oldest pending
+//!   event(s) until it fits. The newest copy is preferred because the
+//!   clipboard has already moved on.
+//! - A single event larger than the byte budget is still accepted after the
+//!   queue is emptied: we never refuse the current clipboard, we refuse an
+//!   unbounded backlog.
+//! - A 100-copy text burst (the reliability contract) stays under both
+//!   budgets, so capture order is preserved under normal load.
+
+use parking_lot::Mutex;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use tokio::sync::Notify;
+
+/// Enough slots for the 100-copy reliability burst, plus a little headroom
+/// for a clear or two that lands in the same window.
+pub(crate) const SNAPSHOT_QUEUE_CAPACITY: usize = 128;
+
+/// Hard RAM cap on queued payload bytes. Count-only bounding would still
+/// allow 128 large screenshots to pin gigabytes.
+pub(crate) const SNAPSHOT_QUEUE_MAX_BYTES: usize = 64 * 1024 * 1024;
+
+pub(crate) trait SizedPayload {
+    fn payload_bytes(&self) -> usize;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EnqueueOutcome {
+    Queued,
+    QueuedAfterDrop {
+        dropped: usize,
+        dropped_bytes: usize,
+    },
+}
+
+/// Apply the SBS-1032 bound. `capacity` and `max_bytes` are parameters so a
+/// test can prove the refusal without allocating the production 64 MiB budget.
+pub(crate) fn enqueue<T: SizedPayload>(
+    queue: &mut VecDeque<T>,
+    queued_bytes: &mut usize,
+    item: T,
+    capacity: usize,
+    max_bytes: usize,
+) -> EnqueueOutcome {
+    debug_assert!(
+        capacity >= 1,
+        "SBS-1032: the queue must be able to hold the current capture"
+    );
+    let item_bytes = item.payload_bytes();
+    let mut dropped = 0;
+    let mut dropped_bytes = 0;
+
+    loop {
+        let count_ok = queue.len() < capacity;
+        // An empty queue accepts even an oversized item so one screenshot
+        // cannot be refused. A non-empty queue evicts until the new item
+        // fits the byte budget.
+        let bytes_ok = queue.is_empty() || queued_bytes.saturating_add(item_bytes) <= max_bytes;
+        if count_ok && bytes_ok {
+            break;
+        }
+        let Some(old) = queue.pop_front() else {
+            break;
+        };
+        let old_bytes = old.payload_bytes();
+        *queued_bytes = queued_bytes.saturating_sub(old_bytes);
+        dropped += 1;
+        dropped_bytes += old_bytes;
+    }
+
+    *queued_bytes = queued_bytes.saturating_add(item_bytes);
+    queue.push_back(item);
+
+    if dropped == 0 {
+        EnqueueOutcome::Queued
+    } else {
+        EnqueueOutcome::QueuedAfterDrop {
+            dropped,
+            dropped_bytes,
+        }
+    }
+}
+
+fn dequeue<T: SizedPayload>(queue: &mut VecDeque<T>, queued_bytes: &mut usize) -> Option<T> {
+    let item = queue.pop_front()?;
+    *queued_bytes = queued_bytes.saturating_sub(item.payload_bytes());
+    Some(item)
+}
+
+struct Inner<T> {
+    items: VecDeque<T>,
+    bytes: usize,
+    receiver_gone: bool,
+    senders_gone: bool,
+}
+
+struct Shared<T> {
+    inner: Mutex<Inner<T>>,
+    notify: Notify,
+}
+
+pub(crate) struct Sender<T> {
+    shared: Arc<Shared<T>>,
+}
+
+pub(crate) struct Receiver<T> {
+    shared: Arc<Shared<T>>,
+}
+
+pub(crate) fn channel<T: SizedPayload>() -> (Sender<T>, Receiver<T>) {
+    let shared = Arc::new(Shared {
+        inner: Mutex::new(Inner {
+            items: VecDeque::new(),
+            bytes: 0,
+            receiver_gone: false,
+            senders_gone: false,
+        }),
+        notify: Notify::new(),
+    });
+    (
+        Sender {
+            shared: Arc::clone(&shared),
+        },
+        Receiver { shared },
+    )
+}
+
+impl<T: SizedPayload> Sender<T> {
+    pub(crate) fn send(&self, item: T) -> Result<EnqueueOutcome, ()> {
+        let mut inner = self.shared.inner.lock();
+        if inner.receiver_gone {
+            return Err(());
+        }
+        let outcome = enqueue(
+            &mut inner.items,
+            &mut inner.bytes,
+            item,
+            SNAPSHOT_QUEUE_CAPACITY,
+            SNAPSHOT_QUEUE_MAX_BYTES,
+        );
+        drop(inner);
+        self.shared.notify.notify_one();
+        Ok(outcome)
+    }
+}
+
+impl<T> Drop for Sender<T> {
+    fn drop(&mut self) {
+        self.shared.inner.lock().senders_gone = true;
+        self.shared.notify.notify_one();
+    }
+}
+
+impl<T: SizedPayload> Receiver<T> {
+    pub(crate) async fn recv(&self) -> Option<T> {
+        loop {
+            {
+                let mut inner = self.shared.inner.lock();
+                if let Some(item) = dequeue(&mut inner.items, &mut inner.bytes) {
+                    return Some(item);
+                }
+                if inner.senders_gone {
+                    return None;
+                }
+            }
+            self.shared.notify.notified().await;
+        }
+    }
+}
+
+impl<T> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        self.shared.inner.lock().receiver_gone = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        channel, dequeue, enqueue, EnqueueOutcome, SizedPayload, SNAPSHOT_QUEUE_CAPACITY,
+        SNAPSHOT_QUEUE_MAX_BYTES,
+    };
+    use std::collections::VecDeque;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct FakeSnapshot {
+        id: u32,
+        bytes: usize,
+    }
+
+    impl SizedPayload for FakeSnapshot {
+        fn payload_bytes(&self) -> usize {
+            self.bytes
+        }
+    }
+
+    fn fake(id: u32, bytes: usize) -> FakeSnapshot {
+        FakeSnapshot { id, bytes }
+    }
+
+    fn ids(queue: &VecDeque<FakeSnapshot>) -> Vec<u32> {
+        queue.iter().map(|item| item.id).collect()
+    }
+
+    /// Fail-without-fix for SBS-1032: the old unbounded push retains every
+    /// payload. 200 × 1 MiB is 200 MiB — over both shipped budgets. If this
+    /// assertion ever fails, the leak we are closing has changed shape.
+    #[test]
+    fn an_unbounded_push_retains_every_flooded_payload() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        for id in 0..200 {
+            let item = fake(id, 1024 * 1024);
+            bytes += item.payload_bytes();
+            queue.push_back(item);
+        }
+        assert!(
+            queue.len() > SNAPSHOT_QUEUE_CAPACITY,
+            "the old channel kept more items than the bound allows"
+        );
+        assert!(
+            bytes > SNAPSHOT_QUEUE_MAX_BYTES,
+            "the old channel kept more payload bytes than the RAM budget"
+        );
+        assert_eq!(queue.len(), 200);
+        assert_eq!(bytes, 200 * 1024 * 1024);
+    }
+
+    /// Replacing [`enqueue`] with `queue.push_back(item)` makes these
+    /// assertions fail — that is the SBS-1032 leak.
+    #[test]
+    fn a_flood_of_large_payloads_cannot_grow_past_the_budget() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        for id in 0..200 {
+            enqueue(
+                &mut queue,
+                &mut bytes,
+                fake(id, 1024 * 1024),
+                SNAPSHOT_QUEUE_CAPACITY,
+                SNAPSHOT_QUEUE_MAX_BYTES,
+            );
+            assert!(queue.len() <= SNAPSHOT_QUEUE_CAPACITY);
+            assert!(
+                bytes <= SNAPSHOT_QUEUE_MAX_BYTES || queue.len() == 1,
+                "queued bytes {bytes} escaped the RAM budget with {} items",
+                queue.len()
+            );
+        }
+        // 64 × 1 MiB fills the byte budget before the 128-item cap.
+        assert_eq!(queue.len(), SNAPSHOT_QUEUE_MAX_BYTES / (1024 * 1024));
+        assert_eq!(bytes, SNAPSHOT_QUEUE_MAX_BYTES);
+        assert_eq!(
+            queue.front().map(|item| item.id),
+            Some(200 - queue.len() as u32)
+        );
+        assert_eq!(queue.back().map(|item| item.id), Some(199));
+    }
+
+    #[test]
+    fn a_100_copy_text_burst_is_kept_in_order() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        for id in 0..100 {
+            let outcome = enqueue(
+                &mut queue,
+                &mut bytes,
+                fake(id, 64),
+                SNAPSHOT_QUEUE_CAPACITY,
+                SNAPSHOT_QUEUE_MAX_BYTES,
+            );
+            assert_eq!(outcome, EnqueueOutcome::Queued);
+        }
+        assert_eq!(queue.len(), 100);
+        assert_eq!(ids(&queue), (0..100).collect::<Vec<u32>>());
+    }
+
+    #[test]
+    fn overflowing_the_count_drops_the_oldest() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        for id in 0..5 {
+            enqueue(&mut queue, &mut bytes, fake(id, 1), 3, 1_000);
+        }
+        assert_eq!(ids(&queue), vec![2, 3, 4]);
+        assert_eq!(bytes, 3);
+    }
+
+    #[test]
+    fn overflowing_the_byte_budget_drops_the_oldest() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        assert_eq!(
+            enqueue(&mut queue, &mut bytes, fake(1, 8), 8, 20),
+            EnqueueOutcome::Queued
+        );
+        assert_eq!(
+            enqueue(&mut queue, &mut bytes, fake(2, 8), 8, 20),
+            EnqueueOutcome::Queued
+        );
+        assert_eq!(
+            enqueue(&mut queue, &mut bytes, fake(3, 8), 8, 20),
+            EnqueueOutcome::QueuedAfterDrop {
+                dropped: 1,
+                dropped_bytes: 8
+            }
+        );
+        assert_eq!(ids(&queue), vec![2, 3]);
+        assert_eq!(bytes, 16);
+    }
+
+    #[test]
+    fn a_single_oversize_payload_is_accepted_after_evicting_the_backlog() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        enqueue(&mut queue, &mut bytes, fake(1, 10), 8, 20);
+        enqueue(&mut queue, &mut bytes, fake(2, 10), 8, 20);
+        let outcome = enqueue(&mut queue, &mut bytes, fake(3, 50), 8, 20);
+        assert_eq!(
+            outcome,
+            EnqueueOutcome::QueuedAfterDrop {
+                dropped: 2,
+                dropped_bytes: 20
+            }
+        );
+        assert_eq!(ids(&queue), vec![3]);
+        assert_eq!(bytes, 50);
+    }
+
+    #[test]
+    fn dequeue_releases_the_byte_budget() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        enqueue(&mut queue, &mut bytes, fake(1, 10), 4, 40);
+        enqueue(&mut queue, &mut bytes, fake(2, 10), 4, 40);
+        assert_eq!(dequeue(&mut queue, &mut bytes).map(|item| item.id), Some(1));
+        assert_eq!(bytes, 10);
+        assert_eq!(dequeue(&mut queue, &mut bytes).map(|item| item.id), Some(2));
+        assert_eq!(bytes, 0);
+        assert!(dequeue(&mut queue, &mut bytes).is_none());
+    }
+
+    #[test]
+    fn the_shipped_capacity_covers_the_100_copy_reliability_burst() {
+        assert!(
+            SNAPSHOT_QUEUE_CAPACITY >= 100,
+            "the reliability contract captures a 100-copy burst; the queue must hold it"
+        );
+    }
+
+    #[test]
+    fn send_fails_after_the_receiver_is_dropped() {
+        let (tx, rx) = channel::<FakeSnapshot>();
+        drop(rx);
+        assert_eq!(tx.send(fake(1, 1)), Err(()));
+    }
+
+    #[tokio::test]
+    async fn recv_delivers_enqueued_items_in_order() {
+        let (tx, rx) = channel();
+        assert_eq!(tx.send(fake(1, 4)), Ok(EnqueueOutcome::Queued));
+        assert_eq!(tx.send(fake(2, 4)), Ok(EnqueueOutcome::Queued));
+        assert_eq!(rx.recv().await, Some(fake(1, 4)));
+        assert_eq!(rx.recv().await, Some(fake(2, 4)));
+    }
+
+    #[tokio::test]
+    async fn recv_ends_when_the_sender_is_dropped() {
+        let (tx, rx) = channel::<FakeSnapshot>();
+        drop(tx);
+        assert_eq!(rx.recv().await, None);
+    }
+
+    #[tokio::test]
+    async fn the_channel_keeps_the_newest_items_after_a_count_flood() {
+        let (tx, rx) = channel();
+        let flood = SNAPSHOT_QUEUE_CAPACITY + 5;
+        for id in 0..flood {
+            tx.send(fake(id as u32, 1))
+                .expect("receiver is still alive");
+        }
+        let first = rx.recv().await.expect("the newest window must remain");
+        assert_eq!(first.id, 5);
+        drop(tx);
+        let mut last = first;
+        while let Some(item) = rx.recv().await {
+            last = item;
+        }
+        assert_eq!(last.id, flood as u32 - 1);
+    }
+}

--- a/src-tauri/src/clipboard/snapshot_queue.rs
+++ b/src-tauri/src/clipboard/snapshot_queue.rs
@@ -6,19 +6,15 @@
 //!
 //! Policy (drop-oldest):
 //! - At most [`SNAPSHOT_QUEUE_CAPACITY`] events may wait.
-//! - Those events may hold at most [`SNAPSHOT_QUEUE_MAX_BYTES`] of payload.
-//! - A new event that would exceed either bound evicts the oldest pending
-//!   event(s) until it fits. The newest copy is preferred because the
-//!   clipboard has already moved on.
+//! - Non-oversize queued payloads may hold at most
+//!   [`SNAPSHOT_QUEUE_MAX_BYTES`] in total. An accepted oversize capture is
+//!   excluded from that sum so a later small event does not evict it, but
+//!   follow-ups that themselves fit the budget are still RAM-bounded.
+//! - Count overflow evicts FIFO from the front (even an oversize resident).
+//!   Byte overflow evicts the oldest non-oversize item.
 //! - A single event larger than the byte budget is still accepted after the
 //!   queue is emptied: we never refuse the current clipboard, we refuse an
-//!   unbounded backlog.
-//! - Once that oversized event is queued, a later event that itself fits
-//!   the byte budget (a 0-byte clear, a small text copy) does not evict it.
-//!   The oversize capture stays until the consumer drains it or a later
-//!   oversized event replaces it. Small follow-ups may ride along until
-//!   the count cap; the byte budget still bounds a flood of normal-sized
-//!   payloads.
+//!   unbounded backlog. A later oversized event replaces that capture.
 //! - A 100-copy text burst (the reliability contract) stays under both
 //!   budgets, so capture order is preserved under normal load.
 //!
@@ -66,31 +62,52 @@ pub(crate) fn enqueue<T: SizedPayload>(
     let mut dropped = 0;
     let mut dropped_bytes = 0;
 
-    loop {
-        let count_ok = queue.len() < capacity;
-        // An empty queue accepts even an oversized item so one screenshot
-        // cannot be refused. A later small event must not evict that
-        // already-accepted capture just because the queue is over budget;
-        // a later oversized event still replaces it (newest clipboard wins).
-        let bytes_ok = if queue.is_empty() {
-            true
-        } else if item_bytes > max_bytes {
-            false
-        } else if *queued_bytes > max_bytes {
-            true
-        } else {
-            queued_bytes.saturating_add(item_bytes) <= max_bytes
-        };
-        if count_ok && bytes_ok {
-            break;
+    if item_bytes > max_bytes {
+        // Newest oversized capture wins: refuse an unbounded backlog of
+        // large payloads, never the current clipboard.
+        while let Some(old) = queue.pop_front() {
+            let old_bytes = old.payload_bytes();
+            *queued_bytes = queued_bytes.saturating_sub(old_bytes);
+            dropped += 1;
+            dropped_bytes += old_bytes;
         }
-        let Some(old) = queue.pop_front() else {
-            break;
-        };
-        let old_bytes = old.payload_bytes();
-        *queued_bytes = queued_bytes.saturating_sub(old_bytes);
-        dropped += 1;
-        dropped_bytes += old_bytes;
+    } else {
+        // Counted bytes skip an already-accepted oversize resident so a
+        // 0-byte clear or small text copy does not evict it.
+        let mut counted_bytes = counted_non_oversize_bytes(queue, max_bytes);
+        loop {
+            let count_ok = queue.len() < capacity;
+            let bytes_ok = counted_bytes.saturating_add(item_bytes) <= max_bytes;
+            if count_ok && bytes_ok {
+                break;
+            }
+            if !count_ok {
+                let Some(old) = queue.pop_front() else {
+                    break;
+                };
+                let old_bytes = old.payload_bytes();
+                *queued_bytes = queued_bytes.saturating_sub(old_bytes);
+                if old_bytes <= max_bytes {
+                    counted_bytes = counted_bytes.saturating_sub(old_bytes);
+                }
+                dropped += 1;
+                dropped_bytes += old_bytes;
+            } else if let Some(index) = queue
+                .iter()
+                .position(|queued| queued.payload_bytes() <= max_bytes)
+            {
+                let Some(old) = queue.remove(index) else {
+                    break;
+                };
+                let old_bytes = old.payload_bytes();
+                *queued_bytes = queued_bytes.saturating_sub(old_bytes);
+                counted_bytes = counted_bytes.saturating_sub(old_bytes);
+                dropped += 1;
+                dropped_bytes += old_bytes;
+            } else {
+                break;
+            }
+        }
     }
 
     *queued_bytes = queued_bytes.saturating_add(item_bytes);
@@ -113,6 +130,14 @@ pub(crate) fn dequeue<T: SizedPayload>(
     let item = queue.pop_front()?;
     *queued_bytes = queued_bytes.saturating_sub(item.payload_bytes());
     Some(item)
+}
+
+fn counted_non_oversize_bytes<T: SizedPayload>(queue: &VecDeque<T>, max_bytes: usize) -> usize {
+    queue
+        .iter()
+        .map(SizedPayload::payload_bytes)
+        .filter(|&bytes| bytes <= max_bytes)
+        .fold(0, usize::saturating_add)
 }
 
 #[cfg(test)]
@@ -141,6 +166,10 @@ mod tests {
 
     fn ids(queue: &VecDeque<FakeSnapshot>) -> Vec<u32> {
         queue.iter().map(|item| item.id).collect()
+    }
+
+    fn counted(queue: &VecDeque<FakeSnapshot>, max_bytes: usize) -> usize {
+        super::counted_non_oversize_bytes(queue, max_bytes)
     }
 
     /// Fail-without-fix for SBS-1032: the old unbounded push retains every
@@ -329,6 +358,69 @@ mod tests {
         assert_eq!(ids(&queue), vec![1, 2, 3]);
         assert_eq!(queue.len(), 3);
         assert_eq!(bytes, 3);
+    }
+
+    /// Fail-without-fix: after an oversize snapshot is accepted, follow-ups
+    /// that themselves fit the budget must still be byte-evicted. The oversize
+    /// resident is excluded from the counted sum and must stay at the front.
+    #[test]
+    fn follow_ups_after_oversize_are_still_byte_bounded() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        enqueue(&mut queue, &mut bytes, fake(1, 50), 8, 20);
+        assert_eq!(
+            enqueue(&mut queue, &mut bytes, fake(2, 8), 8, 20),
+            EnqueueOutcome::Queued
+        );
+        assert_eq!(
+            enqueue(&mut queue, &mut bytes, fake(3, 8), 8, 20),
+            EnqueueOutcome::Queued
+        );
+        let outcome = enqueue(&mut queue, &mut bytes, fake(4, 8), 8, 20);
+        assert_eq!(
+            outcome,
+            EnqueueOutcome::QueuedAfterDrop {
+                dropped: 1,
+                dropped_bytes: 8
+            }
+        );
+        assert_eq!(ids(&queue), vec![1, 3, 4]);
+        assert_eq!(queue.front().map(|item| item.id), Some(1));
+        assert_eq!(counted(&queue, 20), 16);
+        assert!(counted(&queue, 20) <= 20);
+        assert_eq!(bytes, 66);
+    }
+
+    #[test]
+    fn a_flood_of_under_budget_follow_ups_after_oversize_cannot_grow_past_the_budget() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        let oversize = SNAPSHOT_QUEUE_MAX_BYTES + 1;
+        enqueue(
+            &mut queue,
+            &mut bytes,
+            fake(0, oversize),
+            SNAPSHOT_QUEUE_CAPACITY,
+            SNAPSHOT_QUEUE_MAX_BYTES,
+        );
+        for id in 1..=200u32 {
+            enqueue(
+                &mut queue,
+                &mut bytes,
+                fake(id, 1024 * 1024),
+                SNAPSHOT_QUEUE_CAPACITY,
+                SNAPSHOT_QUEUE_MAX_BYTES,
+            );
+            assert!(queue.len() <= SNAPSHOT_QUEUE_CAPACITY);
+            assert!(counted(&queue, SNAPSHOT_QUEUE_MAX_BYTES) <= SNAPSHOT_QUEUE_MAX_BYTES);
+            assert_eq!(queue.front().map(|item| item.id), Some(0));
+        }
+        assert_eq!(
+            counted(&queue, SNAPSHOT_QUEUE_MAX_BYTES),
+            SNAPSHOT_QUEUE_MAX_BYTES
+        );
+        assert_eq!(queue.len(), 1 + SNAPSHOT_QUEUE_MAX_BYTES / (1024 * 1024));
+        assert_eq!(bytes, oversize + SNAPSHOT_QUEUE_MAX_BYTES);
     }
 
     #[test]

--- a/src-tauri/src/clipboard/snapshot_queue.rs
+++ b/src-tauri/src/clipboard/snapshot_queue.rs
@@ -15,11 +15,12 @@
 //!   unbounded backlog.
 //! - A 100-copy text burst (the reliability contract) stays under both
 //!   budgets, so capture order is preserved under normal load.
+//!
+//! Kept free of the Windows-only crate graph so
+//! `rustc --test src-tauri/src/clipboard/snapshot_queue.rs` can prove the
+//! bound on Linux. Windows CI runs the same tests via `cargo test`.
 
-use parking_lot::Mutex;
 use std::collections::VecDeque;
-use std::sync::Arc;
-use tokio::sync::Notify;
 
 /// Enough slots for the 100-copy reliability burst, plus a little headroom
 /// for a clear or two that lands in the same window.
@@ -90,103 +91,19 @@ pub(crate) fn enqueue<T: SizedPayload>(
     }
 }
 
-fn dequeue<T: SizedPayload>(queue: &mut VecDeque<T>, queued_bytes: &mut usize) -> Option<T> {
+pub(crate) fn dequeue<T: SizedPayload>(
+    queue: &mut VecDeque<T>,
+    queued_bytes: &mut usize,
+) -> Option<T> {
     let item = queue.pop_front()?;
     *queued_bytes = queued_bytes.saturating_sub(item.payload_bytes());
     Some(item)
 }
 
-struct Inner<T> {
-    items: VecDeque<T>,
-    bytes: usize,
-    receiver_gone: bool,
-    senders_gone: bool,
-}
-
-struct Shared<T> {
-    inner: Mutex<Inner<T>>,
-    notify: Notify,
-}
-
-pub(crate) struct Sender<T> {
-    shared: Arc<Shared<T>>,
-}
-
-pub(crate) struct Receiver<T> {
-    shared: Arc<Shared<T>>,
-}
-
-pub(crate) fn channel<T: SizedPayload>() -> (Sender<T>, Receiver<T>) {
-    let shared = Arc::new(Shared {
-        inner: Mutex::new(Inner {
-            items: VecDeque::new(),
-            bytes: 0,
-            receiver_gone: false,
-            senders_gone: false,
-        }),
-        notify: Notify::new(),
-    });
-    (
-        Sender {
-            shared: Arc::clone(&shared),
-        },
-        Receiver { shared },
-    )
-}
-
-impl<T: SizedPayload> Sender<T> {
-    pub(crate) fn send(&self, item: T) -> Result<EnqueueOutcome, ()> {
-        let mut inner = self.shared.inner.lock();
-        if inner.receiver_gone {
-            return Err(());
-        }
-        let outcome = enqueue(
-            &mut inner.items,
-            &mut inner.bytes,
-            item,
-            SNAPSHOT_QUEUE_CAPACITY,
-            SNAPSHOT_QUEUE_MAX_BYTES,
-        );
-        drop(inner);
-        self.shared.notify.notify_one();
-        Ok(outcome)
-    }
-}
-
-impl<T> Drop for Sender<T> {
-    fn drop(&mut self) {
-        self.shared.inner.lock().senders_gone = true;
-        self.shared.notify.notify_one();
-    }
-}
-
-impl<T: SizedPayload> Receiver<T> {
-    pub(crate) async fn recv(&self) -> Option<T> {
-        loop {
-            {
-                let mut inner = self.shared.inner.lock();
-                if let Some(item) = dequeue(&mut inner.items, &mut inner.bytes) {
-                    return Some(item);
-                }
-                if inner.senders_gone {
-                    return None;
-                }
-            }
-            self.shared.notify.notified().await;
-        }
-    }
-}
-
-impl<T> Drop for Receiver<T> {
-    fn drop(&mut self) {
-        self.shared.inner.lock().receiver_gone = true;
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
-        channel, dequeue, enqueue, EnqueueOutcome, SizedPayload, SNAPSHOT_QUEUE_CAPACITY,
+        dequeue, enqueue, EnqueueOutcome, SizedPayload, SNAPSHOT_QUEUE_CAPACITY,
         SNAPSHOT_QUEUE_MAX_BYTES,
     };
     use std::collections::VecDeque;
@@ -355,46 +272,5 @@ mod tests {
             SNAPSHOT_QUEUE_CAPACITY >= 100,
             "the reliability contract captures a 100-copy burst; the queue must hold it"
         );
-    }
-
-    #[test]
-    fn send_fails_after_the_receiver_is_dropped() {
-        let (tx, rx) = channel::<FakeSnapshot>();
-        drop(rx);
-        assert_eq!(tx.send(fake(1, 1)), Err(()));
-    }
-
-    #[tokio::test]
-    async fn recv_delivers_enqueued_items_in_order() {
-        let (tx, rx) = channel();
-        assert_eq!(tx.send(fake(1, 4)), Ok(EnqueueOutcome::Queued));
-        assert_eq!(tx.send(fake(2, 4)), Ok(EnqueueOutcome::Queued));
-        assert_eq!(rx.recv().await, Some(fake(1, 4)));
-        assert_eq!(rx.recv().await, Some(fake(2, 4)));
-    }
-
-    #[tokio::test]
-    async fn recv_ends_when_the_sender_is_dropped() {
-        let (tx, rx) = channel::<FakeSnapshot>();
-        drop(tx);
-        assert_eq!(rx.recv().await, None);
-    }
-
-    #[tokio::test]
-    async fn the_channel_keeps_the_newest_items_after_a_count_flood() {
-        let (tx, rx) = channel();
-        let flood = SNAPSHOT_QUEUE_CAPACITY + 5;
-        for id in 0..flood {
-            tx.send(fake(id as u32, 1))
-                .expect("receiver is still alive");
-        }
-        let first = rx.recv().await.expect("the newest window must remain");
-        assert_eq!(first.id, 5);
-        drop(tx);
-        let mut last = first;
-        while let Some(item) = rx.recv().await {
-            last = item;
-        }
-        assert_eq!(last.id, flood as u32 - 1);
     }
 }

--- a/src-tauri/src/clipboard/snapshot_queue.rs
+++ b/src-tauri/src/clipboard/snapshot_queue.rs
@@ -13,6 +13,12 @@
 //! - A single event larger than the byte budget is still accepted after the
 //!   queue is emptied: we never refuse the current clipboard, we refuse an
 //!   unbounded backlog.
+//! - Once that oversized event is queued, a later event that itself fits
+//!   the byte budget (a 0-byte clear, a small text copy) does not evict it.
+//!   The oversize capture stays until the consumer drains it or a later
+//!   oversized event replaces it. Small follow-ups may ride along until
+//!   the count cap; the byte budget still bounds a flood of normal-sized
+//!   payloads.
 //! - A 100-copy text burst (the reliability contract) stays under both
 //!   budgets, so capture order is preserved under normal load.
 //!
@@ -63,9 +69,18 @@ pub(crate) fn enqueue<T: SizedPayload>(
     loop {
         let count_ok = queue.len() < capacity;
         // An empty queue accepts even an oversized item so one screenshot
-        // cannot be refused. A non-empty queue evicts until the new item
-        // fits the byte budget.
-        let bytes_ok = queue.is_empty() || queued_bytes.saturating_add(item_bytes) <= max_bytes;
+        // cannot be refused. A later small event must not evict that
+        // already-accepted capture just because the queue is over budget;
+        // a later oversized event still replaces it (newest clipboard wins).
+        let bytes_ok = if queue.is_empty() {
+            true
+        } else if item_bytes > max_bytes {
+            false
+        } else if *queued_bytes > max_bytes {
+            true
+        } else {
+            queued_bytes.saturating_add(item_bytes) <= max_bytes
+        };
         if count_ok && bytes_ok {
             break;
         }
@@ -251,6 +266,69 @@ mod tests {
         );
         assert_eq!(ids(&queue), vec![3]);
         assert_eq!(bytes, 50);
+    }
+
+    /// Fail-without-fix: after an over-budget snapshot is accepted into an
+    /// empty queue, the next 0-byte/small event must not pop it just because
+    /// `queued_bytes` is already over the budget. A later oversized capture
+    /// may still replace it.
+    #[test]
+    fn a_small_follow_up_does_not_evict_an_accepted_oversize_snapshot() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        assert_eq!(
+            enqueue(&mut queue, &mut bytes, fake(1, 50), 8, 20),
+            EnqueueOutcome::Queued
+        );
+        assert_eq!(ids(&queue), vec![1]);
+        assert_eq!(bytes, 50);
+
+        assert_eq!(
+            enqueue(&mut queue, &mut bytes, fake(2, 0), 8, 20),
+            EnqueueOutcome::Queued
+        );
+        assert_eq!(ids(&queue), vec![1, 2]);
+        assert_eq!(queue.front().map(|item| item.id), Some(1));
+        assert_eq!(bytes, 50);
+
+        assert_eq!(
+            enqueue(&mut queue, &mut bytes, fake(3, 1), 8, 20),
+            EnqueueOutcome::Queued
+        );
+        assert_eq!(ids(&queue), vec![1, 2, 3]);
+        assert_eq!(bytes, 51);
+
+        let outcome = enqueue(&mut queue, &mut bytes, fake(4, 60), 8, 20);
+        assert_eq!(
+            outcome,
+            EnqueueOutcome::QueuedAfterDrop {
+                dropped: 3,
+                dropped_bytes: 51
+            }
+        );
+        assert_eq!(ids(&queue), vec![4]);
+        assert_eq!(bytes, 60);
+    }
+
+    #[test]
+    fn small_follow_ups_after_oversize_still_respect_the_count_cap() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        enqueue(&mut queue, &mut bytes, fake(0, 50), 3, 20);
+        enqueue(&mut queue, &mut bytes, fake(1, 1), 3, 20);
+        enqueue(&mut queue, &mut bytes, fake(2, 1), 3, 20);
+        assert_eq!(ids(&queue), vec![0, 1, 2]);
+        let outcome = enqueue(&mut queue, &mut bytes, fake(3, 1), 3, 20);
+        assert_eq!(
+            outcome,
+            EnqueueOutcome::QueuedAfterDrop {
+                dropped: 1,
+                dropped_bytes: 50
+            }
+        );
+        assert_eq!(ids(&queue), vec![1, 2, 3]);
+        assert_eq!(queue.len(), 3);
+        assert_eq!(bytes, 3);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The native clipboard listener materialized full PNG/HTML/RTF payloads and handed them to the persist consumer over an **unbounded** channel. A copy flood could grow that backlog without limit while the async consumer wrote (and encrypted) each snapshot.

This is distinct from SBS-1022 (TTL correctness). This ticket is only the RAM bound.

**Policy (drop-oldest), documented in `src-tauri/src/clipboard/snapshot_queue.rs`:**

- At most 128 pending events (covers the 100-copy reliability burst, plus a little headroom).
- Those events may hold at most 64 MiB of payload. A count-only cap would still let 128 large screenshots pin gigabytes.
- A new event that would exceed either bound evicts the oldest pending event(s) until it fits. The newest copy is preferred because the clipboard has already moved on.
- A single event larger than the byte budget is still accepted after the queue is emptied: we never refuse the current clipboard, we refuse an unbounded backlog.
- Under flood, a warning is logged (`SBS-1032`). Dropped events are not retried.
- A 100-copy text burst stays under both budgets, so capture order is preserved under normal load.

The policy is std-only so `rustc --test src-tauri/src/clipboard/snapshot_queue.rs` can prove it on Linux (same pattern as `managed_image`). The async sender in `snapshot_channel.rs` is a thin wrapper that replaced `tokio::sync::mpsc::unbounded_channel`. Enqueue/dequeue go through `Inner` methods so we do not split-borrow a `parking_lot::MutexGuard` (that failed Windows CI).

## Verification

- [x] I kept this pull request focused.
- [ ] I tested the change on Windows 11.
- [x] I added or updated tests where practical.
- [x] I updated documentation for changed behavior.
- [x] I did not include clipboard contents, credentials, signing material, or other secrets.

**Fail-without-fix:** `an_unbounded_push_retains_every_flooded_payload` documents the old channel (200 × 1 MiB stays in the queue). `a_flood_of_large_payloads_cannot_grow_past_the_budget` fails if `enqueue` is replaced with `push_back`. Payload accounting is pinned to PNG + HTML + RTF bytes, not a slot count.

**Local (Linux, this agent):**

```
rustc --test src-tauri/src/clipboard/snapshot_queue.rs -o /tmp/snapshot_queue_tests
/tmp/snapshot_queue_tests
```

8 passed (bound policy, including fail-without-fix). Full `cargo test` needs Windows/GTK; Windows CI covers the channel wrapper and `snapshot_payload_bytes_count_png_html_and_rtf`.

Cite: SBS-1032. Do not merge from this agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32a44f2a-cfad-40c8-8a3f-98b869321fc4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32a44f2a-cfad-40c8-8a3f-98b869321fc4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound clipboard snapshot queue to 128 items and 64 MiB with drop-oldest eviction
> - Replaces `tokio::sync::mpsc::unbounded_channel` in `init` with a custom bounded channel built on the new [snapshot_queue](https://github.com/tsouth89/cubby-clipboard/pull/280/files#diff-d0368d77f4ef255e7412edc4c45c07f0b76b8e26803943482b3799cbe7e98ef1) and [snapshot_channel](https://github.com/tsouth89/cubby-clipboard/pull/280/files#diff-80951e5da99e7d7307b50623f7ac20dcd5837d88b6027dbf82dd2168bd803adc) modules.
> - The queue caps at `SNAPSHOT_QUEUE_CAPACITY` (128) and `SNAPSHOT_QUEUE_MAX_BYTES` (64 MiB), evicting oldest eligible items when either bound is exceeded; oversize items that do not fit even after eviction are still accepted once.
> - Adds `SizedPayload` trait and `ClipboardSnapshot::payload_bytes` so the queue can budget by actual PNG/HTML/RTF byte sizes rather than item count alone.
> - Event delivery in `capture_one_bound_sequence` and `capture_clipboard_update` now routes through `enqueue_listener_event`, which logs a warning with counts and bytes when eviction occurs.
> - Risk: under a rapid clipboard flood, the consumer now receives the newest window of snapshots instead of all of them; oldest pending items are silently dropped after a warning log. Review `snapshot_queue::enqueue` and `counted_non_oversize_bytes` to confirm eviction order and oversize handling match expectations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7369fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->