### PR TITLE
SBS-1049: Stop claiming remote hotkey works without Win+V replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 ## Unreleased
 
 ### Fixed
+- Settings and the support FAQ no longer say the configured hotkey opens Cubby in remote sessions unless Replace Windows clipboard shortcut is on (SBS-1049)
 - CI now publishes a stable `shipped-windows` check that fails when any SBS-779 `Check <arch> <features>` cargo-check fails. Branch protection on main still requires only `test` until a repo admin adds that name; the docs no longer claim the matrix legs already block merge (SBS-1025)
 
 ## v1.3.3

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -1227,9 +1227,11 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
                             </span>
                           </button>
                         </div>
-                        <p className="mt-3 text-xs text-muted-foreground">
-                          {t('settings.remoteHotkeyHint')}
-                        </p>
+                        {settings.replace_win_v && (
+                          <p className="mt-3 text-xs text-muted-foreground">
+                            {t('settings.remoteHotkeyHint')}
+                          </p>
+                        )}
                       </Row>
                       <Row
                         title={t('settings.remoteClipboardRelay')}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -102,7 +102,7 @@
     "remotePasteCopyDesc": "Recommended for large logs and everyday use. Cubby restores the remote app, then you press Ctrl+V.",
     "remotePasteKeystrokes": "Paste as keystrokes",
     "remotePasteKeystrokesDesc": "Automatically types short text through Ninja Remote. Slow for large content.",
-    "remoteHotkeyHint": "Your hotkey opens Cubby inside remote sessions when the remote client's keyboard forwarding is off. With forwarding on, open Cubby from the tray icon.",
+    "remoteHotkeyHint": "Replace Windows clipboard shortcut also lets your hotkey open Cubby inside remote sessions when the remote client's keyboard forwarding is off. With forwarding on, open Cubby from the tray icon.",
     "remoteClipboardRelay": "Sync clipboard between remote sessions",
     "remoteClipboardRelayDesc": "Re-announce anything copied inside a remote session so your other remote sessions pick it up. Copy in one session, Ctrl+V in another.",
     "importHeading": "Import",

--- a/product_pages/support.html
+++ b/product_pages/support.html
@@ -58,7 +58,7 @@
       <div class="faq">
         <details>
           <summary>How do I open Cubby?</summary>
-          <p>Cubby is designed to use <kbd>Win</kbd> + <kbd>V</kbd> as its primary shortcut. You can release or change that shortcut in Settings. A remote-session trigger is also available for workflows where the remote client intercepts Windows shortcuts.</p>
+          <p>Cubby is designed to use <kbd>Win</kbd> + <kbd>V</kbd> as its primary shortcut. You can release or change that shortcut in Settings. When Replace Windows clipboard shortcut is on, your configured hotkey can open Cubby inside a remote session if the remote client's keyboard forwarding is off. Otherwise, open Cubby from the tray icon.</p>
         </details>
         <details>
           <summary>What happened to emoji and GIFs?</summary>

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -6,6 +6,7 @@ import { checkPrivilegedActionPins } from '../.github/scripts/check-privileged-a
 import {
   findFileListHistoryClaims,
   findStaleBackupOmissionClaims,
+  findUnqualifiedRemoteHotkeyClaims,
   findWeakerFileRetentionClaim,
 } from './product-page-claims.mjs';
 import { extractDefaultSkipLikelySecrets, evaluateSecretHeuristicsDoc, saysDefaultOff } from './release-check-helpers.mjs';
@@ -286,6 +287,30 @@ for (const [docName, doc] of userFacingHistoryDocs) {
       `${docName} still claims encrypted backups omit HTML/RTF or full-resolution originals: ${claim}`
     );
   }
