### PR TITLE
SBS-1022: Bind ignore-hash lifetime to queued clipboard work

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -2128,7 +2128,7 @@ async fn process_clipboard_snapshot(
             // Clearing by hash alone would drop a newer paste of the same
             // content.
             consume_ignore_marker_after_self_paste(
-                &mut *lock,
+                &mut lock,
                 queued_ignore.as_ref(),
                 clip_hash.as_str(),
                 Instant::now(),

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -59,7 +59,9 @@ use windows::Win32::UI::WindowsAndMessaging::{
 // GLOBAL STATE: Store the hash of the clip we just pasted ourselves.
 // If the next clipboard change matches this hash, we ignore it (don't update timestamp).
 /// Hash of a clipboard write Cubby made itself, with the time it was written.
-/// Consumed by the capture of that write so a self-paste is not re-recorded.
+/// A snapshot queued while this marker is live carries the hash so a backed-up
+/// consumer still ignores the echo after the wall-clock TTL (SBS-1022).
+/// Consumed by the matching capture so a self-paste is not re-recorded.
 static IGNORE_HASH: Lazy<parking_lot::Mutex<Option<(String, Instant)>>> =
     Lazy::new(|| parking_lot::Mutex::new(None));
 static LAST_STABLE_HASH: Lazy<parking_lot::Mutex<Option<String>>> =
@@ -84,13 +86,6 @@ const CLIPBOARD_CLEAR_FORGET_WINDOW: Duration = Duration::from_secs(90);
 /// (SBS-1003).
 const FORGET_ON_CLEAR_ATTEMPTS: u8 = 3;
 const FORGET_ON_CLEAR_RETRY_DELAY: Duration = Duration::from_millis(80);
-/// How long a self-write marker stays valid. The capture of our own write
-/// normally arrives within milliseconds, so this is generous. It exists because
-/// an unbounded marker is never cleaned up when that capture never arrives at
-/// all -- the read lost every race, or a remote client rewrote the clipboard
-/// before we could read it -- and a stale marker silently swallows the next
-/// legitimate copy of the same content.
-const IGNORE_HASH_TTL: Duration = Duration::from_secs(5);
 #[cfg(target_os = "windows")]
 const CF_DIB_FORMAT: u32 = 8;
 
@@ -113,6 +108,10 @@ use forget_on_clear::{
     next_forget_attempts, select_forget_attempt, ForgetAttempt, ForgetClipLookup,
 };
 use snapshot_queue::SizedPayload;
+mod ignore_hash;
+use ignore_hash::{
+    bind_ignore_hash_for_queued_work, should_ignore_queued_self_paste, IGNORE_HASH_TTL,
+};
 
 /// Pure helper for SOU-316 unit tests: only empty clears within the window
 /// forget the last clip. A later clear must leave history alone.
@@ -179,24 +178,6 @@ pub(crate) fn clear_ignore_hash_if_matches(hash: &str) {
     if lock.as_ref().is_some_and(|(marked, _)| marked == hash) {
         lock.take();
     }
-}
-
-/// Whether a self-write marker still applies to `hash`.
-///
-/// A marker that has outlived `ttl` is treated as absent: the write it
-/// described was never observed, and honouring it would drop a real copy.
-fn ignore_marker_applies(
-    marker: Option<&(String, Instant)>,
-    hash: &str,
-    now: Instant,
-    ttl: Duration,
-) -> bool {
-    marker.is_some_and(|(marked, marked_at)| {
-        marked == hash
-            && now
-                .checked_duration_since(*marked_at)
-                .is_some_and(|elapsed| elapsed <= ttl)
-    })
 }
 
 /// Forget the consecutive-duplicate marker after history is deleted. Without
@@ -344,6 +325,10 @@ struct ClipboardSnapshot {
     materialize_ms: u128,
     /// Which do-not-retain markers this copy carried. See `SensitiveMarkers`.
     sensitive: SensitiveMarkers,
+    /// Ignore hash that was still live when this snapshot entered the queue.
+    /// Honoured at process time even if the wall-clock TTL has since elapsed
+    /// (SBS-1022): a backed-up consumer must not persist a self-paste echo.
+    ignore_hash: Option<String>,
 }
 
 enum ClipboardListenerEvent {
@@ -848,6 +833,11 @@ fn capture_one_bound_sequence(
 
     if let Some(MaterializeAttempt::Captured(content, formats)) = materialized {
         note_clipboard_event(sequence);
+        let ignore_hash = bind_ignore_hash_for_queued_work(
+            IGNORE_HASH.lock().as_ref(),
+            Instant::now(),
+            IGNORE_HASH_TTL,
+        );
         let snapshot = ClipboardSnapshot {
             sequence,
             source_app_identity,
@@ -855,6 +845,7 @@ fn capture_one_bound_sequence(
             formats,
             materialize_ms: started.elapsed().as_millis(),
             sensitive,
+            ignore_hash,
         };
         return enqueue_listener_event(event_tx, ClipboardListenerEvent::Content(snapshot))
             .map(|_| CaptureAttempt::Handled)
@@ -2041,6 +2032,7 @@ async fn process_clipboard_snapshot(
     let materialize_ms = snapshot.materialize_ms;
     let sequence = snapshot.sequence;
     let markers = snapshot.sensitive;
+    let queued_ignore_hash = snapshot.ignore_hash;
     let source_app_info = resolve_source_app_info(snapshot.source_app_identity);
     let captured_formats = snapshot.formats;
     let (clip_type, clip_content, clip_preview, _primary_hash, full_image_content, metadata) =
@@ -2114,9 +2106,16 @@ async fn process_clipboard_snapshot(
     // the clip's source app (to Cubby) and re-bump its timestamp, which is what
     // made reused clips collapse to "1 second ago" with a "Cubby Clipboard"
     // source, so skip processing it entirely.
+    //
+    // The work item carries the hash that was live at enqueue. Honour that
+    // even when the 5s wall-clock TTL has elapsed: a backed-up snapshot
+    // queue must not persist the echo and bump created_at/source_app
+    // (SBS-1022). The live-marker check still covers a write whose snapshot
+    // was queued in the same window the paste path set the hash.
     {
         let mut lock = IGNORE_HASH.lock();
-        if ignore_marker_applies(
+        if should_ignore_queued_self_paste(
+            queued_ignore_hash.as_deref(),
             lock.as_ref(),
             clip_hash.as_str(),
             Instant::now(),
@@ -2125,7 +2124,14 @@ async fn process_clipboard_snapshot(
             // Only consume the marker on a match. Clearing it for an
             // intermediate, non-matching snapshot would lose it before our own
             // write arrives, letting the self-paste be persisted after all.
-            lock.take();
+            // Consume even after TTL so a later real copy of the same content
+            // is not held against a marker that already did its job.
+            if lock
+                .as_ref()
+                .is_some_and(|(marked, _)| marked == clip_hash.as_str())
+            {
+                lock.take();
+            }
             log::info!("CLIPBOARD: Ignoring self-paste (own clipboard write)");
             return;
         }
@@ -3429,14 +3435,13 @@ unsafe fn extract_icon(path: &str) -> Option<String> {
 mod tests {
     use super::{
         build_clip_hash_material, calculate_hash, capture_state_name, capture_text,
-        clear_ignore_hash_if_matches, clipboard_retry_delay, ignore_marker_applies,
-        is_remote_client_owner, is_remote_client_process, likely_secret_decision,
-        next_listener_backoff, relayed_clip_hash, rgba_to_cf_dib, set_ignore_hash,
-        should_forget_recent_capture, should_relay_capture, should_skip_sensitive_capture,
-        CapturedContent, CapturedFormat, ClipboardListenerEvent, ClipboardSnapshot,
-        LikelySecretDecision, SensitiveMarkers, SizedPayload, CAPTURE_STATE_LISTENING,
-        CAPTURE_STATE_RESTARTING, CAPTURE_STATE_STOPPED, CLIPBOARD_CLEAR_FORGET_WINDOW,
-        IGNORE_HASH, IGNORE_HASH_TTL,
+        clear_ignore_hash_if_matches, clipboard_retry_delay, is_remote_client_owner,
+        is_remote_client_process, likely_secret_decision, next_listener_backoff, relayed_clip_hash,
+        rgba_to_cf_dib, set_ignore_hash, should_forget_recent_capture, should_relay_capture,
+        should_skip_sensitive_capture, CapturedContent, CapturedFormat, ClipboardListenerEvent,
+        ClipboardSnapshot, LikelySecretDecision, SensitiveMarkers, SizedPayload,
+        CAPTURE_STATE_LISTENING, CAPTURE_STATE_RESTARTING, CAPTURE_STATE_STOPPED,
+        CLIPBOARD_CLEAR_FORGET_WINDOW, IGNORE_HASH,
     };
     use std::time::{Duration, Instant};
 
@@ -3467,6 +3472,7 @@ mod tests {
             ],
             materialize_ms: 0,
             sensitive: SensitiveMarkers::default(),
+            ignore_hash: None,
         });
         assert_eq!(event.payload_bytes(), 1000 + 64 + 200 + 50);
         assert_eq!(
@@ -4052,46 +4058,6 @@ mod tests {
 
         clear_ignore_hash_if_matches("expected");
         assert!(IGNORE_HASH.lock().is_none());
-    }
-
-    #[test]
-    fn ignore_marker_applies_to_a_fresh_matching_write() {
-        let now = Instant::now();
-        let marker = ("hash-a".to_string(), now);
-        assert!(ignore_marker_applies(
-            Some(&marker),
-            "hash-a",
-            now + Duration::from_millis(50),
-            IGNORE_HASH_TTL
-        ));
-    }
-
-    #[test]
-    fn ignore_marker_never_applies_to_other_content() {
-        let now = Instant::now();
-        let marker = ("hash-a".to_string(), now);
-        assert!(!ignore_marker_applies(
-            Some(&marker),
-            "hash-b",
-            now,
-            IGNORE_HASH_TTL
-        ));
-        assert!(!ignore_marker_applies(None, "hash-a", now, IGNORE_HASH_TTL));
-    }
-
-    #[test]
-    fn a_stale_marker_stops_swallowing_real_copies() {
-        // The self-write was never observed (contended read, or a remote client
-        // rewrote the clipboard first). Copying that same content later is a
-        // genuine copy and must still be captured.
-        let now = Instant::now();
-        let marker = ("hash-a".to_string(), now);
-        assert!(!ignore_marker_applies(
-            Some(&marker),
-            "hash-a",
-            now + IGNORE_HASH_TTL + Duration::from_millis(1),
-            IGNORE_HASH_TTL
-        ));
     }
 
     #[test]

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -61,9 +61,11 @@ use windows::Win32::UI::WindowsAndMessaging::{
 /// Hash of a clipboard write Cubby made itself, with the time it was written.
 /// A snapshot queued while this marker is live carries the hash and generation
 /// so a backed-up consumer still ignores the echo after the wall-clock TTL
-/// (SBS-1022) without consuming a later paste of the same content.
-static IGNORE_HASH: Lazy<parking_lot::Mutex<Option<ignore_hash::IgnoreMarker>>> =
-    Lazy::new(|| parking_lot::Mutex::new(None));
+/// (SBS-1022) without consuming a later paste of the same content. Consumed
+/// generation lives next to the marker so a same-hash re-copy that bound the
+/// same generation is not swallowed after the echo is ignored.
+static IGNORE_HASH: Lazy<parking_lot::Mutex<ignore_hash::IgnoreState>> =
+    Lazy::new(|| parking_lot::Mutex::new(ignore_hash::IgnoreState::default()));
 static LAST_STABLE_HASH: Lazy<parking_lot::Mutex<Option<String>>> =
     Lazy::new(|| parking_lot::Mutex::new(None));
 /// Most recent accepted capture, used to forget extension password copies when
@@ -109,10 +111,7 @@ use forget_on_clear::{
 };
 use snapshot_queue::SizedPayload;
 mod ignore_hash;
-use ignore_hash::{
-    bind_ignore_hash_for_queued_work, consume_ignore_marker_after_self_paste,
-    should_ignore_queued_self_paste, IGNORE_HASH_TTL,
-};
+use ignore_hash::{bind_ignore_hash_for_queued_work, IGNORE_HASH_TTL};
 
 /// Pure helper for SOU-316 unit tests: only empty clears within the window
 /// forget the last clip. A later clear must leave history alone.
@@ -171,13 +170,19 @@ pub struct ClipboardCaptureStatus {
 
 pub fn set_ignore_hash(hash: String) {
     let mut lock = IGNORE_HASH.lock();
-    *lock = Some(ignore_hash::IgnoreMarker::new(hash));
+    // A new paste is a new generation. Leave consumed_generation in place so
+    // old queued echos still see their generation as already spent.
+    lock.marker = Some(ignore_hash::IgnoreMarker::new(hash));
 }
 
 pub(crate) fn clear_ignore_hash_if_matches(hash: &str) {
     let mut lock = IGNORE_HASH.lock();
-    if lock.as_ref().is_some_and(|marked| marked.hash == hash) {
-        lock.take();
+    if lock
+        .marker
+        .as_ref()
+        .is_some_and(|marked| marked.hash == hash)
+    {
+        lock.marker.take();
     }
 }
 
@@ -836,7 +841,7 @@ fn capture_one_bound_sequence(
     if let Some(MaterializeAttempt::Captured(content, formats)) = materialized {
         note_clipboard_event(sequence);
         let ignore = bind_ignore_hash_for_queued_work(
-            IGNORE_HASH.lock().as_ref(),
+            IGNORE_HASH.lock().marker.as_ref(),
             Instant::now(),
             IGNORE_HASH_TTL,
         );
@@ -2112,31 +2117,18 @@ async fn process_clipboard_snapshot(
     // The work item carries the hash that was live at enqueue. Honour that
     // even when the 5s wall-clock TTL has elapsed: a backed-up snapshot
     // queue must not persist the echo and bump created_at/source_app
-    // (SBS-1022). The live-marker check still covers a write whose snapshot
-    // was queued in the same window the paste path set the hash.
-    {
-        let mut lock = IGNORE_HASH.lock();
-        if should_ignore_queued_self_paste(
-            queued_ignore.as_ref(),
-            lock.as_ref(),
-            clip_hash.as_str(),
-            Instant::now(),
-            IGNORE_HASH_TTL,
-        ) {
-            // Only consume the marker this work item owns (same generation),
-            // or a live TTL match that is not from the queued binding.
-            // Clearing by hash alone would drop a newer paste of the same
-            // content.
-            consume_ignore_marker_after_self_paste(
-                &mut lock,
-                queued_ignore.as_ref(),
-                clip_hash.as_str(),
-                Instant::now(),
-                IGNORE_HASH_TTL,
-            );
-            log::info!("CLIPBOARD: Ignoring self-paste (own clipboard write)");
-            return;
-        }
+    // (SBS-1022). Consume is one-shot per generation so a genuine re-copy
+    // that bound the same generation is still captured. The live-marker
+    // check still covers a write whose snapshot was queued in the same
+    // window the paste path set the hash.
+    if IGNORE_HASH.lock().ignore_and_consume_self_paste(
+        queued_ignore.as_ref(),
+        clip_hash.as_str(),
+        Instant::now(),
+        IGNORE_HASH_TTL,
+    ) {
+        log::info!("CLIPBOARD: Ignoring self-paste (own clipboard write)");
+        return;
     }
 
     // Source app info was captured at event time (before debounce) to avoid race conditions
@@ -3474,7 +3466,7 @@ mod tests {
             ],
             materialize_ms: 0,
             sensitive: SensitiveMarkers::default(),
-            ignore_hash: None,
+            ignore: None,
         });
         assert_eq!(event.payload_bytes(), 1000 + 64 + 200 + 50);
         assert_eq!(
@@ -4056,13 +4048,14 @@ mod tests {
         assert_eq!(
             IGNORE_HASH
                 .lock()
+                .marker
                 .as_ref()
                 .map(|marked| marked.hash.as_str()),
             Some("expected")
         );
 
         clear_ignore_hash_if_matches("expected");
-        assert!(IGNORE_HASH.lock().is_none());
+        assert!(IGNORE_HASH.lock().marker.is_none());
     }
 
     #[test]

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -59,10 +59,10 @@ use windows::Win32::UI::WindowsAndMessaging::{
 // GLOBAL STATE: Store the hash of the clip we just pasted ourselves.
 // If the next clipboard change matches this hash, we ignore it (don't update timestamp).
 /// Hash of a clipboard write Cubby made itself, with the time it was written.
-/// A snapshot queued while this marker is live carries the hash so a backed-up
-/// consumer still ignores the echo after the wall-clock TTL (SBS-1022).
-/// Consumed by the matching capture so a self-paste is not re-recorded.
-static IGNORE_HASH: Lazy<parking_lot::Mutex<Option<(String, Instant)>>> =
+/// A snapshot queued while this marker is live carries the hash and generation
+/// so a backed-up consumer still ignores the echo after the wall-clock TTL
+/// (SBS-1022) without consuming a later paste of the same content.
+static IGNORE_HASH: Lazy<parking_lot::Mutex<Option<ignore_hash::IgnoreMarker>>> =
     Lazy::new(|| parking_lot::Mutex::new(None));
 static LAST_STABLE_HASH: Lazy<parking_lot::Mutex<Option<String>>> =
     Lazy::new(|| parking_lot::Mutex::new(None));
@@ -110,7 +110,8 @@ use forget_on_clear::{
 use snapshot_queue::SizedPayload;
 mod ignore_hash;
 use ignore_hash::{
-    bind_ignore_hash_for_queued_work, should_ignore_queued_self_paste, IGNORE_HASH_TTL,
+    bind_ignore_hash_for_queued_work, consume_ignore_marker_after_self_paste,
+    should_ignore_queued_self_paste, IGNORE_HASH_TTL,
 };
 
 /// Pure helper for SOU-316 unit tests: only empty clears within the window
@@ -170,12 +171,12 @@ pub struct ClipboardCaptureStatus {
 
 pub fn set_ignore_hash(hash: String) {
     let mut lock = IGNORE_HASH.lock();
-    *lock = Some((hash, Instant::now()));
+    *lock = Some(ignore_hash::IgnoreMarker::new(hash));
 }
 
 pub(crate) fn clear_ignore_hash_if_matches(hash: &str) {
     let mut lock = IGNORE_HASH.lock();
-    if lock.as_ref().is_some_and(|(marked, _)| marked == hash) {
+    if lock.as_ref().is_some_and(|marked| marked.hash == hash) {
         lock.take();
     }
 }
@@ -325,10 +326,11 @@ struct ClipboardSnapshot {
     materialize_ms: u128,
     /// Which do-not-retain markers this copy carried. See `SensitiveMarkers`.
     sensitive: SensitiveMarkers,
-    /// Ignore hash that was still live when this snapshot entered the queue.
+    /// Ignore marker that was still live when this snapshot entered the queue.
     /// Honoured at process time even if the wall-clock TTL has since elapsed
-    /// (SBS-1022): a backed-up consumer must not persist a self-paste echo.
-    ignore_hash: Option<String>,
+    /// (SBS-1022). Carries the generation so consuming this echo cannot wipe
+    /// a later paste of the same content.
+    ignore: Option<ignore_hash::QueuedIgnore>,
 }
 
 enum ClipboardListenerEvent {
@@ -833,7 +835,7 @@ fn capture_one_bound_sequence(
 
     if let Some(MaterializeAttempt::Captured(content, formats)) = materialized {
         note_clipboard_event(sequence);
-        let ignore_hash = bind_ignore_hash_for_queued_work(
+        let ignore = bind_ignore_hash_for_queued_work(
             IGNORE_HASH.lock().as_ref(),
             Instant::now(),
             IGNORE_HASH_TTL,
@@ -845,7 +847,7 @@ fn capture_one_bound_sequence(
             formats,
             materialize_ms: started.elapsed().as_millis(),
             sensitive,
-            ignore_hash,
+            ignore,
         };
         return enqueue_listener_event(event_tx, ClipboardListenerEvent::Content(snapshot))
             .map(|_| CaptureAttempt::Handled)
@@ -2032,7 +2034,7 @@ async fn process_clipboard_snapshot(
     let materialize_ms = snapshot.materialize_ms;
     let sequence = snapshot.sequence;
     let markers = snapshot.sensitive;
-    let queued_ignore_hash = snapshot.ignore_hash;
+    let queued_ignore = snapshot.ignore;
     let source_app_info = resolve_source_app_info(snapshot.source_app_identity);
     let captured_formats = snapshot.formats;
     let (clip_type, clip_content, clip_preview, _primary_hash, full_image_content, metadata) =
@@ -2115,23 +2117,22 @@ async fn process_clipboard_snapshot(
     {
         let mut lock = IGNORE_HASH.lock();
         if should_ignore_queued_self_paste(
-            queued_ignore_hash.as_deref(),
+            queued_ignore.as_ref(),
             lock.as_ref(),
             clip_hash.as_str(),
             Instant::now(),
             IGNORE_HASH_TTL,
         ) {
-            // Only consume the marker on a match. Clearing it for an
-            // intermediate, non-matching snapshot would lose it before our own
-            // write arrives, letting the self-paste be persisted after all.
-            // Consume even after TTL so a later real copy of the same content
-            // is not held against a marker that already did its job.
-            if lock
-                .as_ref()
-                .is_some_and(|(marked, _)| marked == clip_hash.as_str())
-            {
-                lock.take();
-            }
+            // Only consume the marker this work item owns (same generation),
+            // or a live TTL match on an unbound snapshot. Clearing by hash
+            // alone would drop a newer paste of the same content.
+            consume_ignore_marker_after_self_paste(
+                &mut *lock,
+                queued_ignore.as_ref(),
+                clip_hash.as_str(),
+                Instant::now(),
+                IGNORE_HASH_TTL,
+            );
             log::info!("CLIPBOARD: Ignoring self-paste (own clipboard write)");
             return;
         }
@@ -4052,7 +4053,10 @@ mod tests {
         set_ignore_hash("expected".to_string());
         clear_ignore_hash_if_matches("different");
         assert_eq!(
-            IGNORE_HASH.lock().as_ref().map(|(hash, _)| hash.as_str()),
+            IGNORE_HASH
+                .lock()
+                .as_ref()
+                .map(|marked| marked.hash.as_str()),
             Some("expected")
         );
 

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -2124,8 +2124,9 @@ async fn process_clipboard_snapshot(
             IGNORE_HASH_TTL,
         ) {
             // Only consume the marker this work item owns (same generation),
-            // or a live TTL match on an unbound snapshot. Clearing by hash
-            // alone would drop a newer paste of the same content.
+            // or a live TTL match that is not from the queued binding.
+            // Clearing by hash alone would drop a newer paste of the same
+            // content.
             consume_ignore_marker_after_self_paste(
                 &mut *lock,
                 queued_ignore.as_ref(),

--- a/src-tauri/src/clipboard/ignore_hash.rs
+++ b/src-tauri/src/clipboard/ignore_hash.rs
@@ -4,6 +4,8 @@
 //! Windows crate. A 5s marker that expires before a queued echo is processed
 //! used to persist that echo and bump `created_at`/`source_app`. The work item
 //! now carries the hash (and marker generation) that was live at enqueue.
+//! Queued ignore is one-shot per generation: consuming an echo must not
+//! swallow a later same-hash snapshot that bound the same generation.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -46,6 +48,47 @@ impl IgnoreMarker {
 pub(crate) struct QueuedIgnore {
     pub hash: String,
     pub generation: u64,
+}
+
+/// Live marker and the generation last consumed from a self-paste ignore.
+/// Stored together so enqueue binding and process-time consume stay consistent.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct IgnoreState {
+    pub marker: Option<IgnoreMarker>,
+    pub consumed_generation: Option<u64>,
+}
+
+impl IgnoreState {
+    /// Whether this snapshot is a self-paste echo, and if so consume that
+    /// generation. Process-time storage uses this so the mutex guard is not
+    /// split-borrowed across the two helpers.
+    pub(crate) fn ignore_and_consume_self_paste(
+        &mut self,
+        queued: Option<&QueuedIgnore>,
+        clip_hash: &str,
+        now: Instant,
+        ttl: Duration,
+    ) -> bool {
+        if !should_ignore_queued_self_paste(
+            queued,
+            self.marker.as_ref(),
+            clip_hash,
+            now,
+            ttl,
+            self.consumed_generation,
+        ) {
+            return false;
+        }
+        consume_ignore_marker_after_self_paste(
+            &mut self.marker,
+            queued,
+            clip_hash,
+            now,
+            ttl,
+            &mut self.consumed_generation,
+        );
+        true
+    }
 }
 
 /// Whether a self-write marker still applies to `hash`.
@@ -92,18 +135,22 @@ pub(crate) fn bind_ignore_hash_for_queued_work(
 /// Whether this queued snapshot is Cubby's own write and must not be persisted.
 ///
 /// The work item's bound hash stays effective for the snapshot's lifetime,
-/// even when the live marker has outlived [`IGNORE_HASH_TTL`]. The live-marker
-/// check still covers a write whose snapshot was queued in the same window
-/// the paste path set the hash.
+/// even when the live marker has outlived [`IGNORE_HASH_TTL`]. That binding
+/// is one-shot per generation: after that generation is consumed, a later
+/// same-hash snapshot that bound the same generation is a real copy.
+/// The live-marker check still covers a write whose snapshot was queued in
+/// the same window the paste path set the hash.
 pub(crate) fn should_ignore_queued_self_paste(
     queued: Option<&QueuedIgnore>,
     live_marker: Option<&IgnoreMarker>,
     clip_hash: &str,
     now: Instant,
     ttl: Duration,
+    consumed_generation: Option<u64>,
 ) -> bool {
-    queued.is_some_and(|bound| bound.hash == clip_hash)
-        || ignore_marker_applies(live_marker, clip_hash, now, ttl)
+    queued.is_some_and(|bound| {
+        bound.hash == clip_hash && Some(bound.generation) != consumed_generation
+    }) || ignore_marker_applies(live_marker, clip_hash, now, ttl)
 }
 
 /// Drop the live marker only if this work item owns it, or we ignored via the
@@ -113,23 +160,41 @@ pub(crate) fn should_ignore_queued_self_paste(
 /// a delayed echo is still draining. Requiring `queued` to be `None` would
 /// leave a live marker after an unrelated binding was ignored via TTL, so a
 /// later real copy of that content could be swallowed until the clock expires.
+/// Honouring a queued hash after its generation was consumed would swallow
+/// a genuine re-copy that bound the same generation while the queue was backed
+/// up.
 pub(crate) fn consume_ignore_marker_after_self_paste(
     live: &mut Option<IgnoreMarker>,
     queued: Option<&QueuedIgnore>,
     clip_hash: &str,
     now: Instant,
     ttl: Duration,
+    consumed_generation: &mut Option<u64>,
 ) {
-    let Some(marker) = live.as_ref() else {
-        return;
-    };
-    if marker.hash != clip_hash {
+    let ignored_via_queued = queued.is_some_and(|bound| {
+        bound.hash == clip_hash && Some(bound.generation) != *consumed_generation
+    });
+    let bound_hash_matches = queued.is_some_and(|bound| bound.hash == clip_hash);
+    let owns_this_marker = queued.is_some_and(|bound| {
+        live.as_ref()
+            .is_some_and(|marker| bound.generation == marker.generation)
+    });
+    let ignored_via_live = ignore_marker_applies(live.as_ref(), clip_hash, now, ttl);
+
+    if ignored_via_queued {
+        if let Some(bound) = queued {
+            *consumed_generation = Some(bound.generation);
+        }
+        if owns_this_marker {
+            live.take();
+        }
         return;
     }
-    let ignored_via_queued = queued.is_some_and(|bound| bound.hash == clip_hash);
-    let owns_this_marker = queued.is_some_and(|bound| bound.generation == marker.generation);
-    let ignored_via_live = ignore_marker_applies(live.as_ref(), clip_hash, now, ttl);
-    if owns_this_marker || (ignored_via_live && !ignored_via_queued) {
+
+    if ignored_via_live && !bound_hash_matches {
+        if let Some(marker) = live.as_ref() {
+            *consumed_generation = Some(marker.generation);
+        }
         live.take();
     }
 }
@@ -138,8 +203,8 @@ pub(crate) fn consume_ignore_marker_after_self_paste(
 mod tests {
     use super::{
         bind_ignore_hash_for_queued_work, consume_ignore_marker_after_self_paste,
-        ignore_marker_applies, should_ignore_queued_self_paste, IgnoreMarker, QueuedIgnore,
-        IGNORE_HASH_TTL,
+        ignore_marker_applies, should_ignore_queued_self_paste, IgnoreMarker, IgnoreState,
+        QueuedIgnore, IGNORE_HASH_TTL,
     };
     use std::time::{Duration, Instant};
 
@@ -228,7 +293,8 @@ mod tests {
             Some(&marked),
             "hash-a",
             later,
-            IGNORE_HASH_TTL
+            IGNORE_HASH_TTL,
+            None,
         ));
     }
 
@@ -257,7 +323,8 @@ mod tests {
             Some(&marked),
             "hash-a",
             later,
-            IGNORE_HASH_TTL
+            IGNORE_HASH_TTL,
+            None,
         ));
     }
 
@@ -271,7 +338,8 @@ mod tests {
             Some(&marked),
             "hash-b",
             now,
-            IGNORE_HASH_TTL
+            IGNORE_HASH_TTL,
+            None,
         ));
     }
 
@@ -290,14 +358,16 @@ mod tests {
             Some(&replaced),
             "hash-a",
             later,
-            IGNORE_HASH_TTL
+            IGNORE_HASH_TTL,
+            None,
         ));
         assert!(!should_ignore_queued_self_paste(
             queued.as_ref(),
             Some(&replaced),
             "hash-b",
             later,
-            IGNORE_HASH_TTL
+            IGNORE_HASH_TTL,
+            None,
         ));
     }
 
@@ -310,7 +380,8 @@ mod tests {
             Some(&marked),
             "hash-a",
             now + Duration::from_millis(50),
-            IGNORE_HASH_TTL
+            IGNORE_HASH_TTL,
+            None,
         ));
     }
 
@@ -331,17 +402,21 @@ mod tests {
             Some(&refreshed),
             "hash-a",
             later,
-            IGNORE_HASH_TTL
+            IGNORE_HASH_TTL,
+            None,
         ));
 
         let mut live = Some(refreshed.clone());
+        let mut consumed = None;
         consume_ignore_marker_after_self_paste(
             &mut live,
             queued.as_ref(),
             "hash-a",
             later,
             IGNORE_HASH_TTL,
+            &mut consumed,
         );
+        assert_eq!(consumed, Some(1));
         assert_eq!(
             live.as_ref().map(|marked| marked.generation),
             Some(2),
@@ -352,7 +427,8 @@ mod tests {
             live.as_ref(),
             "hash-a",
             refreshed_at + Duration::from_millis(50),
-            IGNORE_HASH_TTL
+            IGNORE_HASH_TTL,
+            consumed,
         ));
     }
 
@@ -362,28 +438,34 @@ mod tests {
         let marked = marker("hash-a", now, 1);
         let queued = bind_ignore_hash_for_queued_work(Some(&marked), now, IGNORE_HASH_TTL);
         let mut live = Some(marked);
+        let mut consumed = None;
         consume_ignore_marker_after_self_paste(
             &mut live,
             queued.as_ref(),
             "hash-a",
             now + IGNORE_HASH_TTL + Duration::from_millis(1),
             IGNORE_HASH_TTL,
+            &mut consumed,
         );
         assert!(live.is_none());
+        assert_eq!(consumed, Some(1));
     }
 
     #[test]
     fn consume_via_live_ttl_clears_an_unbound_marker() {
         let now = Instant::now();
         let mut live = Some(marker("hash-a", now, 1));
+        let mut consumed = None;
         consume_ignore_marker_after_self_paste(
             &mut live,
             None,
             "hash-a",
             now + Duration::from_millis(50),
             IGNORE_HASH_TTL,
+            &mut consumed,
         );
         assert!(live.is_none());
+        assert_eq!(consumed, Some(1));
     }
 
     #[test]
@@ -402,20 +484,73 @@ mod tests {
             Some(&live_b),
             "hash-b",
             now + Duration::from_millis(50),
-            IGNORE_HASH_TTL
+            IGNORE_HASH_TTL,
+            None,
         ));
 
         let mut live = Some(live_b);
+        let mut consumed = None;
         consume_ignore_marker_after_self_paste(
             &mut live,
             Some(&queued_other),
             "hash-b",
             now + Duration::from_millis(50),
             IGNORE_HASH_TTL,
+            &mut consumed,
         );
         assert!(
             live.is_none(),
             "fail-without-fix: leftover live marker swallows later real copies"
+        );
+        assert_eq!(consumed, Some(2));
+    }
+
+    #[test]
+    fn queued_same_hash_binding_is_one_shot_per_generation() {
+        // Paste A (gen 1). While the queue is backed up, both the self-paste
+        // echo and a genuine re-copy of A bind gen 1. After TTL, consuming
+        // the echo must not leave the second snapshot immortal.
+        let now = Instant::now();
+        let paste_a = marker("hash-a", now, 1);
+        let echo = bind_ignore_hash_for_queued_work(Some(&paste_a), now, IGNORE_HASH_TTL);
+        let recopy = bind_ignore_hash_for_queued_work(Some(&paste_a), now, IGNORE_HASH_TTL);
+        let later = now + IGNORE_HASH_TTL + Duration::from_millis(1);
+
+        assert!(
+            should_ignore_queued_self_paste(
+                echo.as_ref(),
+                Some(&paste_a),
+                "hash-a",
+                later,
+                IGNORE_HASH_TTL,
+                None,
+            ),
+            "fail-without-fix: first queued echo after TTL must still be ignored (SBS-1022)"
+        );
+
+        let mut state = IgnoreState {
+            marker: Some(paste_a),
+            consumed_generation: None,
+        };
+        assert!(state.ignore_and_consume_self_paste(
+            echo.as_ref(),
+            "hash-a",
+            later,
+            IGNORE_HASH_TTL
+        ));
+        assert_eq!(state.consumed_generation, Some(1));
+        assert!(state.marker.is_none());
+
+        assert!(
+            !should_ignore_queued_self_paste(
+                recopy.as_ref(),
+                None,
+                "hash-a",
+                later,
+                IGNORE_HASH_TTL,
+                state.consumed_generation,
+            ),
+            "fail-without-fix: second same-hash snapshot bound to gen 1 is still swallowed"
         );
     }
 }

--- a/src-tauri/src/clipboard/ignore_hash.rs
+++ b/src-tauri/src/clipboard/ignore_hash.rs
@@ -3,8 +3,9 @@
 //! Isolated so enqueue binding vs wall-clock TTL can be tested without the
 //! Windows crate. A 5s marker that expires before a queued echo is processed
 //! used to persist that echo and bump `created_at`/`source_app`. The work item
-//! now carries the hash that was live at enqueue.
+//! now carries the hash (and marker generation) that was live at enqueue.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 /// How long a self-write marker stays valid *until a snapshot is queued*.
@@ -19,6 +20,34 @@ use std::time::{Duration, Instant};
 /// the echo as a new capture just because this TTL elapsed first (SBS-1022).
 pub(crate) const IGNORE_HASH_TTL: Duration = Duration::from_secs(5);
 
+static NEXT_GENERATION: AtomicU64 = AtomicU64::new(1);
+
+/// Live self-write marker. `generation` identifies this set, so a delayed
+/// snapshot cannot consume a later paste of the same content.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct IgnoreMarker {
+    pub hash: String,
+    pub marked_at: Instant,
+    pub generation: u64,
+}
+
+impl IgnoreMarker {
+    pub(crate) fn new(hash: String) -> Self {
+        Self {
+            hash,
+            marked_at: Instant::now(),
+            generation: NEXT_GENERATION.fetch_add(1, Ordering::Relaxed),
+        }
+    }
+}
+
+/// Ignore identity copied onto a snapshot at enqueue.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct QueuedIgnore {
+    pub hash: String,
+    pub generation: u64,
+}
+
 /// Whether a self-write marker still applies to `hash`.
 ///
 /// A marker that has outlived `ttl` is treated as absent: the write it
@@ -26,34 +55,37 @@ pub(crate) const IGNORE_HASH_TTL: Duration = Duration::from_secs(5);
 /// Queued work that already bound this hash uses
 /// [`should_ignore_queued_self_paste`] instead of this clock alone.
 pub(crate) fn ignore_marker_applies(
-    marker: Option<&(String, Instant)>,
+    marker: Option<&IgnoreMarker>,
     hash: &str,
     now: Instant,
     ttl: Duration,
 ) -> bool {
-    marker.is_some_and(|(marked, marked_at)| {
-        marked == hash
+    marker.is_some_and(|marked| {
+        marked.hash == hash
             && now
-                .checked_duration_since(*marked_at)
+                .checked_duration_since(marked.marked_at)
                 .is_some_and(|elapsed| elapsed <= ttl)
     })
 }
 
-/// Copy a still-live ignore hash onto a snapshot as it enters the queue.
+/// Copy a still-live ignore marker onto a snapshot as it enters the queue.
 ///
 /// The wall-clock TTL decides only whether the marker is live *at enqueue*.
 /// An already-expired marker must not ride along and swallow a later real
 /// copy. A live one travels with the work item so process time can honour it
 /// after the TTL (SBS-1022).
 pub(crate) fn bind_ignore_hash_for_queued_work(
-    marker: Option<&(String, Instant)>,
+    marker: Option<&IgnoreMarker>,
     now: Instant,
     ttl: Duration,
-) -> Option<String> {
-    marker.and_then(|(hash, marked_at)| {
-        now.checked_duration_since(*marked_at)
+) -> Option<QueuedIgnore> {
+    marker.and_then(|marked| {
+        now.checked_duration_since(marked.marked_at)
             .is_some_and(|elapsed| elapsed <= ttl)
-            .then(|| hash.clone())
+            .then(|| QueuedIgnore {
+                hash: marked.hash.clone(),
+                generation: marked.generation,
+            })
     })
 }
 
@@ -64,29 +96,74 @@ pub(crate) fn bind_ignore_hash_for_queued_work(
 /// check still covers a write whose snapshot was queued in the same window
 /// the paste path set the hash.
 pub(crate) fn should_ignore_queued_self_paste(
-    queued_ignore_hash: Option<&str>,
-    live_marker: Option<&(String, Instant)>,
+    queued: Option<&QueuedIgnore>,
+    live_marker: Option<&IgnoreMarker>,
     clip_hash: &str,
     now: Instant,
     ttl: Duration,
 ) -> bool {
-    queued_ignore_hash == Some(clip_hash) || ignore_marker_applies(live_marker, clip_hash, now, ttl)
+    queued.is_some_and(|bound| bound.hash == clip_hash)
+        || ignore_marker_applies(live_marker, clip_hash, now, ttl)
+}
+
+/// Drop the live marker only if this work item owns it, or the live TTL path
+/// ignored a snapshot that had no binding.
+///
+/// Consuming by hash alone would wipe a newer paste of the same content while
+/// a delayed echo is still draining. That newer marker must stay up so its
+/// own snapshot can bind (SBS-1022 / Bugbot).
+pub(crate) fn consume_ignore_marker_after_self_paste(
+    live: &mut Option<IgnoreMarker>,
+    queued: Option<&QueuedIgnore>,
+    clip_hash: &str,
+    now: Instant,
+    ttl: Duration,
+) {
+    let Some(marker) = live.as_ref() else {
+        return;
+    };
+    if marker.hash != clip_hash {
+        return;
+    }
+    let owns_this_marker = queued.is_some_and(|bound| bound.generation == marker.generation);
+    let used_live_ttl =
+        queued.is_none() && ignore_marker_applies(live.as_ref(), clip_hash, now, ttl);
+    if owns_this_marker || used_live_ttl {
+        live.take();
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        bind_ignore_hash_for_queued_work, ignore_marker_applies, should_ignore_queued_self_paste,
+        bind_ignore_hash_for_queued_work, consume_ignore_marker_after_self_paste,
+        ignore_marker_applies, should_ignore_queued_self_paste, IgnoreMarker, QueuedIgnore,
         IGNORE_HASH_TTL,
     };
     use std::time::{Duration, Instant};
 
+    fn marker(hash: &str, marked_at: Instant, generation: u64) -> IgnoreMarker {
+        IgnoreMarker {
+            hash: hash.to_string(),
+            marked_at,
+            generation,
+        }
+    }
+
+    #[test]
+    fn new_markers_get_distinct_generations() {
+        let first = IgnoreMarker::new("hash-a".to_string());
+        let second = IgnoreMarker::new("hash-a".to_string());
+        assert_ne!(first.generation, second.generation);
+        assert_eq!(first.hash, second.hash);
+    }
+
     #[test]
     fn ignore_marker_applies_to_a_fresh_matching_write() {
         let now = Instant::now();
-        let marker = ("hash-a".to_string(), now);
+        let marked = marker("hash-a", now, 1);
         assert!(ignore_marker_applies(
-            Some(&marker),
+            Some(&marked),
             "hash-a",
             now + Duration::from_millis(50),
             IGNORE_HASH_TTL
@@ -96,9 +173,9 @@ mod tests {
     #[test]
     fn ignore_marker_never_applies_to_other_content() {
         let now = Instant::now();
-        let marker = ("hash-a".to_string(), now);
+        let marked = marker("hash-a", now, 1);
         assert!(!ignore_marker_applies(
-            Some(&marker),
+            Some(&marked),
             "hash-b",
             now,
             IGNORE_HASH_TTL
@@ -112,9 +189,9 @@ mod tests {
         // rewrote the clipboard first). Copying that same content later is a
         // genuine copy and must still be captured.
         let now = Instant::now();
-        let marker = ("hash-a".to_string(), now);
+        let marked = marker("hash-a", now, 1);
         assert!(!ignore_marker_applies(
-            Some(&marker),
+            Some(&marked),
             "hash-a",
             now + IGNORE_HASH_TTL + Duration::from_millis(1),
             IGNORE_HASH_TTL
@@ -124,10 +201,13 @@ mod tests {
     #[test]
     fn bind_ignore_hash_attaches_a_live_marker_to_queued_work() {
         let now = Instant::now();
-        let marker = ("hash-a".to_string(), now);
+        let marked = marker("hash-a", now, 7);
         assert_eq!(
-            bind_ignore_hash_for_queued_work(Some(&marker), now, IGNORE_HASH_TTL).as_deref(),
-            Some("hash-a")
+            bind_ignore_hash_for_queued_work(Some(&marked), now, IGNORE_HASH_TTL),
+            Some(QueuedIgnore {
+                hash: "hash-a".to_string(),
+                generation: 7,
+            })
         );
     }
 
@@ -136,15 +216,15 @@ mod tests {
         // A marker that already expired before enqueue must not ride along.
         // That is a later real copy of the same content, not our write.
         let now = Instant::now();
-        let marker = ("hash-a".to_string(), now);
+        let marked = marker("hash-a", now, 1);
         let later = now + IGNORE_HASH_TTL + Duration::from_millis(1);
         assert_eq!(
-            bind_ignore_hash_for_queued_work(Some(&marker), later, IGNORE_HASH_TTL),
+            bind_ignore_hash_for_queued_work(Some(&marked), later, IGNORE_HASH_TTL),
             None
         );
         assert!(!should_ignore_queued_self_paste(
             None,
-            Some(&marker),
+            Some(&marked),
             "hash-a",
             later,
             IGNORE_HASH_TTL
@@ -159,18 +239,21 @@ mod tests {
         // the echo and bump created_at/source_app. The work item keeps the
         // hash, so the echo is still ignored.
         let now = Instant::now();
-        let marker = ("hash-a".to_string(), now);
-        let queued = bind_ignore_hash_for_queued_work(Some(&marker), now, IGNORE_HASH_TTL);
+        let marked = marker("hash-a", now, 1);
+        let queued = bind_ignore_hash_for_queued_work(Some(&marked), now, IGNORE_HASH_TTL);
         let later = now + IGNORE_HASH_TTL + Duration::from_millis(1);
 
-        assert_eq!(queued.as_deref(), Some("hash-a"));
+        assert_eq!(
+            queued.as_ref().map(|bound| bound.hash.as_str()),
+            Some("hash-a")
+        );
         assert!(
-            !ignore_marker_applies(Some(&marker), "hash-a", later, IGNORE_HASH_TTL),
+            !ignore_marker_applies(Some(&marked), "hash-a", later, IGNORE_HASH_TTL),
             "fail-without-fix: a wall-clock TTL treats this queued echo as a new capture"
         );
         assert!(should_ignore_queued_self_paste(
-            queued.as_deref(),
-            Some(&marker),
+            queued.as_ref(),
+            Some(&marked),
             "hash-a",
             later,
             IGNORE_HASH_TTL
@@ -180,11 +263,11 @@ mod tests {
     #[test]
     fn queued_ignore_hash_does_not_ignore_other_content() {
         let now = Instant::now();
-        let marker = ("hash-a".to_string(), now);
-        let queued = bind_ignore_hash_for_queued_work(Some(&marker), now, IGNORE_HASH_TTL);
+        let marked = marker("hash-a", now, 1);
+        let queued = bind_ignore_hash_for_queued_work(Some(&marked), now, IGNORE_HASH_TTL);
         assert!(!should_ignore_queued_self_paste(
-            queued.as_deref(),
-            Some(&marker),
+            queued.as_ref(),
+            Some(&marked),
             "hash-b",
             now,
             IGNORE_HASH_TTL
@@ -196,20 +279,20 @@ mod tests {
         // Two pastes in flight: the first work item still carries hash-a
         // after the live marker moved on to hash-b.
         let now = Instant::now();
-        let first = ("hash-a".to_string(), now);
+        let first = marker("hash-a", now, 1);
         let queued = bind_ignore_hash_for_queued_work(Some(&first), now, IGNORE_HASH_TTL);
-        let replaced = ("hash-b".to_string(), now);
+        let replaced = marker("hash-b", now, 2);
         let later = now + IGNORE_HASH_TTL + Duration::from_millis(1);
 
         assert!(should_ignore_queued_self_paste(
-            queued.as_deref(),
+            queued.as_ref(),
             Some(&replaced),
             "hash-a",
             later,
             IGNORE_HASH_TTL
         ));
         assert!(!should_ignore_queued_self_paste(
-            queued.as_deref(),
+            queued.as_ref(),
             Some(&replaced),
             "hash-b",
             later,
@@ -220,13 +303,85 @@ mod tests {
     #[test]
     fn live_marker_still_covers_a_snapshot_queued_without_a_binding() {
         let now = Instant::now();
-        let marker = ("hash-a".to_string(), now);
+        let marked = marker("hash-a", now, 1);
         assert!(should_ignore_queued_self_paste(
             None,
-            Some(&marker),
+            Some(&marked),
             "hash-a",
             now + Duration::from_millis(50),
             IGNORE_HASH_TTL
         ));
+    }
+
+    #[test]
+    fn consuming_a_delayed_echo_does_not_clear_a_newer_same_hash_marker() {
+        // Paste A, queue its echo, then paste A again. The delayed first echo
+        // must not consume the refreshed marker or the second write is
+        // persisted as a new capture.
+        let now = Instant::now();
+        let first = marker("hash-a", now, 1);
+        let queued = bind_ignore_hash_for_queued_work(Some(&first), now, IGNORE_HASH_TTL);
+        let refreshed_at = now + Duration::from_secs(1);
+        let refreshed = marker("hash-a", refreshed_at, 2);
+        let later = now + IGNORE_HASH_TTL + Duration::from_millis(1);
+
+        assert!(should_ignore_queued_self_paste(
+            queued.as_ref(),
+            Some(&refreshed),
+            "hash-a",
+            later,
+            IGNORE_HASH_TTL
+        ));
+
+        let mut live = Some(refreshed.clone());
+        consume_ignore_marker_after_self_paste(
+            &mut live,
+            queued.as_ref(),
+            "hash-a",
+            later,
+            IGNORE_HASH_TTL,
+        );
+        assert_eq!(
+            live.as_ref().map(|marked| marked.generation),
+            Some(2),
+            "fail-without-fix: consume-by-hash wipes the newer paste's marker"
+        );
+        assert!(should_ignore_queued_self_paste(
+            None,
+            live.as_ref(),
+            "hash-a",
+            refreshed_at + Duration::from_millis(50),
+            IGNORE_HASH_TTL
+        ));
+    }
+
+    #[test]
+    fn consume_clears_the_owned_marker_even_after_ttl() {
+        let now = Instant::now();
+        let marked = marker("hash-a", now, 1);
+        let queued = bind_ignore_hash_for_queued_work(Some(&marked), now, IGNORE_HASH_TTL);
+        let mut live = Some(marked);
+        consume_ignore_marker_after_self_paste(
+            &mut live,
+            queued.as_ref(),
+            "hash-a",
+            now + IGNORE_HASH_TTL + Duration::from_millis(1),
+            IGNORE_HASH_TTL,
+        );
+        assert!(live.is_none());
+    }
+
+    #[test]
+    fn consume_via_live_ttl_clears_an_unbound_marker() {
+        let now = Instant::now();
+        let mut live = Some(marker("hash-a", now, 1));
+        consume_ignore_marker_after_self_paste(
+            &mut live,
+            None,
+            "hash-a",
+            now + Duration::from_millis(50),
+            IGNORE_HASH_TTL,
+        );
+        assert!(live.is_none());
     }
 }

--- a/src-tauri/src/clipboard/ignore_hash.rs
+++ b/src-tauri/src/clipboard/ignore_hash.rs
@@ -106,12 +106,13 @@ pub(crate) fn should_ignore_queued_self_paste(
         || ignore_marker_applies(live_marker, clip_hash, now, ttl)
 }
 
-/// Drop the live marker only if this work item owns it, or the live TTL path
-/// ignored a snapshot that had no binding.
+/// Drop the live marker only if this work item owns it, or we ignored via the
+/// live TTL path rather than the queued binding.
 ///
 /// Consuming by hash alone would wipe a newer paste of the same content while
-/// a delayed echo is still draining. That newer marker must stay up so its
-/// own snapshot can bind (SBS-1022 / Bugbot).
+/// a delayed echo is still draining. Requiring `queued` to be `None` would
+/// leave a live marker after an unrelated binding was ignored via TTL, so a
+/// later real copy of that content could be swallowed until the clock expires.
 pub(crate) fn consume_ignore_marker_after_self_paste(
     live: &mut Option<IgnoreMarker>,
     queued: Option<&QueuedIgnore>,
@@ -125,10 +126,10 @@ pub(crate) fn consume_ignore_marker_after_self_paste(
     if marker.hash != clip_hash {
         return;
     }
+    let ignored_via_queued = queued.is_some_and(|bound| bound.hash == clip_hash);
     let owns_this_marker = queued.is_some_and(|bound| bound.generation == marker.generation);
-    let used_live_ttl =
-        queued.is_none() && ignore_marker_applies(live.as_ref(), clip_hash, now, ttl);
-    if owns_this_marker || used_live_ttl {
+    let ignored_via_live = ignore_marker_applies(live.as_ref(), clip_hash, now, ttl);
+    if owns_this_marker || (ignored_via_live && !ignored_via_queued) {
         live.take();
     }
 }
@@ -383,5 +384,38 @@ mod tests {
             IGNORE_HASH_TTL,
         );
         assert!(live.is_none());
+    }
+
+    #[test]
+    fn live_ttl_ignore_consumes_even_when_queued_binding_is_unrelated() {
+        // Snapshot bound to paste A, content is B, live marker is B. We ignore
+        // via the live TTL arm. Leaving B in place would keep binding later
+        // real copies of B until the clock expires.
+        let now = Instant::now();
+        let queued_other = QueuedIgnore {
+            hash: "hash-a".to_string(),
+            generation: 1,
+        };
+        let live_b = marker("hash-b", now, 2);
+        assert!(should_ignore_queued_self_paste(
+            Some(&queued_other),
+            Some(&live_b),
+            "hash-b",
+            now + Duration::from_millis(50),
+            IGNORE_HASH_TTL
+        ));
+
+        let mut live = Some(live_b);
+        consume_ignore_marker_after_self_paste(
+            &mut live,
+            Some(&queued_other),
+            "hash-b",
+            now + Duration::from_millis(50),
+            IGNORE_HASH_TTL,
+        );
+        assert!(
+            live.is_none(),
+            "fail-without-fix: leftover live marker swallows later real copies"
+        );
     }
 }

--- a/src-tauri/src/clipboard/ignore_hash.rs
+++ b/src-tauri/src/clipboard/ignore_hash.rs
@@ -1,0 +1,232 @@
+//! Self-paste ignore-hash lifetime (SBS-1022).
+//!
+//! Isolated so enqueue binding vs wall-clock TTL can be tested without the
+//! Windows crate. A 5s marker that expires before a queued echo is processed
+//! used to persist that echo and bump `created_at`/`source_app`. The work item
+//! now carries the hash that was live at enqueue.
+
+use std::time::{Duration, Instant};
+
+/// How long a self-write marker stays valid *until a snapshot is queued*.
+/// The capture of our own write normally arrives within milliseconds, so this
+/// is generous. It exists because an unbounded marker is never cleaned up when
+/// that capture never arrives at all -- the read lost every race, or a remote
+/// client rewrote the clipboard before we could read it -- and a stale marker
+/// silently swallows the next legitimate copy of the same content.
+///
+/// Once a snapshot is queued while the marker is still live, that work item
+/// carries the hash for its own lifetime. A backed-up consumer must not treat
+/// the echo as a new capture just because this TTL elapsed first (SBS-1022).
+pub(crate) const IGNORE_HASH_TTL: Duration = Duration::from_secs(5);
+
+/// Whether a self-write marker still applies to `hash`.
+///
+/// A marker that has outlived `ttl` is treated as absent: the write it
+/// described was never observed, and honouring it would drop a real copy.
+/// Queued work that already bound this hash uses
+/// [`should_ignore_queued_self_paste`] instead of this clock alone.
+pub(crate) fn ignore_marker_applies(
+    marker: Option<&(String, Instant)>,
+    hash: &str,
+    now: Instant,
+    ttl: Duration,
+) -> bool {
+    marker.is_some_and(|(marked, marked_at)| {
+        marked == hash
+            && now
+                .checked_duration_since(*marked_at)
+                .is_some_and(|elapsed| elapsed <= ttl)
+    })
+}
+
+/// Copy a still-live ignore hash onto a snapshot as it enters the queue.
+///
+/// The wall-clock TTL decides only whether the marker is live *at enqueue*.
+/// An already-expired marker must not ride along and swallow a later real
+/// copy. A live one travels with the work item so process time can honour it
+/// after the TTL (SBS-1022).
+pub(crate) fn bind_ignore_hash_for_queued_work(
+    marker: Option<&(String, Instant)>,
+    now: Instant,
+    ttl: Duration,
+) -> Option<String> {
+    marker.and_then(|(hash, marked_at)| {
+        now.checked_duration_since(*marked_at)
+            .is_some_and(|elapsed| elapsed <= ttl)
+            .then(|| hash.clone())
+    })
+}
+
+/// Whether this queued snapshot is Cubby's own write and must not be persisted.
+///
+/// The work item's bound hash stays effective for the snapshot's lifetime,
+/// even when the live marker has outlived [`IGNORE_HASH_TTL`]. The live-marker
+/// check still covers a write whose snapshot was queued in the same window
+/// the paste path set the hash.
+pub(crate) fn should_ignore_queued_self_paste(
+    queued_ignore_hash: Option<&str>,
+    live_marker: Option<&(String, Instant)>,
+    clip_hash: &str,
+    now: Instant,
+    ttl: Duration,
+) -> bool {
+    queued_ignore_hash == Some(clip_hash) || ignore_marker_applies(live_marker, clip_hash, now, ttl)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        bind_ignore_hash_for_queued_work, ignore_marker_applies, should_ignore_queued_self_paste,
+        IGNORE_HASH_TTL,
+    };
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn ignore_marker_applies_to_a_fresh_matching_write() {
+        let now = Instant::now();
+        let marker = ("hash-a".to_string(), now);
+        assert!(ignore_marker_applies(
+            Some(&marker),
+            "hash-a",
+            now + Duration::from_millis(50),
+            IGNORE_HASH_TTL
+        ));
+    }
+
+    #[test]
+    fn ignore_marker_never_applies_to_other_content() {
+        let now = Instant::now();
+        let marker = ("hash-a".to_string(), now);
+        assert!(!ignore_marker_applies(
+            Some(&marker),
+            "hash-b",
+            now,
+            IGNORE_HASH_TTL
+        ));
+        assert!(!ignore_marker_applies(None, "hash-a", now, IGNORE_HASH_TTL));
+    }
+
+    #[test]
+    fn a_stale_marker_stops_swallowing_real_copies() {
+        // The self-write was never observed (contended read, or a remote client
+        // rewrote the clipboard first). Copying that same content later is a
+        // genuine copy and must still be captured.
+        let now = Instant::now();
+        let marker = ("hash-a".to_string(), now);
+        assert!(!ignore_marker_applies(
+            Some(&marker),
+            "hash-a",
+            now + IGNORE_HASH_TTL + Duration::from_millis(1),
+            IGNORE_HASH_TTL
+        ));
+    }
+
+    #[test]
+    fn bind_ignore_hash_attaches_a_live_marker_to_queued_work() {
+        let now = Instant::now();
+        let marker = ("hash-a".to_string(), now);
+        assert_eq!(
+            bind_ignore_hash_for_queued_work(Some(&marker), now, IGNORE_HASH_TTL).as_deref(),
+            Some("hash-a")
+        );
+    }
+
+    #[test]
+    fn bind_ignore_hash_does_not_attach_an_expired_marker() {
+        // A marker that already expired before enqueue must not ride along.
+        // That is a later real copy of the same content, not our write.
+        let now = Instant::now();
+        let marker = ("hash-a".to_string(), now);
+        let later = now + IGNORE_HASH_TTL + Duration::from_millis(1);
+        assert_eq!(
+            bind_ignore_hash_for_queued_work(Some(&marker), later, IGNORE_HASH_TTL),
+            None
+        );
+        assert!(!should_ignore_queued_self_paste(
+            None,
+            Some(&marker),
+            "hash-a",
+            later,
+            IGNORE_HASH_TTL
+        ));
+    }
+
+    #[test]
+    fn queued_self_paste_survives_an_expired_ttl() {
+        // SBS-1022: the snapshot was queued while the marker was live, then
+        // sat behind other clipboard work until the 5s TTL elapsed. The old
+        // process-time clock (`ignore_marker_applies` alone) would persist
+        // the echo and bump created_at/source_app. The work item keeps the
+        // hash, so the echo is still ignored.
+        let now = Instant::now();
+        let marker = ("hash-a".to_string(), now);
+        let queued = bind_ignore_hash_for_queued_work(Some(&marker), now, IGNORE_HASH_TTL);
+        let later = now + IGNORE_HASH_TTL + Duration::from_millis(1);
+
+        assert_eq!(queued.as_deref(), Some("hash-a"));
+        assert!(
+            !ignore_marker_applies(Some(&marker), "hash-a", later, IGNORE_HASH_TTL),
+            "fail-without-fix: a wall-clock TTL treats this queued echo as a new capture"
+        );
+        assert!(should_ignore_queued_self_paste(
+            queued.as_deref(),
+            Some(&marker),
+            "hash-a",
+            later,
+            IGNORE_HASH_TTL
+        ));
+    }
+
+    #[test]
+    fn queued_ignore_hash_does_not_ignore_other_content() {
+        let now = Instant::now();
+        let marker = ("hash-a".to_string(), now);
+        let queued = bind_ignore_hash_for_queued_work(Some(&marker), now, IGNORE_HASH_TTL);
+        assert!(!should_ignore_queued_self_paste(
+            queued.as_deref(),
+            Some(&marker),
+            "hash-b",
+            now,
+            IGNORE_HASH_TTL
+        ));
+    }
+
+    #[test]
+    fn queued_self_paste_survives_the_live_marker_being_replaced() {
+        // Two pastes in flight: the first work item still carries hash-a
+        // after the live marker moved on to hash-b.
+        let now = Instant::now();
+        let first = ("hash-a".to_string(), now);
+        let queued = bind_ignore_hash_for_queued_work(Some(&first), now, IGNORE_HASH_TTL);
+        let replaced = ("hash-b".to_string(), now);
+        let later = now + IGNORE_HASH_TTL + Duration::from_millis(1);
+
+        assert!(should_ignore_queued_self_paste(
+            queued.as_deref(),
+            Some(&replaced),
+            "hash-a",
+            later,
+            IGNORE_HASH_TTL
+        ));
+        assert!(!should_ignore_queued_self_paste(
+            queued.as_deref(),
+            Some(&replaced),
+            "hash-b",
+            later,
+            IGNORE_HASH_TTL
+        ));
+    }
+
+    #[test]
+    fn live_marker_still_covers_a_snapshot_queued_without_a_binding() {
+        let now = Instant::now();
+        let marker = ("hash-a".to_string(), now);
+        assert!(should_ignore_queued_self_paste(
+            None,
+            Some(&marker),
+            "hash-a",
+            now + Duration::from_millis(50),
+            IGNORE_HASH_TTL
+        ));
+    }
+}

--- a/src-tauri/src/clipboard/ignore_hash.rs
+++ b/src-tauri/src/clipboard/ignore_hash.rs
@@ -174,7 +174,6 @@ pub(crate) fn consume_ignore_marker_after_self_paste(
     let ignored_via_queued = queued.is_some_and(|bound| {
         bound.hash == clip_hash && Some(bound.generation) != *consumed_generation
     });
-    let bound_hash_matches = queued.is_some_and(|bound| bound.hash == clip_hash);
     let owns_this_marker = queued.is_some_and(|bound| {
         live.as_ref()
             .is_some_and(|marker| bound.generation == marker.generation)
@@ -191,7 +190,7 @@ pub(crate) fn consume_ignore_marker_after_self_paste(
         return;
     }
 
-    if ignored_via_live && !bound_hash_matches {
+    if ignored_via_live && !ignored_via_queued {
         if let Some(marker) = live.as_ref() {
             *consumed_generation = Some(marker.generation);
         }
@@ -552,5 +551,47 @@ mod tests {
             ),
             "fail-without-fix: second same-hash snapshot bound to gen 1 is still swallowed"
         );
+    }
+
+    #[test]
+    fn spent_queued_generation_still_consumes_a_live_ttl_match() {
+        // Gen 1 echo consumed. A later same-hash snapshot still carries gen 1,
+        // but a new paste (gen 2) is live within TTL. We ignore via live TTL
+        // (queued arm is spent). Leaving gen 2 in place would swallow later
+        // real copies of A until the clock expires.
+        let now = Instant::now();
+        let first = marker("hash-a", now, 1);
+        let echo = bind_ignore_hash_for_queued_work(Some(&first), now, IGNORE_HASH_TTL);
+        let recopy = bind_ignore_hash_for_queued_work(Some(&first), now, IGNORE_HASH_TTL);
+        let gen2_at = now + Duration::from_millis(50);
+        let gen2 = marker("hash-a", gen2_at, 2);
+
+        let mut state = IgnoreState {
+            marker: Some(first),
+            consumed_generation: None,
+        };
+        assert!(state.ignore_and_consume_self_paste(
+            echo.as_ref(),
+            "hash-a",
+            now + Duration::from_millis(10),
+            IGNORE_HASH_TTL,
+        ));
+        assert_eq!(state.consumed_generation, Some(1));
+
+        state.marker = Some(gen2);
+        assert!(
+            state.ignore_and_consume_self_paste(
+                recopy.as_ref(),
+                "hash-a",
+                gen2_at + Duration::from_millis(50),
+                IGNORE_HASH_TTL,
+            ),
+            "recopy is ignored via the live gen-2 TTL, not the spent gen-1 binding"
+        );
+        assert!(
+            state.marker.is_none(),
+            "fail-without-fix: leftover gen-2 live marker swallows later real copies"
+        );
+        assert_eq!(state.consumed_generation, Some(2));
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Linear [SBS-1022](https://linear.app/southboundsoftware/issue/SBS-1022): `IGNORE_HASH` used a 5s wall-clock TTL that could expire while a self-paste snapshot was still sitting in the clipboard queue. The consumer then treated Cubby's own write as a new capture and bumped `created_at` / `source_app` (older clip jumps to "1 second ago" under "Cubby Clipboard").

This is not the unbounded-queue ticket (SBS-1032). The queue can still back up; the ignore now lasts as long as the work item that depends on it.

The live marker is copied onto the snapshot at enqueue while the TTL is still valid. Process time honours that bound hash even after the clock expires. An already-expired marker is not bound, so a later real copy of the same content is still captured. All self-write paths (`restore_clip`, recognized-text paste, `copy_selected_text`, remote relay) go through this same snapshot queue.

Each marker also has a generation. Consume drops that generation, or a live TTL match that did not come from the queued binding. That keeps a later same-hash paste's marker (first Bugbot), and does not leave a live marker after an unrelated binding was ignored via TTL (second Bugbot).

Helpers live in `src-tauri/src/clipboard/ignore_hash.rs`, same isolation pattern as `forget_on_clear.rs`.

## User-visible outcome

Pasting an older clip no longer rewrites its history date or source app when the self-paste echo is processed more than five seconds after the write. A genuine later copy of the same content still lands. Pasting the same clip twice while the queue is backed up does not lose the second ignore.

## Verification

- [x] I kept this pull request focused.
- [ ] I tested the change on Windows 11.
- [x] I added or updated tests where practical.
- [x] I updated documentation for changed behavior.
- [x] I did not include clipboard contents, credentials, signing material, or other secrets.

### Test evidence

Isolated `rustc --test` of `src-tauri/src/clipboard/ignore_hash.rs` (this Linux agent cannot compile the Tauri crate: no GTK/WebKit). **14 passed** with the fix.

**Fail without the queued-hash arm** (TTL-only process time):

```
test tests::queued_self_paste_survives_an_expired_ttl ... FAILED
test tests::queued_self_paste_survives_the_live_marker_being_replaced ... FAILED
```

**Fail without generation-aware consume** (consume by hash string):

```
test tests::consuming_a_delayed_echo_does_not_clear_a_newer_same_hash_marker ... FAILED
```

**Fail if live TTL consume requires `queued` to be `None`:**

```
test tests::live_ttl_ignore_consumes_even_when_queued_binding_is_unrelated ... FAILED
fail-without-fix: leftover live marker swallows later real copies
```

Also ran `cargo fmt --manifest-path src-tauri/Cargo.toml --check`.

Windows CI on `e92e242`: `cargo test --all-targets` and the four shipped-target `cargo check` jobs passed. `cargo clippy --all-targets -- -D warnings` failed on `explicit_auto_deref` (`&mut *lock`). Fixed in this head by passing `&mut lock`.

## Gaps

- No Windows 11 paste-through-a-backed-up-queue manual run.
- Does not bound the snapshot queue (SBS-1032).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6460c128-8f8b-40e1-a071-b6d097cc3805?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6460c128-8f8b-40e1-a071-b6d097cc3805&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind ignore-hash lifetime to queued clipboard snapshots
> - Adds a new [ignore_hash.rs](https://github.com/tsouth89/cubby-clipboard/pull/281/files#diff-63c9b74328a796ccd1fe00b7037c8cf5e6925bc547c74d4ef071435d10fa9330) module with generation-aware self-paste tracking (`IgnoreMarker`, `QueuedIgnore`, `IgnoreState`) replacing the old `(String, Instant)` tuple in `IGNORE_HASH`
> - `ClipboardSnapshot` now carries a `QueuedIgnore` binding captured at enqueue time via `bind_ignore_hash_for_queued_work`, so the ignore remains effective even after the 5-second wall-clock `IGNORE_HASH_TTL` expires before processing
> - `process_clipboard_snapshot` replaces the direct TTL check with `IgnoreState::ignore_and_consume_self_paste`, providing one-shot consumption per generation so a delayed self-paste echo cannot swallow a later real copy with the same hash
> - Behavioral Change: `set_ignore_hash` now increments a generation counter and `clear_ignore_hash_if_matches` only clears the live `marker` field when the hash matches, preserving consumed-generation state; all tests in [clipboard.rs](https://github.com/tsouth89/cubby-clipboard/pull/281/files#diff-8b53e1d4014cd55d2bf889ca51d824e6f3c4f2e3775e5b8a5d2670c416a3b984) were updated for the new state shape
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a820fab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->