### PR TITLE
SBS-1051: Recover dest-gone rolling backup replace on FAT/exFAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 ## Unreleased
 
 ### Fixed
+- Recover a dest-gone rolling `cubby.db.bak` replace on FAT/exFAT instead of deleting the only remaining copy (SBS-1051)
 - CI now publishes a stable `shipped-windows` check that fails when any SBS-779 `Check <arch> <features>` cargo-check fails. Branch protection on main still requires only `test` until a repo admin adds that name; the docs no longer claim the matrix legs already block merge (SBS-1025)
 
 ## v1.3.3

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -967,9 +967,29 @@ async fn perform_rolling_backup_refresh_with(
     let temporary_for_rename = temporary.clone();
     let backup_for_rename = backup.clone();
     let installed = tokio::task::spawn_blocking(move || {
-        install(&temporary_for_rename, &backup_for_rename).inspect_err(|_| {
-            let _ = std::fs::remove_file(&temporary_for_rename);
-        })
+        if let Err(error) = install(&temporary_for_rename, &backup_for_rename) {
+            // On exFAT/FAT, replace is delete-then-rename. A failure after dest
+            // is gone leaves the temp as the only remaining recovery copy, so
+            // deleting it would wipe both (SBS-1051). Same dest-gone fallback
+            // as settings.json, `.cubbybak` persist, and image `{uuid}.cubby`.
+            if crate::settings_load::recover_or_discard_replace_temp(
+                &temporary_for_rename,
+                &backup_for_rename,
+            ) {
+                log::warn!(
+                    "STORAGE: replacing rolling backup failed ({error}); the new copy was renamed into place instead"
+                );
+                return Ok(());
+            }
+            if !backup_for_rename.is_file() {
+                log::error!(
+                    "STORAGE: replacing rolling backup failed ({error}) and the destination is not a file; leaving {}",
+                    temporary_for_rename.display()
+                );
+            }
+            return Err(error);
+        }
+        Ok(())
     })
     .await;
     match installed {
@@ -1665,10 +1685,11 @@ mod tests {
     use super::{
         apply_database_health, backup_is_fresh_as_of, classify_sqlite_health_failure,
         copy_backup_snapshot, count_clips_in_file, join_distinct_notes,
-        perform_rolling_backup_refresh, prepare_database_file, quarantine_database_files,
-        replace_backup_atomically, rolling_backup_path, sanitize_storage_diagnostic,
-        should_skip_backup_refresh, sqlite_failure_is_corruption, verify_database_quick_check,
-        ContentHashDedup, Database, DatabaseHealth, RollingBackupScheduler, RollingBackupTick,
+        perform_rolling_backup_refresh, perform_rolling_backup_refresh_with, prepare_database_file,
+        quarantine_database_files, replace_backup_atomically, rolling_backup_path,
+        sanitize_storage_diagnostic, should_skip_backup_refresh, sqlite_failure_is_corruption,
+        verify_database_quick_check, BackupRefreshOutcome, ContentHashDedup, Database,
+        DatabaseHealth, RollingBackupScheduler, RollingBackupTick,
     };
     use crate::crypto::CryptoManager;
     use sqlx::sqlite::SqlitePoolOptions;
@@ -2940,6 +2961,22 @@ mod tests {
         Err(std::io::Error::other("simulated install failure"))
     }
 
+    /// FAT/exFAT `MoveFileExW(REPLACE_EXISTING)` is delete-then-rename. This
+    /// stand-in deletes dest and then fails, leaving the temp as the only copy.
+    fn simulate_fat_dest_gone_backup_replace(
+        source: &std::path::Path,
+        dest: &std::path::Path,
+    ) -> Result<(), std::io::Error> {
+        let _ = std::fs::remove_file(dest);
+        assert!(
+            source.exists(),
+            "the staged backup temp must still be the only remaining copy"
+        );
+        Err(std::io::Error::other(
+            "simulated FAT dest-gone replace failure",
+        ))
+    }
+
     fn modified_time(path: &std::path::Path) -> SystemTime {
         std::fs::metadata(path).unwrap().modified().unwrap()
     }
@@ -3254,6 +3291,54 @@ mod tests {
         assert!(
             after_modified > before_modified,
             "backup mtime must move when the in-session refresh installs a new copy"
+        );
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    /// SBS-1051: FAT dest-gone mid-replace leaves the temp as the only copy.
+    /// `inspect_err` used to delete that temp, wiping the recovery copy.
+    /// Recovering it into place is success.
+    #[tokio::test]
+    async fn dest_gone_mid_replace_recovers_the_rolling_backup() {
+        let directory = temp_dir();
+        let database_path = directory.join("cubby.db");
+        write_history_marker(&database_path, "known-good").await;
+        perform_rolling_backup_refresh(&database_path)
+            .await
+            .expect("seed backup should write");
+
+        let backup = rolling_backup_path(&database_path);
+        write_history_marker(&database_path, "newer").await;
+
+        let outcome = perform_rolling_backup_refresh_with(
+            &database_path,
+            simulate_fat_dest_gone_backup_replace,
+        )
+        .await;
+
+        assert_eq!(
+            outcome,
+            Ok(BackupRefreshOutcome::Installed),
+            "dest-gone must recover the staged backup, not fail the install: {outcome:?}"
+        );
+        assert!(
+            backup.exists(),
+            "the rolling bak must exist after dest-gone recovery"
+        );
+        assert_eq!(
+            read_history_marker(&backup).await,
+            "newer",
+            "the recovered bak must hold the new snapshot, not be wiped"
+        );
+        let leftover_temps: Vec<_> = std::fs::read_dir(&directory)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains(".tmp"))
+            .collect();
+        assert!(
+            leftover_temps.is_empty(),
+            "recovery consumes the temp so cleanup has nothing to delete: {leftover_temps:?}"
         );
         let _ = std::fs::remove_dir_all(directory);
     }

--- a/src-tauri/src/settings_load.rs
+++ b/src-tauri/src/settings_load.rs
@@ -7,9 +7,9 @@
 //! the leftover temp.
 //!
 //! `recover_dest_gone_replace` is the shared dest-gone fallback: settings save,
-//! backup persist, and image `{uuid}.cubby` replace (SBS-1030) all call it
-//! after a failed replace so Drop/cleanup cannot delete the only remaining
-//! copy.
+//! backup persist, image `{uuid}.cubby` replace (SBS-1030), and rolling
+//! `cubby.db.bak` install (SBS-1051) all call it after a failed replace so
+//! Drop/cleanup cannot delete the only remaining copy.
 //!
 //! This file has no crate dependencies so `rustc --test` can pin the contract
 //! on a Linux box that cannot compile the Windows crate.
@@ -62,6 +62,23 @@ pub fn promote_interrupted_tmp(canonical: &Path) -> Result<(), String> {
 /// in place instead of deleting the only copy (same idea as `backup.rs`).
 pub fn recover_dest_gone_replace(tmp: &Path, dest: &Path) -> bool {
     !dest.exists() && tmp.exists() && fs::rename(tmp, dest).is_ok()
+}
+
+/// After a failed replace: recover dest-gone, else delete the temp only when
+/// dest still exists. Returns true when the temp was promoted onto dest
+/// (caller should treat the replace as succeeded).
+///
+/// Rolling `cubby.db.bak` install used `inspect_err` to always delete the
+/// temp (SBS-1051). That wipes the only remaining recovery copy after a FAT
+/// dest-gone mid-replace.
+pub fn recover_or_discard_replace_temp(tmp: &Path, dest: &Path) -> bool {
+    if recover_dest_gone_replace(tmp, dest) {
+        return true;
+    }
+    if dest.is_file() {
+        let _ = fs::remove_file(tmp);
+    }
+    false
 }
 
 #[cfg(test)]
@@ -165,6 +182,46 @@ mod tests {
         assert!(tmp.exists());
         let on_disk = parse_auto_delete_days(&fs::read_to_string(&dest).unwrap()).unwrap();
         assert_eq!(on_disk, 365);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// SBS-1051: rolling backup install used to `inspect_err`-delete the temp
+    /// after a dest-gone replace. Recover first; cleanup then finds no temp.
+    #[test]
+    fn rolling_backup_dest_gone_recovers_instead_of_deleting_the_only_copy() {
+        let dir = test_dir();
+        let dest = dir.join("cubby.db.bak");
+        let tmp = dir.join("cubby.db.bak.1.uuid.tmp");
+        fs::write(&tmp, b"new-rolling-backup").unwrap();
+        assert!(!dest.exists());
+
+        let recovered = recover_or_discard_replace_temp(&tmp, &dest);
+        if !recovered && tmp.exists() {
+            // Old inspect_err after a failed replace_backup_atomically.
+            let _ = fs::remove_file(&tmp);
+        }
+
+        assert!(recovered, "dest-gone must put the staged backup in place");
+        assert!(dest.exists(), "the rolling bak path must exist again");
+        assert!(!tmp.exists(), "recovery consumes the temp");
+        assert_eq!(fs::read(&dest).unwrap(), b"new-rolling-backup");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn failed_replace_that_left_dest_discards_the_temp() {
+        let dir = test_dir();
+        let dest = dir.join("cubby.db.bak");
+        let tmp = dir.join("cubby.db.bak.1.uuid.tmp");
+        fs::write(&dest, b"old-rolling-backup").unwrap();
+        fs::write(&tmp, b"new-rolling-backup").unwrap();
+
+        assert!(!recover_or_discard_replace_temp(&tmp, &dest));
+        assert_eq!(fs::read(&dest).unwrap(), b"old-rolling-backup");
+        assert!(
+            !tmp.exists(),
+            "a dest that survived must still drop the temp"
+        );
         let _ = fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

On FAT/exFAT, `MoveFileExW(REPLACE_EXISTING)` is delete-then-rename. Rolling `cubby.db.bak` install wrote a sibling temp, then `replace_backup_atomically`. When that replace failed after dest was already gone, `inspect_err` deleted the leftover temp — both copies gone. Settings save (SBS-935), backup persist, and image `{uuid}.cubby` replace (SBS-1030 / PR #279) already recover that dest-gone state. PR #279 documented this rolling-backup gap and left it.

`perform_rolling_backup_refresh_with` now uses the same dest-gone fallback (`recover_or_discard_replace_temp` → `recover_dest_gone_replace`). If dest is gone, the staged temp is renamed onto `cubby.db.bak` and the refresh is treated as installed. If dest survived, the temp is still discarded. If dest is gone and the recovery rename also fails, the temp is left on disk instead of being deleted.

## Verification

- [x] I kept this pull request focused.
- [ ] I tested the change on Windows 11.
- [x] I added or updated tests where practical.
- [x] I updated documentation for changed behavior.
- [x] I did not include clipboard contents, credentials, signing material, or other secrets.

Tests that fail without the fix:

- `rolling_backup_dest_gone_recovers_instead_of_deleting_the_only_copy` in `settings_load.rs` (`rustc --test`). Against the old `inspect_err` cleanup this asserts `dest-gone must put the staged backup in place`.
- `dest_gone_mid_replace_recovers_the_rolling_backup` — injected FAT dest-gone installer through `perform_rolling_backup_refresh_with`; without recovery, install errors and `inspect_err` deletes the only remaining `cubby.db.bak`.
- `failed_replace_that_left_dest_discards_the_temp` — dest still present still drops the temp.

`rustc --test src-tauri/src/settings_load.rs` was run here (Linux cannot compile the Windows crate). Windows CI (`cargo test`) covers the `database.rs` path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6a8429e-e7d7-48d1-b937-3d8a8cf2c40d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6a8429e-e7d7-48d1-b937-3d8a8cf2c40d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix rolling backup replace on FAT/exFAT to recover dest-gone temp instead of deleting it
> - On FAT/exFAT, a failed `install` during rolling backup replace leaves the destination deleted and the staged temp as the only copy. Previously the code discarded that temp and failed.
> - Adds `recover_or_discard_replace_temp` in [settings_load.rs](https://github.com/tsouth89/cubby-clipboard/pull/285/files#diff-208a2c2fe40666cd2616f2700d4f952813643d5e5214c181ce7c842173b320d8), which promotes the temp into place when the destination is gone, or discards the temp only when the destination survived.
> - Updates `perform_rolling_backup_refresh_with` in [database.rs](https://github.com/tsouth89/cubby-clipboard/pull/285/files#diff-6a8f2d03587850d3f942776b1cf06ca106b6ce46ca2e5eb3bd008d7b728c327f) to call this helper on install errors, returning `Ok(())` when recovery succeeds and preserving the temp when the destination is missing.
> - Risk: callers that relied on a failed replace leaving no backup behind now see the temp promoted as the backup; the in-tree caller in `database.rs` is updated, but any out-of-tree consumers of `recover_or_discard_replace_temp` must handle the new recovery semantics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3a6535.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->