### PR TITLE
SBS-1042: Stop emitting decrypted clip bodies on dead clipboard-write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 
 ## Unreleased
 
+### Security
+- Paste and copy no longer emit the full decrypted clip body to the WebView on a `clipboard-write` event that has no frontend listener (SBS-1042)
+
 ### Fixed
 - CI now publishes a stable `shipped-windows` check that fails when any SBS-779 `Check <arch> <features>` cargo-check fails. Branch protection on main still requires only `test` until a repo admin adds that name; the docs no longer claim the matrix legs already block merge (SBS-1025)
 

--- a/src-tauri/src/clipboard_write_ipc.rs
+++ b/src-tauri/src/clipboard_write_ipc.rs
@@ -1,0 +1,136 @@
+//! Native clipboard-write IPC policy (SBS-1042).
+//!
+//! Paste, copy, recognized-text restore, and image-selection copy write the
+//! OS clipboard from the native process. They used to also
+//! `emit("clipboard-write", decrypted_body)`. The frontend has no listener
+//! for that event, so the payload sat in WebView memory for a dead event.
+//!
+//! Restore/copy must not emit it, and must not decrypt solely to produce a
+//! payload for it. Isolated so `cargo test` can pin the call sites without a
+//! Tauri window. `rustc --test src-tauri/src/clipboard_write_ipc.rs` runs
+//! these tests on Linux.
+
+/// Event that used to carry the full decrypted clip after paste/copy.
+/// The frontend has no listener. Do not emit it.
+const DEAD_CLIPBOARD_WRITE_EVENT: &str = "clipboard-write";
+
+#[cfg(test)]
+mod tests {
+    use super::DEAD_CLIPBOARD_WRITE_EVENT;
+
+    fn rust_fn_body<'a>(src: &'a str, needle: &str) -> &'a str {
+        let start = src
+            .find(needle)
+            .unwrap_or_else(|| panic!("{needle} should exist"));
+        let rest = &src[start..];
+        let brace = rest.find('{').expect("function should have a body");
+        let body_start = start + brace;
+        let bytes = src.as_bytes();
+        let mut depth = 0usize;
+        for (offset, &byte) in bytes[body_start..].iter().enumerate() {
+            match byte {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &src[body_start..=body_start + offset];
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("{needle} body was unbalanced");
+    }
+
+    /// `.emit("clipboard-write"` including a line-broken argument list.
+    fn emits_clipboard_write(src: &str) -> bool {
+        let mut rest = src;
+        while let Some(idx) = rest.find(".emit(") {
+            let after = rest[idx + ".emit(".len()..].trim_start();
+            if after.starts_with(&format!("\"{DEAD_CLIPBOARD_WRITE_EVENT}\"")) {
+                return true;
+            }
+            rest = &rest[idx + ".emit(".len()..];
+        }
+        false
+    }
+
+    /// The three sites named in SBS-1042. A file-wide scan still runs below
+    /// so a fourth copy of the same dead event cannot hide next to them.
+    #[test]
+    fn restore_and_copy_sites_do_not_emit_clipboard_write() {
+        let src = include_str!("commands.rs");
+        let mut leaked = Vec::new();
+        for needle in [
+            "async fn restore_clip(",
+            "async fn restore_recognized_text(",
+            "pub async fn copy_selected_text(",
+        ] {
+            let body = rust_fn_body(src, needle);
+            if emits_clipboard_write(body) {
+                leaked.push(needle);
+            }
+        }
+        assert!(
+            leaked.is_empty(),
+            "fail-without-fix: {} emit clipboard-write with a decrypted body (SBS-1042)",
+            leaked.join(", ")
+        );
+
+        // restore_clip used to build `String::from_utf8_lossy(&clip.content)`
+        // solely for that emit. The clipboard write itself goes through
+        // `clipboard_contents_for_restore`; this body must not materialize
+        // the plaintext a second time for the WebView.
+        let restore_clip = rust_fn_body(src, "async fn restore_clip(");
+        assert!(
+            !restore_clip.contains("from_utf8_lossy(&clip.content)"),
+            "fail-without-fix: restore_clip still materializes the decrypted body for the WebView"
+        );
+    }
+
+    #[test]
+    fn native_sources_do_not_emit_clipboard_write() {
+        // Sweep every native emit site, not just the three named in the ticket.
+        // clipboard-change is the live event and is allowed; clipboard-write is not.
+        let sources = [
+            ("commands.rs", include_str!("commands.rs")),
+            ("clipboard.rs", include_str!("clipboard.rs")),
+            ("lib.rs", include_str!("lib.rs")),
+            ("settings_commands.rs", include_str!("settings_commands.rs")),
+            ("ocr_queue.rs", include_str!("ocr_queue.rs")),
+        ];
+        for (name, src) in sources {
+            assert!(
+                !emits_clipboard_write(src),
+                "fail-without-fix: {name} emits clipboard-write (SBS-1042)"
+            );
+        }
+    }
+
+    #[test]
+    fn frontend_has_no_clipboard_write_listener() {
+        // The event is dead. A new listener that expected the decrypted body
+        // would be a reason to reintroduce the emit; fail here instead.
+        let sources = [
+            ("App.tsx", include_str!("../../frontend/src/App.tsx")),
+            (
+                "HistoryWindow.tsx",
+                include_str!("../../frontend/src/windows/HistoryWindow.tsx"),
+            ),
+            (
+                "ImageWindow.tsx",
+                include_str!("../../frontend/src/windows/ImageWindow.tsx"),
+            ),
+            (
+                "SettingsPanel.tsx",
+                include_str!("../../frontend/src/components/SettingsPanel.tsx"),
+            ),
+        ];
+        for (name, src) in sources {
+            assert!(
+                !src.contains(DEAD_CLIPBOARD_WRITE_EVENT),
+                "fail-without-fix: {name} mentions clipboard-write; restore/copy do not emit it (SBS-1042)"
+            );
+        }
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1321,12 +1321,8 @@ async fn restore_clip(
                     .state::<Arc<crate::settings_manager::SettingsManager>>()
                     .get()
                     .remote_paste_mode;
-                let content = if clip.clip_type == "image" {
-                    "[Image]".to_string()
-                } else {
-                    String::from_utf8_lossy(&clip.content).to_string()
-                };
-                let _ = window.emit("clipboard-write", &content);
+                // Do not emit the decrypted body to the WebView. A former
+                // `clipboard-write` event had no frontend listener (SBS-1042).
 
                 if should_paste {
                     crate::animate_window_hide(
@@ -1399,8 +1395,8 @@ async fn restore_recognized_text(
     hash_material.extend_from_slice(text.as_bytes());
     let content_hash = crate::clipboard::calculate_hash(&hash_material);
     crate::clipboard::set_ignore_hash(content_hash.clone());
-    if let Err(error) = ClipboardContext::new()
-        .and_then(|context| context.set(vec![ClipboardContent::Text(text.clone())]))
+    if let Err(error) =
+        ClipboardContext::new().and_then(|context| context.set(vec![ClipboardContent::Text(text)]))
     {
         crate::clipboard::clear_ignore_hash_if_matches(&content_hash);
         return Err(format!("Failed to copy recognized text: {error}"));
@@ -1410,7 +1406,8 @@ async fn restore_recognized_text(
         .bind(id)
         .execute(&db.pool)
         .await;
-    let _ = window.emit("clipboard-write", &text);
+    // Recognized text is already on the OS clipboard. Do not also emit it
+    // to the WebView; there is no `clipboard-write` listener (SBS-1042).
 
     if should_paste {
         let remote_paste_mode = window
@@ -2995,7 +2992,7 @@ pub async fn get_source_apps(
 /// same ignore-hash discipline as the other copy paths so Cubby's own capture
 /// loop doesn't treat the write as a fresh copy and duplicate it.
 #[tauri::command]
-pub async fn copy_selected_text(text: String, window: tauri::WebviewWindow) -> Result<(), String> {
+pub async fn copy_selected_text(text: String) -> Result<(), String> {
     if text.is_empty() {
         return Err("Nothing selected".to_string());
     }
@@ -3005,14 +3002,15 @@ pub async fn copy_selected_text(text: String, window: tauri::WebviewWindow) -> R
     hash_material.extend_from_slice(text.as_bytes());
     let content_hash = crate::clipboard::calculate_hash(&hash_material);
     crate::clipboard::set_ignore_hash(content_hash.clone());
-    if let Err(error) = ClipboardContext::new()
-        .and_then(|context| context.set(vec![ClipboardContent::Text(text.clone())]))
+    if let Err(error) =
+        ClipboardContext::new().and_then(|context| context.set(vec![ClipboardContent::Text(text)]))
     {
         crate::clipboard::clear_ignore_hash_if_matches(&content_hash);
         return Err(format!("Failed to copy the selection: {error}"));
     }
 
-    let _ = window.emit("clipboard-write", &text);
+    // The selection is already in the renderer (the user highlighted it).
+    // Do not emit it back on `clipboard-write`; there is no listener (SBS-1042).
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,11 @@ mod clip_list;
 mod clipboard;
 mod clipboard_miss;
 mod clipboard_policy;
+// SBS-1042: restore/copy must not emit decrypted bodies to the WebView.
+// Compiled for tests so the source pin runs on every `cargo test`; a release
+// build does not include it.
+#[cfg(test)]
+mod clipboard_write_ipc;
 mod commands;
 // SBS-408 compatibility-matrix model. Compiled under `test` as well as
 // `dev-harness` on purpose: CI runs `cargo test --all-targets` without the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Paste, copy, recognized-text restore, and image-selection copy wrote the OS clipboard from the native process, then also `emit("clipboard-write", decrypted_body)` into the WebView.

The frontend has no `clipboard-write` listener (`clipboard-change` is the live event). That left the full plaintext sitting in renderer memory for a dead event.

Sites named in [SBS-1042](https://linear.app/southboundsoftware/issue/SBS-1042):

- `restore_clip` — built `String::from_utf8_lossy(&clip.content)` solely for the emit
- `restore_recognized_text` — emitted the OCR text already written to the clipboard
- `copy_selected_text` — echoed the renderer-supplied selection back over IPC

## What this PR does

- Removes the three `clipboard-write` emits. Restore/copy still write the OS clipboard and still hide the flyout / synthesize paste. They no longer ship the decrypted body to the WebView, and `restore_clip` no longer materializes `clip.content` a second time just to emit it.
- Drops the unused `window` argument from `copy_selected_text` (the frontend already called `invoke('copy_selected_text', { text })`).
- Adds `src-tauri/src/clipboard_write_ipc.rs`, compiled only under `#[cfg(test)]`, so `cargo test` is a real merge gate. The tests fail without the fix (proven on this branch before the emit removals) and sweep the same pattern:

  - the three named functions
  - every other native emit site (`commands.rs`, `clipboard.rs`, `lib.rs`, `settings_commands.rs`, `ocr_queue.rs`)
  - frontend listeners (`App.tsx`, History, Image, Settings)

`clipboard-change` is unchanged. It is the event the flyout and History actually listen for, and capture already sends a preview — not a restore/copy body.

## Fail-without-fix

`rustc --test src-tauri/src/clipboard_write_ipc.rs --edition 2021` against unfixed `commands.rs`:

```
test tests::native_sources_do_not_emit_clipboard_write ... FAILED
  fail-without-fix: commands.rs emits clipboard-write (SBS-1042)
test tests::restore_and_copy_sites_do_not_emit_clipboard_write ... FAILED
  fail-without-fix: async fn restore_clip( emits clipboard-write with a decrypted body (SBS-1042)
```

After the removals, the same three tests pass.

## Verification

- [x] I kept this pull request focused.
- [ ] I tested the change on Windows 11 (Linux agent; Windows CI on this PR).
- [x] I added tests that fail without the fix and sweep the same emit pattern.
- [x] I updated `CHANGELOG.md` (Unreleased / Security).
- [x] I did not include clipboard contents, credentials, signing material, or other secrets.

Local:

- [x] `rustc --test src-tauri/src/clipboard_write_ipc.rs --edition 2021` — 3/3 pass
- [x] `rg 'emit\("clipboard-write"' src-tauri` — no matches

GitHub Actions on this PR ([run 32645674310](https://github.com/tsouth89/cubby-clipboard/actions/runs/32645674310)):

- [x] `test` (required)
- [x] `Check x64 default` / `Check x64 app-store` / `Check arm64 default` / `Check arm64 app-store`
- [x] `shipped-windows`
- [x] CodeQL (actions, javascript-typescript, rust)

`github-advanced-security` (`Code scanning AI findings on PR`) failed with `You are not licensed to use Copilot`. That is GitHub’s dynamic Copilot Autofix workflow, not this repo’s CI, and not a required check. CodeQL itself succeeded.

## References

- [SBS-1042](https://linear.app/southboundsoftware/issue/SBS-1042)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-969c92e0-1ef6-42b1-b8a4-6c680d070628?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-969c92e0-1ef6-42b1-b8a4-6c680d070628&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop emitting decrypted clip bodies on dead `clipboard-write` event
> - Removes `window.emit("clipboard-write", ...)` calls from `restore_clip`, `restore_recognized_text`, and `copy_selected_text` in [commands.rs](https://github.com/tsouth89/cubby-clipboard/pull/284/files#diff-59f7096c7cd88d5d187e749ca400716cd225f951e78eac3d0081ec6c28ce5dcc). The event had no frontend listener, so the decrypted content was emitted to the WebView for no purpose.
> - `restore_clip` no longer materializes a `String::from_utf8_lossy(&clip.content)` solely for the emit; `copy_selected_text` drops its `tauri::WebviewWindow` parameter.
> - Adds a test-only module [clipboard_write_ipc.rs](https://github.com/tsouth89/cubby-clipboard/pull/284/files#diff-c3f79a41aad8c078aecef67feafe81a5a0c9405f6775512228f319ad56a48bb9) that statically scans Rust and TSX sources to guard against re-introducing the dead event or a listener for it.
> - **Risk:** `copy_selected_text` signature changed (removed `WebviewWindow` param); any call sites not updated in this PR will fail to compile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d233f54.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->