+}
+
+// SBS-1049: the remote-session hotkey path is the Win+V helper hook.
+// Settings and support once advertised that path without the replacement.
+for (const [docName, doc] of userFacingHistoryDocs) {
+  const [claim] = findUnqualifiedRemoteHotkeyClaims(doc);
+  if (claim) {
+    throw new Error(
+      `${docName} claims the remote hotkey works without Win+V replacement: ${claim}`
+    );
+  }
+}
+
+// The hint is only true while replacement is on. An unconditional render
+// next to Remote session paste restated the Settings lie when the toggle
+// was off.
+if (
+  !/settings\.replace_win_v\s*&&[\s\S]{0,250}settings\.remoteHotkeyHint/.test(
+    settingsPanelSource
+  )
+) {
+  throw new Error(
+    'SettingsPanel must render settings.remoteHotkeyHint only when replace_win_v is on'
+  );
 }
 
 const backupSection = privacyPageDoc.match(

--- a/scripts/product-page-claims.mjs
+++ b/scripts/product-page-claims.mjs
@@ -188,6 +188,41 @@ export function findStaleBackupOmissionClaims(source) {
  * it never says "file lists". `no`/`without`/`none`/`neither` have to count
  * as negation or a disclaimer such as "No files are retained" false-fails.
  */
+/**
+ * SBS-1049: the remote-session hotkey path is the Win+V helper hook.
+ * Settings and support once said the configured hotkey / remote trigger
+ * opens Cubby whenever keyboard forwarding is off, which is false with
+ * replacement disabled.
+ *
+ * A sentence is a claim when it names a remote session, a hotkey or
+ * trigger, and an open/available verb, without also naming the hook.
+ */
+const REMOTE_SESSION = /\bremote(?:[\s-]session)?s?\b/i;
+const HOTKEY_OR_TRIGGER = /\b(?:hotkeys?|(?:remote[\s-]+session\s+)?triggers?)\b/i;
+const OPENS_OR_AVAILABLE = /\b(?:opens?\s+cubby|open\s+cubby|available)\b/i;
+const WIN_V_REPLACEMENT_DEPENDENCY =
+  /\b(?:win\s*\+\s*v\s+replacement|replace(?:s|ment)?\s+windows\s+clipboard|helper\s+hook|replacement\s+(?:mode|must|is\s+on|enabled))\b/i;
+
+export function findUnqualifiedRemoteHotkeyClaims(source) {
+  const claims = [];
+  for (const segment of segments(source)) {
+    if (!REMOTE_SESSION.test(segment)) {
+      continue;
+    }
+    if (!HOTKEY_OR_TRIGGER.test(segment)) {
+      continue;
+    }
+    if (!OPENS_OR_AVAILABLE.test(segment)) {
+      continue;
+    }
+    if (WIN_V_REPLACEMENT_DEPENDENCY.test(segment)) {
+      continue;
+    }
+    claims.push(segment);
+  }
+  return claims;
+}
+
 export function findWeakerFileRetentionClaim(source) {
   const fileMentionPattern = /\bfiles?\b/i;
   const retentionClaimPattern =

--- a/scripts/product-page-claims.mjs
+++ b/scripts/product-page-claims.mjs
@@ -191,6 +191,8 @@ export function findStaleBackupOmissionClaims(source) {
  * trigger, and an open/available verb, without also naming the hook.
  * A negation in the same clause before that verb is a disclaimer, the
  * same way the file-list detectors treat "does not store file lists".
+ * Each open/available match is judged on its own clause so an earlier
+ * disclaimer cannot hide a later claim.
  */
 const REMOTE_SESSION = /\bremote(?:[\s-]session)?s?\b/i;
 const HOTKEY_OR_TRIGGER = /\b(?:hotkeys?|(?:remote[\s-]+session\s+)?triggers?)\b/i;
@@ -198,13 +200,16 @@ const OPENS_OR_AVAILABLE = /\b(?:opens?\s+cubby|open\s+cubby|available)\b/i;
 const WIN_V_REPLACEMENT_DEPENDENCY =
   /\b(?:win\s*\+\s*v\s+replacement|replace(?:s|ment)?\s+windows\s+clipboard|helper\s+hook|replacement\s+(?:mode|must|is\s+on|enabled))\b/i;
 
-function isNegatedOpenOrAvailable(segment) {
-  const open = segment.search(OPENS_OR_AVAILABLE);
-  if (open === -1) {
-    return false;
+function hasUnnegatedOpenOrAvailable(segment) {
+  const pattern = new RegExp(OPENS_OR_AVAILABLE.source, 'gi');
+  let match;
+  while ((match = pattern.exec(segment)) !== null) {
+    const before = segment.slice(0, match.index);
+    if (lastMatchIndex(NEGATION, before.slice(lastClauseStart(before))) === -1) {
+      return true;
+    }
   }
-  const before = segment.slice(0, open);
-  return lastMatchIndex(NEGATION, before.slice(lastClauseStart(before))) !== -1;
+  return false;
 }
 
 export function findUnqualifiedRemoteHotkeyClaims(source) {
@@ -216,13 +221,10 @@ export function findUnqualifiedRemoteHotkeyClaims(source) {
     if (!HOTKEY_OR_TRIGGER.test(segment)) {
       continue;
     }
-    if (!OPENS_OR_AVAILABLE.test(segment)) {
-      continue;
-    }
     if (WIN_V_REPLACEMENT_DEPENDENCY.test(segment)) {
       continue;
     }
-    if (isNegatedOpenOrAvailable(segment)) {
+    if (!hasUnnegatedOpenOrAvailable(segment)) {
       continue;
     }
     claims.push(segment);

--- a/scripts/product-page-claims.mjs
+++ b/scripts/product-page-claims.mjs
@@ -182,13 +182,6 @@ export function findStaleBackupOmissionClaims(source) {
 }
 
 /**
- * Weaker scan used by the release check: a sentence that says files are
- * retained or supported without also negating that. Broader than
- * `findFileListHistoryClaims` so "Cubby stores files" still fails even when
- * it never says "file lists". `no`/`without`/`none`/`neither` have to count
- * as negation or a disclaimer such as "No files are retained" false-fails.
- */
-/**
  * SBS-1049: the remote-session hotkey path is the Win+V helper hook.
  * Settings and support once said the configured hotkey / remote trigger
  * opens Cubby whenever keyboard forwarding is off, which is false with
@@ -196,12 +189,23 @@ export function findStaleBackupOmissionClaims(source) {
  *
  * A sentence is a claim when it names a remote session, a hotkey or
  * trigger, and an open/available verb, without also naming the hook.
+ * A negation in the same clause before that verb is a disclaimer, the
+ * same way the file-list detectors treat "does not store file lists".
  */
 const REMOTE_SESSION = /\bremote(?:[\s-]session)?s?\b/i;
 const HOTKEY_OR_TRIGGER = /\b(?:hotkeys?|(?:remote[\s-]+session\s+)?triggers?)\b/i;
 const OPENS_OR_AVAILABLE = /\b(?:opens?\s+cubby|open\s+cubby|available)\b/i;
 const WIN_V_REPLACEMENT_DEPENDENCY =
   /\b(?:win\s*\+\s*v\s+replacement|replace(?:s|ment)?\s+windows\s+clipboard|helper\s+hook|replacement\s+(?:mode|must|is\s+on|enabled))\b/i;
+
+function isNegatedOpenOrAvailable(segment) {
+  const open = segment.search(OPENS_OR_AVAILABLE);
+  if (open === -1) {
+    return false;
+  }
+  const before = segment.slice(0, open);
+  return lastMatchIndex(NEGATION, before.slice(lastClauseStart(before))) !== -1;
+}
 
 export function findUnqualifiedRemoteHotkeyClaims(source) {
   const claims = [];
@@ -218,11 +222,21 @@ export function findUnqualifiedRemoteHotkeyClaims(source) {
     if (WIN_V_REPLACEMENT_DEPENDENCY.test(segment)) {
       continue;
     }
+    if (isNegatedOpenOrAvailable(segment)) {
+      continue;
+    }
     claims.push(segment);
   }
   return claims;
 }
 
+/**
+ * Weaker scan used by the release check: a sentence that says files are
+ * retained or supported without also negating that. Broader than
+ * `findFileListHistoryClaims` so "Cubby stores files" still fails even when
+ * it never says "file lists". `no`/`without`/`none`/`neither` have to count
+ * as negation or a disclaimer such as "No files are retained" false-fails.
+ */
 export function findWeakerFileRetentionClaim(source) {
   const fileMentionPattern = /\bfiles?\b/i;
   const retentionClaimPattern =

--- a/scripts/product-page-claims.test.mjs
+++ b/scripts/product-page-claims.test.mjs
@@ -383,6 +383,15 @@ test('a later negation does not hide an earlier remote-hotkey claim', () => {
   );
 });
 
+test('an earlier negated clause does not hide a later remote-hotkey claim', () => {
+  assert.equal(
+    findUnqualifiedRemoteHotkeyClaims(
+      'A remote-session trigger is not available locally, and your hotkey opens Cubby inside remote sessions.'
+    ).length,
+    1
+  );
+});
+
 test('naming Win+V replacement qualifies the remote-hotkey sentence', () => {
   for (const sentence of [
     'When Replace Windows clipboard shortcut is on, your hotkey opens Cubby inside remote sessions if keyboard forwarding is off.',

--- a/scripts/product-page-claims.test.mjs
+++ b/scripts/product-page-claims.test.mjs
@@ -8,6 +8,7 @@ import {
   claimSegments,
   findFileListHistoryClaims,
   findStaleBackupOmissionClaims,
+  findUnqualifiedRemoteHotkeyClaims,
   findWeakerFileRetentionClaim,
 } from './product-page-claims.mjs';
 
@@ -332,4 +333,66 @@ test('live privacy.html does not claim backups omit formats', async () => {
   const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   const source = await readFile(path.join(root, 'product_pages/privacy.html'), 'utf8');
   assert.deepEqual(findStaleBackupOmissionClaims(source), []);
+});
+
+// SBS-1049: Settings and support said the configured hotkey opens Cubby
+// in remote sessions whenever keyboard forwarding is off. That path is
+// the Win+V helper hook, so replacement must be named.
+
+test('the original Settings remote-hotkey hint is a claim', () => {
+  const sentence =
+    'Your hotkey opens Cubby inside remote sessions when the remote client\'s keyboard forwarding is off.';
+  const claims = findUnqualifiedRemoteHotkeyClaims(sentence);
+  assert.equal(claims.length, 1);
+  assert.match(claims[0], /hotkey opens Cubby/);
+});
+
+test('the original support FAQ trigger sentence is a claim', () => {
+  const sentence =
+    'A remote-session trigger is also available for workflows where the remote client intercepts Windows shortcuts.';
+  const claims = findUnqualifiedRemoteHotkeyClaims(sentence);
+  assert.equal(claims.length, 1);
+  assert.match(claims[0], /remote-session trigger/);
+});
+
+test('a restated remote-hotkey claim without replacement is reported', () => {
+  assert.equal(
+    findUnqualifiedRemoteHotkeyClaims(
+      'Your configured hotkey can open Cubby inside a remote session if keyboard forwarding is off.'
+    ).length,
+    1
+  );
+});
+
+test('naming Win+V replacement qualifies the remote-hotkey sentence', () => {
+  for (const sentence of [
+    'When Replace Windows clipboard shortcut is on, your hotkey opens Cubby inside remote sessions if keyboard forwarding is off.',
+    'Win+V replacement also lets your hotkey open Cubby inside remote sessions.',
+    'The helper hook opens Cubby in a remote session when forwarding is off.',
+    'The trigger is available in a remote session only while replacement mode is enabled.',
+  ]) {
+    assert.deepEqual(findUnqualifiedRemoteHotkeyClaims(sentence), [], sentence);
+  }
+});
+
+test('remote paste and tray fallback copy are not remote-hotkey claims', () => {
+  for (const sentence of [
+    'With forwarding on, open Cubby from the tray icon.',
+    'RDP and third-party remote tools decide whether Windows shortcuts stay local.',
+    'Cubby includes a remote-session workflow for this reason.',
+    'Cubby is designed to use Win+V as its primary shortcut.',
+  ]) {
+    assert.deepEqual(findUnqualifiedRemoteHotkeyClaims(sentence), [], sentence);
+  }
+});
+
+test('live Settings and support copy name the Win+V replacement dependency', async () => {
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  for (const relative of [
+    'frontend/src/i18n/locales/en.json',
+    'product_pages/support.html',
+  ]) {
+    const source = await readFile(path.join(root, relative), 'utf8');
+    assert.deepEqual(findUnqualifiedRemoteHotkeyClaims(source), [], relative);
+  }
 });

--- a/scripts/product-page-claims.test.mjs
+++ b/scripts/product-page-claims.test.mjs
@@ -364,6 +364,25 @@ test('a restated remote-hotkey claim without replacement is reported', () => {
   );
 });
 
+test('a negated remote-hotkey sentence is not a claim', () => {
+  for (const sentence of [
+    'The configured hotkey does not open Cubby in remote sessions.',
+    'A remote-session trigger is not available when keyboard forwarding is off.',
+    'Your hotkey never opens Cubby inside a remote session.',
+  ]) {
+    assert.deepEqual(findUnqualifiedRemoteHotkeyClaims(sentence), [], sentence);
+  }
+});
+
+test('a later negation does not hide an earlier remote-hotkey claim', () => {
+  assert.equal(
+    findUnqualifiedRemoteHotkeyClaims(
+      'Your hotkey opens Cubby inside remote sessions, not from the tray.'
+    ).length,
+    1
+  );
+});
+
 test('naming Win+V replacement qualifies the remote-hotkey sentence', () => {
   for (const sentence of [
     'When Replace Windows clipboard shortcut is on, your hotkey opens Cubby inside remote sessions if keyboard forwarding is off.',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The remote-session hotkey path lives in the Win+V helper hook (`REMOTE_SESSIONS.md`, `SHORTCUT_BEHAVIOR.md`). Settings `remoteHotkeyHint` and the support FAQ said the configured hotkey opens Cubby in remote sessions whenever keyboard forwarding is off. That stayed on screen after **Replace Windows clipboard shortcut** was disabled.

- Show `settings.remoteHotkeyHint` only while `replace_win_v` is on.
- Name the replacement dependency in the remaining Settings and support copy.
- Reject the old unqualified claim in `scripts/product-page-claims.mjs` and `release:check`, and require the Settings render to stay gated on `replace_win_v`.

Fixes SBS-1049.

## Verification

- [x] I kept this pull request focused.
- [ ] I tested the change on Windows 11.
- [x] I added or updated tests where practical.
- [x] I updated documentation for changed behavior.
- [x] I did not include clipboard contents, credentials, signing material, or other secrets.

Local checks:

- `pnpm run format:check`
- `pnpm run test` (168 frontend tests)
- `node --test scripts/product-page-claims.test.mjs scripts/release-check-helpers.test.mjs`
- `pnpm run release:check`
- `node .github/scripts/check-site.mjs`

The original Settings hint and support FAQ sentences fail the new detector; the updated copy and live files pass. Windows 11 UI was not exercised in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb4a3872-a282-4496-bcd5-31b42c177bc3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb4a3872-a282-4496-bcd5-31b42c177bc3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide remote hotkey hint in `SettingsPanel` unless `replace_win_v` is enabled
> - Wraps the remote-hotkey hint paragraph in `SettingsPanel` with a conditional so it only renders when `settings.replace_win_v` is true
> - Updates the support FAQ and `en.json` to qualify that the configured hotkey opens Cubby in remote sessions only when Replace Windows clipboard shortcut is on; otherwise users should open from the tray icon
> - Adds `findUnqualifiedRemoteHotkeyClaims` scanner in `scripts/product-page-claims.mjs` and wires it into `scripts/check-release.mjs` so the release check fails if docs or `SettingsPanel` make unqualified remote-hotkey claims
> - Risk: the new regex-based assertion in `scripts/check-release.mjs` will fail the build if future edits to `SettingsPanel.tsx` render `settings.remoteHotkeyHint` outside a `replace_win_v` guard; the assertion is pattern-matched, not AST-based
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdf0163.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->