### PR TITLE
SBS-1045: Keep Cleared events when the snapshot queue floods

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -3591,22 +3591,23 @@ mod tests {
 
         let mut queue = VecDeque::new();
         let mut queued_bytes = 0usize;
-        assert_eq!(
+        assert!(matches!(
             enqueue(&mut queue, &mut queued_bytes, cleared, 2, 20),
             EnqueueOutcome::Queued
-        );
-        assert_eq!(
+        ));
+        assert!(matches!(
             enqueue(&mut queue, &mut queued_bytes, content(8, 8), 2, 20),
             EnqueueOutcome::Queued
-        );
+        ));
         let outcome = enqueue(&mut queue, &mut queued_bytes, content(9, 8), 2, 20);
-        assert_eq!(
+        assert!(matches!(
             outcome,
             EnqueueOutcome::QueuedAfterDrop {
                 dropped: 1,
-                dropped_bytes: 8
-            }
-        );
+                dropped_bytes: 8,
+                evicted,
+            } if evicted.len() == 1
+        ));
         assert!(matches!(
             queue.front(),
             Some(ClipboardListenerEvent::Cleared { sequence: 7 })

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -247,7 +247,8 @@ pub fn get_clipboard_capture_status() -> ClipboardCaptureStatus {
 pub fn init(app: &AppHandle, db: Arc<Database>) {
     crate::ocr_queue::init(app.clone(), db.clone());
     // SBS-1032: snapshots carry full PNG/HTML/RTF bytes. The queue is
-    // bounded (drop-oldest); see `snapshot_queue` for the policy.
+    // bounded (drop-oldest, Cleared retained — SBS-1045); see
+    // `snapshot_queue` for the policy.
     let (event_tx, event_rx) = snapshot_channel::channel();
     let app_for_consumer = app.clone();
     let db_for_consumer = db.clone();
@@ -352,6 +353,14 @@ impl SizedPayload for ClipboardListenerEvent {
             Self::Cleared { .. } => 0,
             Self::Content(snapshot) => snapshot.payload_bytes(),
         }
+    }
+
+    fn retain_on_flood(&self) -> bool {
+        matches!(self, Self::Cleared { .. })
+    }
+
+    fn replaces_queued(&self, older: &Self) -> bool {
+        matches!((self, older), (Self::Cleared { .. }, Self::Cleared { .. }))
     }
 }
 
@@ -3469,10 +3478,68 @@ mod tests {
             ignore: None,
         });
         assert_eq!(event.payload_bytes(), 1000 + 64 + 200 + 50);
+        assert!(!event.retain_on_flood());
         assert_eq!(
             ClipboardListenerEvent::Cleared { sequence: 2 }.payload_bytes(),
             0
         );
+        assert!(ClipboardListenerEvent::Cleared { sequence: 2 }.retain_on_flood());
+        assert!(ClipboardListenerEvent::Cleared { sequence: 3 }
+            .replaces_queued(&ClipboardListenerEvent::Cleared { sequence: 2 }));
+        assert!(!event.replaces_queued(&ClipboardListenerEvent::Cleared { sequence: 2 }));
+    }
+
+    /// SBS-1045: a 0-byte `Cleared` used to be the first byte-budget victim.
+    /// The real event type must stay retained so forget-on-clear still runs.
+    #[test]
+    fn a_queued_cleared_survives_a_content_flood() {
+        use super::snapshot_queue::{enqueue, EnqueueOutcome};
+        use std::collections::VecDeque;
+
+        let cleared = ClipboardListenerEvent::Cleared { sequence: 7 };
+        let content = |sequence: u32, bytes: usize| {
+            ClipboardListenerEvent::Content(ClipboardSnapshot {
+                sequence,
+                source_app_identity: None,
+                content: CapturedContent::Text {
+                    content: vec![b'x'; bytes],
+                    preview: String::new(),
+                    hash: String::new(),
+                },
+                formats: Vec::new(),
+                materialize_ms: 0,
+                sensitive: SensitiveMarkers::default(),
+                ignore: None,
+            })
+        };
+
+        let mut queue = VecDeque::new();
+        let mut queued_bytes = 0usize;
+        assert_eq!(
+            enqueue(&mut queue, &mut queued_bytes, cleared, 2, 20),
+            EnqueueOutcome::Queued
+        );
+        assert_eq!(
+            enqueue(&mut queue, &mut queued_bytes, content(8, 8), 2, 20),
+            EnqueueOutcome::Queued
+        );
+        let outcome = enqueue(&mut queue, &mut queued_bytes, content(9, 8), 2, 20);
+        assert_eq!(
+            outcome,
+            EnqueueOutcome::QueuedAfterDrop {
+                dropped: 1,
+                dropped_bytes: 8
+            }
+        );
+        assert!(matches!(
+            queue.front(),
+            Some(ClipboardListenerEvent::Cleared { sequence: 7 })
+        ));
+        assert!(matches!(
+            queue.back(),
+            Some(ClipboardListenerEvent::Content(snapshot)) if snapshot.sequence == 9
+        ));
+        assert_eq!(queue.len(), 2);
     }
 
     #[cfg(target_os = "windows")]

--- a/src-tauri/src/clipboard/snapshot_queue.rs
+++ b/src-tauri/src/clipboard/snapshot_queue.rs
@@ -4,17 +4,23 @@
 //! hand them to the async consumer over an unbounded channel. A copy flood
 //! then held every pending snapshot in RAM until persist caught up.
 //!
-//! Policy (drop-oldest):
+//! Policy (drop-oldest, with a retain exception):
 //! - At most [`SNAPSHOT_QUEUE_CAPACITY`] events may wait.
 //! - Non-oversize queued payloads may hold at most
 //!   [`SNAPSHOT_QUEUE_MAX_BYTES`] in total. An accepted oversize capture is
 //!   excluded from that sum so a later small event does not evict it, but
 //!   follow-ups that themselves fit the budget are still RAM-bounded.
-//! - Count overflow evicts FIFO from the front (even an oversize resident).
-//!   Byte overflow evicts the oldest non-oversize item.
-//! - A single event larger than the byte budget is still accepted after the
-//!   queue is emptied: we never refuse the current clipboard, we refuse an
-//!   unbounded backlog. A later oversized event replaces that capture.
+//! - Count overflow evicts the oldest droppable item (even an oversize
+//!   resident). Byte overflow evicts the oldest droppable non-oversize item.
+//! - [`SizedPayload::retain_on_flood`] items (clipboard `Cleared`) are not
+//!   evicted to make room. A 0-byte clear used to be the first byte-budget
+//!   victim, which skipped credential forget-on-clear (SBS-1045).
+//! - Adjacent retain items that [`SizedPayload::replaces_queued`] accepts
+//!   collapse into one slot so an OS clear flood cannot fill the queue.
+//! - A single event larger than the byte budget is still accepted after
+//!   droppable items are evicted: we never refuse the current clipboard, we
+//!   refuse an unbounded backlog. A later oversized event replaces that
+//!   capture. Retained clears stay in place.
 //! - A 100-copy text burst (the reliability contract) stays under both
 //!   budgets, so capture order is preserved under normal load.
 //!
@@ -34,6 +40,19 @@ pub(crate) const SNAPSHOT_QUEUE_MAX_BYTES: usize = 64 * 1024 * 1024;
 
 pub(crate) trait SizedPayload {
     fn payload_bytes(&self) -> usize;
+
+    /// Stay queued when flood eviction needs a slot or byte-budget room.
+    /// `Cleared` is the only production case (SBS-1045).
+    fn retain_on_flood(&self) -> bool {
+        false
+    }
+
+    /// Replace `older` at the back instead of taking another slot.
+    /// Adjacent `Cleared` events coalesce so an OS clear flood cannot fill
+    /// the queue with retain items (SBS-1045).
+    fn replaces_queued(&self, _older: &Self) -> bool {
+        false
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -58,14 +77,35 @@ pub(crate) fn enqueue<T: SizedPayload>(
         capacity >= 1,
         "SBS-1032: the queue must be able to hold the current capture"
     );
+
+    // Adjacent retain items (repeated Cleared) share one slot so an OS
+    // clear flood cannot crowd out the 100-copy burst (SBS-1045).
+    if queue
+        .back()
+        .is_some_and(|older| item.replaces_queued(older))
+    {
+        if let Some(old) = queue.pop_back() {
+            *queued_bytes = queued_bytes.saturating_sub(old.payload_bytes());
+        }
+    }
+
     let item_bytes = item.payload_bytes();
     let mut dropped = 0;
     let mut dropped_bytes = 0;
 
     if item_bytes > max_bytes {
         // Newest oversized capture wins: refuse an unbounded backlog of
-        // large payloads, never the current clipboard.
-        while let Some(old) = queue.pop_front() {
+        // large payloads, never the current clipboard. Keep retain items
+        // so a password-manager clear is not discarded (SBS-1045).
+        let mut index = 0;
+        while index < queue.len() {
+            if queue[index].retain_on_flood() {
+                index += 1;
+                continue;
+            }
+            let Some(old) = queue.remove(index) else {
+                break;
+            };
             let old_bytes = old.payload_bytes();
             *queued_bytes = queued_bytes.saturating_sub(old_bytes);
             dropped += 1;
@@ -82,7 +122,14 @@ pub(crate) fn enqueue<T: SizedPayload>(
                 break;
             }
             if !count_ok {
-                let Some(old) = queue.pop_front() else {
+                // Skip retain items so a fronted Cleared is not the FIFO
+                // victim (SBS-1045). If the queue is retain-only, stop:
+                // coalescing should have prevented that, and we still
+                // accept the current clipboard below.
+                let Some(index) = queue.iter().position(|queued| !queued.retain_on_flood()) else {
+                    break;
+                };
+                let Some(old) = queue.remove(index) else {
                     break;
                 };
                 let old_bytes = old.payload_bytes();
@@ -94,7 +141,7 @@ pub(crate) fn enqueue<T: SizedPayload>(
                 dropped_bytes += old_bytes;
             } else if let Some(index) = queue
                 .iter()
-                .position(|queued| queued.payload_bytes() <= max_bytes)
+                .position(|queued| !queued.retain_on_flood() && queued.payload_bytes() <= max_bytes)
             {
                 let Some(old) = queue.remove(index) else {
                     break;
@@ -152,16 +199,41 @@ mod tests {
     struct FakeSnapshot {
         id: u32,
         bytes: usize,
+        retain: bool,
+        kind: u8,
     }
 
     impl SizedPayload for FakeSnapshot {
         fn payload_bytes(&self) -> usize {
             self.bytes
         }
+
+        fn retain_on_flood(&self) -> bool {
+            self.retain
+        }
+
+        fn replaces_queued(&self, older: &Self) -> bool {
+            self.retain && older.retain && self.kind == older.kind
+        }
     }
 
     fn fake(id: u32, bytes: usize) -> FakeSnapshot {
-        FakeSnapshot { id, bytes }
+        FakeSnapshot {
+            id,
+            bytes,
+            retain: false,
+            kind: 0,
+        }
+    }
+
+    /// 0-byte retain item: the production `Cleared` shape (SBS-1045).
+    fn cleared(id: u32) -> FakeSnapshot {
+        FakeSnapshot {
+            id,
+            bytes: 0,
+            retain: true,
+            kind: 1,
+        }
     }
 
     fn ids(queue: &VecDeque<FakeSnapshot>) -> Vec<u32> {
@@ -446,5 +518,137 @@ mod tests {
                 "the reliability contract captures a 100-copy burst; the queue must hold it"
             )
         };
+    }
+
+    /// Fail-without-fix for SBS-1045: count overflow used `pop_front`, so a
+    /// Cleared sitting at the head was discarded and forget-on-clear never
+    /// ran. Evict the oldest droppable item instead.
+    #[test]
+    fn a_retained_clear_survives_count_overflow() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        enqueue(&mut queue, &mut bytes, cleared(0), 3, 1_000);
+        enqueue(&mut queue, &mut bytes, fake(1, 1), 3, 1_000);
+        enqueue(&mut queue, &mut bytes, fake(2, 1), 3, 1_000);
+        let outcome = enqueue(&mut queue, &mut bytes, fake(3, 1), 3, 1_000);
+        assert_eq!(
+            outcome,
+            EnqueueOutcome::QueuedAfterDrop {
+                dropped: 1,
+                dropped_bytes: 1
+            }
+        );
+        assert_eq!(ids(&queue), vec![0, 2, 3]);
+        assert!(queue.front().is_some_and(|item| item.retain));
+        assert_eq!(bytes, 2);
+    }
+
+    /// Fail-without-fix for SBS-1045: byte overflow evicted the oldest
+    /// non-oversize item, and a 0-byte Cleared always qualified first.
+    #[test]
+    fn a_retained_clear_survives_byte_overflow() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        enqueue(&mut queue, &mut bytes, cleared(0), 8, 20);
+        enqueue(&mut queue, &mut bytes, fake(1, 8), 8, 20);
+        enqueue(&mut queue, &mut bytes, fake(2, 8), 8, 20);
+        assert_eq!(ids(&queue), vec![0, 1, 2]);
+        let outcome = enqueue(&mut queue, &mut bytes, fake(3, 8), 8, 20);
+        assert_eq!(
+            outcome,
+            EnqueueOutcome::QueuedAfterDrop {
+                dropped: 1,
+                dropped_bytes: 8
+            }
+        );
+        assert_eq!(ids(&queue), vec![0, 2, 3]);
+        assert!(queue.iter().any(|item| item.retain && item.id == 0));
+        assert_eq!(bytes, 16);
+    }
+
+    /// An oversized follow-up may replace the capture backlog, not the
+    /// pending clear that still has to drive forget-on-clear.
+    #[test]
+    fn a_retained_clear_survives_an_oversize_replacement() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        enqueue(&mut queue, &mut bytes, fake(1, 10), 8, 20);
+        enqueue(&mut queue, &mut bytes, cleared(2), 8, 20);
+        enqueue(&mut queue, &mut bytes, fake(3, 10), 8, 20);
+        let outcome = enqueue(&mut queue, &mut bytes, fake(4, 50), 8, 20);
+        assert_eq!(
+            outcome,
+            EnqueueOutcome::QueuedAfterDrop {
+                dropped: 2,
+                dropped_bytes: 20
+            }
+        );
+        assert_eq!(ids(&queue), vec![2, 4]);
+        assert!(queue.front().is_some_and(|item| item.retain));
+        assert_eq!(bytes, 50);
+    }
+
+    /// Fail-without-fix: an OS clear flood used to occupy every slot with
+    /// 0-byte Cleared events. Adjacent clears collapse to the newest.
+    #[test]
+    fn adjacent_retained_clears_coalesce_instead_of_filling_the_queue() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        for id in 0..200 {
+            let outcome = enqueue(&mut queue, &mut bytes, cleared(id), 8, 20);
+            assert_eq!(outcome, EnqueueOutcome::Queued);
+            assert_eq!(queue.len(), 1);
+            assert_eq!(bytes, 0);
+        }
+        assert_eq!(ids(&queue), vec![199]);
+        assert!(queue.front().is_some_and(|item| item.retain));
+    }
+
+    #[test]
+    fn a_retained_clear_does_not_steal_the_100_copy_burst() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        enqueue(
+            &mut queue,
+            &mut bytes,
+            cleared(0),
+            SNAPSHOT_QUEUE_CAPACITY,
+            SNAPSHOT_QUEUE_MAX_BYTES,
+        );
+        for id in 1..=100 {
+            let outcome = enqueue(
+                &mut queue,
+                &mut bytes,
+                fake(id, 64),
+                SNAPSHOT_QUEUE_CAPACITY,
+                SNAPSHOT_QUEUE_MAX_BYTES,
+            );
+            assert_eq!(outcome, EnqueueOutcome::Queued);
+        }
+        assert_eq!(queue.len(), 101);
+        assert!(queue
+            .front()
+            .is_some_and(|item| item.retain && item.id == 0));
+        assert_eq!(
+            ids(&queue),
+            std::iter::once(0).chain(1..=100).collect::<Vec<u32>>()
+        );
+    }
+
+    #[test]
+    fn a_clear_between_content_is_not_moved_behind_later_copies() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        enqueue(&mut queue, &mut bytes, fake(1, 1), 3, 1_000);
+        enqueue(&mut queue, &mut bytes, cleared(2), 3, 1_000);
+        enqueue(&mut queue, &mut bytes, fake(3, 1), 3, 1_000);
+        enqueue(&mut queue, &mut bytes, fake(4, 1), 3, 1_000);
+        // Evict the oldest droppable (id 1), leave Cleared ahead of id 3.
+        // Rotating Cleared to the back would let a later copy overwrite
+        // LAST_ACCEPTED_CAPTURE before forget-on-clear runs.
+        assert_eq!(ids(&queue), vec![2, 3, 4]);
+        assert!(queue
+            .front()
+            .is_some_and(|item| item.retain && item.id == 2));
     }
 }

--- a/src-tauri/src/clipboard/snapshot_queue.rs
+++ b/src-tauri/src/clipboard/snapshot_queue.rs
@@ -64,6 +64,29 @@ pub(crate) enum EnqueueOutcome {
     },
 }
 
+/// Flood eviction can remove the content that separated two retained clears.
+/// Collapse any newly adjacent replacements so alternating clear/content
+/// traffic cannot grow the retained portion beyond the queue bound.
+fn coalesce_adjacent_replacements<T: SizedPayload>(
+    queue: &mut VecDeque<T>,
+    queued_bytes: &mut usize,
+) -> usize {
+    let mut index = 0;
+    let mut removed_bytes = 0usize;
+    while index + 1 < queue.len() {
+        if queue[index + 1].replaces_queued(&queue[index]) {
+            if let Some(old) = queue.remove(index) {
+                let old_bytes = old.payload_bytes();
+                *queued_bytes = queued_bytes.saturating_sub(old_bytes);
+                removed_bytes = removed_bytes.saturating_add(old_bytes);
+            }
+        } else {
+            index += 1;
+        }
+    }
+    removed_bytes
+}
+
 /// Apply the SBS-1032 bound. `capacity` and `max_bytes` are parameters so a
 /// test can prove the refusal without allocating the production 64 MiB budget.
 pub(crate) fn enqueue<T: SizedPayload>(
@@ -110,6 +133,7 @@ pub(crate) fn enqueue<T: SizedPayload>(
             *queued_bytes = queued_bytes.saturating_sub(old_bytes);
             dropped += 1;
             dropped_bytes += old_bytes;
+            let _ = coalesce_adjacent_replacements(queue, queued_bytes);
         }
     } else {
         // Counted bytes skip an already-accepted oversize resident so a
@@ -139,6 +163,8 @@ pub(crate) fn enqueue<T: SizedPayload>(
                 }
                 dropped += 1;
                 dropped_bytes += old_bytes;
+                let coalesced_bytes = coalesce_adjacent_replacements(queue, queued_bytes);
+                counted_bytes = counted_bytes.saturating_sub(coalesced_bytes);
             } else if let Some(index) = queue
                 .iter()
                 .position(|queued| !queued.retain_on_flood() && queued.payload_bytes() <= max_bytes)
@@ -151,6 +177,8 @@ pub(crate) fn enqueue<T: SizedPayload>(
                 counted_bytes = counted_bytes.saturating_sub(old_bytes);
                 dropped += 1;
                 dropped_bytes += old_bytes;
+                let coalesced_bytes = coalesce_adjacent_replacements(queue, queued_bytes);
+                counted_bytes = counted_bytes.saturating_sub(coalesced_bytes);
             } else {
                 break;
             }
@@ -602,6 +630,21 @@ mod tests {
         }
         assert_eq!(ids(&queue), vec![199]);
         assert!(queue.front().is_some_and(|item| item.retain));
+    }
+
+    /// Evicting the content between retained clears makes those clears
+    /// equivalent. They must then coalesce or alternating traffic can grow
+    /// the retained queue past its configured capacity.
+    #[test]
+    fn alternating_clear_and_content_flood_stays_count_bounded() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        for id in 0..500 {
+            enqueue(&mut queue, &mut bytes, cleared(id * 2), 8, 20);
+            enqueue(&mut queue, &mut bytes, fake(id * 2 + 1, 8), 8, 20);
+            assert!(queue.len() <= 8, "queue grew to {} items", queue.len());
+            assert!(bytes <= 20, "queue grew to {bytes} bytes");
+        }
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The SBS-1032 snapshot queue drops oldest pending events under flood. `ClipboardListenerEvent::Cleared` is 0 bytes, so it was the first byte-budget victim and also a FIFO victim when it sat at the front. Dropping it skipped `process_clipboard_clear`, so a password-manager clear that raced a copy flood left the credential in history.

**Policy (SBS-1045), in `snapshot_queue`:**

- `Cleared` is retained: count overflow evicts the oldest *droppable* item, byte overflow evicts the oldest *droppable* non-oversize item, and an oversized replacement empties only droppable backlog.
- The clear stays in its original position. Rotating it behind later copies would let a new capture overwrite `LAST_ACCEPTED_CAPTURE` before forget-on-clear runs.
- Adjacent `Cleared` events coalesce to one slot so an OS clear flood cannot fill the 128-item queue and crowd out the 100-copy reliability burst.

The consumer path is unchanged: a retained `Cleared` still reaches `process_clipboard_clear`.

## Verification

- [x] I kept this pull request focused.
- [ ] I tested the change on Windows 11.
- [x] I added or updated tests where practical.
- [x] I updated documentation for changed behavior.
- [x] I did not include clipboard contents, credentials, signing material, or other secrets.

**Fail-without-fix:** `a_retained_clear_survives_count_overflow` and `a_retained_clear_survives_byte_overflow` fail if eviction still uses `pop_front` / oldest 0-byte item. `a_queued_cleared_survives_a_content_flood` pins the real `ClipboardListenerEvent::Cleared` type.

**Local (Linux, this agent):**

```
rustc --test src-tauri/src/clipboard/snapshot_queue.rs -o /tmp/snapshot_queue_tests
/tmp/snapshot_queue_tests
```

18 passed (bound policy + retain/coalesce). Full `cargo test` needs Windows; CI covers `clipboard.rs` wiring.

Cite: SBS-1045. Do not merge from this agent.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-384b7300-6493-422b-bf71-484701dee979?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-384b7300-6493-422b-bf71-484701dee979&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retain `Cleared` events during `snapshot_queue` flood eviction
> - Adds `retain_on_flood` and `replaces_queued` methods to the `SizedPayload` trait, defaulting to `false`.
> - Updates `ClipboardListenerEvent` so `Cleared` events survive flood eviction and adjacent clears coalesce.
> - Modifies `enqueue` in [snapshot_queue.rs](https://github.com/tsouth89/cubby-clipboard/pull/282/files#diff-d0368d77f4ef255e7412edc4c45c07f0b76b8e26803943482b3799cbe7e98ef1) to evict only droppable items during count and byte overflows, preserving retained items.
> - Behavioral Change: `enqueue` skips retained items during eviction instead of unconditionally popping the front item.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6affa02.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->