### PR TITLE
SBS-1039: Release ignore-hash when a queued self-paste echo is flood-dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 ## Unreleased
 
 ### Fixed
+- Flood-dropping a queued self-paste echo no longer leaves the ignore hash swallowing the next real copy of that content (SBS-1039)
 - CI now publishes a stable `shipped-windows` check that fails when any SBS-779 `Check <arch> <features>` cargo-check fails. Branch protection on main still requires only `test` until a repo admin adds that name; the docs no longer claim the matrix legs already block merge (SBS-1025)
 
 ## v1.3.3

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -382,13 +382,12 @@ fn enqueue_listener_event(
     event_tx: &snapshot_channel::Sender<ClipboardListenerEvent>,
     event: ClipboardListenerEvent,
 ) -> Result<(), ()> {
-    match event_tx.send(event) {
+    match event_tx.send(event, release_ignore_for_dropped_events) {
         Ok(snapshot_queue::EnqueueOutcome::QueuedAfterDrop {
             dropped,
             dropped_bytes,
-            evicted,
+            ..
         }) => {
-            release_ignore_for_dropped_events(&evicted);
             log::warn!(
                 "CLIPBOARD: Snapshot queue evicted {dropped} older pending capture(s) ({dropped_bytes} bytes) under flood (SBS-1032)"
             );

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -421,17 +421,11 @@ fn captured_clip_hash(content: &CapturedContent, formats: &[CapturedFormat]) -> 
 /// after persist, so a dropped snapshot never stamped consecutive-dedup and
 /// [`reset_capture_dedup`] is the history-delete path, not this one.
 fn release_ignore_for_dropped_events(evicted: &[ClipboardListenerEvent]) {
-    let now = Instant::now();
     let mut lock = IGNORE_HASH.lock();
     for event in evicted {
         if let ClipboardListenerEvent::Content(snapshot) = event {
             let clip_hash = captured_clip_hash(&snapshot.content, &snapshot.formats);
-            if lock.release_dropped_queued_work(
-                snapshot.ignore.as_ref(),
-                clip_hash.as_str(),
-                now,
-                IGNORE_HASH_TTL,
-            ) {
+            if lock.release_dropped_queued_work(snapshot.ignore.as_ref(), clip_hash.as_str()) {
                 log::info!(
                     "CLIPBOARD: Released self-paste ignore after snapshot was dropped under flood (SBS-1039)"
                 );

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -386,7 +386,9 @@ fn enqueue_listener_event(
         Ok(snapshot_queue::EnqueueOutcome::QueuedAfterDrop {
             dropped,
             dropped_bytes,
+            evicted,
         }) => {
+            release_ignore_for_dropped_events(&evicted);
             log::warn!(
                 "CLIPBOARD: Snapshot queue evicted {dropped} older pending capture(s) ({dropped_bytes} bytes) under flood (SBS-1032)"
             );
@@ -394,6 +396,48 @@ fn enqueue_listener_event(
         }
         Ok(snapshot_queue::EnqueueOutcome::Queued) => Ok(()),
         Err(()) => Err(()),
+    }
+}
+
+/// Identity used for self-paste ignore. Must match process-time `clip_hash`
+/// so a flood-dropped echo consumes the same generation the paste path set.
+fn captured_clip_hash(content: &CapturedContent, formats: &[CapturedFormat]) -> String {
+    let (clip_type, primary) = match content {
+        CapturedContent::Text { content, .. } => ("text", content.as_slice()),
+        CapturedContent::Image { png_bytes, .. } => ("image", png_bytes.as_slice()),
+    };
+    calculate_hash(&build_clip_hash_material(
+        clip_type,
+        primary,
+        formats
+            .iter()
+            .map(|format| (format.name, format.content.as_slice())),
+    ))
+}
+
+/// SBS-1039: a flood-evicted snapshot never reaches
+/// [`process_clipboard_snapshot`]. Consume a matching self-paste binding so
+/// IGNORE_HASH cannot keep suppressing later real copies. Unrelated dropped
+/// work (or a Cleared event) is left alone. LAST_STABLE_HASH is only written
+/// after persist, so a dropped snapshot never stamped consecutive-dedup and
+/// [`reset_capture_dedup`] is the history-delete path, not this one.
+fn release_ignore_for_dropped_events(evicted: &[ClipboardListenerEvent]) {
+    let now = Instant::now();
+    let mut lock = IGNORE_HASH.lock();
+    for event in evicted {
+        if let ClipboardListenerEvent::Content(snapshot) = event {
+            let clip_hash = captured_clip_hash(&snapshot.content, &snapshot.formats);
+            if lock.release_dropped_queued_work(
+                snapshot.ignore.as_ref(),
+                clip_hash.as_str(),
+                now,
+                IGNORE_HASH_TTL,
+            ) {
+                log::info!(
+                    "CLIPBOARD: Released self-paste ignore after snapshot was dropped under flood (SBS-1039)"
+                );
+            }
+        }
     }
 }
 
@@ -840,6 +884,9 @@ fn capture_one_bound_sequence(
 
     if let Some(MaterializeAttempt::Captured(content, formats)) = materialized {
         note_clipboard_event(sequence);
+        // Bind the live marker onto this work item (SBS-1022). If flood
+        // policy later evicts it, enqueue_listener_event must release that
+        // binding (SBS-1039) so IGNORE_HASH cannot keep swallowing copies.
         let ignore = bind_ignore_hash_for_queued_work(
             IGNORE_HASH.lock().marker.as_ref(),
             Instant::now(),
@@ -2040,6 +2087,7 @@ async fn process_clipboard_snapshot(
     let sequence = snapshot.sequence;
     let markers = snapshot.sensitive;
     let queued_ignore = snapshot.ignore;
+    let clip_hash = captured_clip_hash(&snapshot.content, &snapshot.formats);
     let source_app_info = resolve_source_app_info(snapshot.source_app_identity);
     let captured_formats = snapshot.formats;
     let (clip_type, clip_content, clip_preview, _primary_hash, full_image_content, metadata) =
@@ -2105,7 +2153,11 @@ async fn process_clipboard_snapshot(
             .iter()
             .map(|format| (format.name, format.content.as_slice())),
     );
-    let clip_hash = calculate_hash(&hash_material);
+    debug_assert_eq!(
+        clip_hash,
+        calculate_hash(&hash_material),
+        "captured_clip_hash must match process-time clip identity"
+    );
 
     // Ignore our own clipboard writes. When a clip is pasted or reused from
     // Cubby, the paste path sets this ignore hash and already performed the
@@ -3428,16 +3480,47 @@ unsafe fn extract_icon(path: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_clip_hash_material, calculate_hash, capture_state_name, capture_text,
-        clear_ignore_hash_if_matches, clipboard_retry_delay, is_remote_client_owner,
+        bind_ignore_hash_for_queued_work, build_clip_hash_material, calculate_hash,
+        capture_state_name, capture_text, captured_clip_hash, clear_ignore_hash_if_matches,
+        clipboard_retry_delay, enqueue_listener_event, is_remote_client_owner,
         is_remote_client_process, likely_secret_decision, next_listener_backoff, relayed_clip_hash,
-        rgba_to_cf_dib, set_ignore_hash, should_forget_recent_capture, should_relay_capture,
-        should_skip_sensitive_capture, CapturedContent, CapturedFormat, ClipboardListenerEvent,
-        ClipboardSnapshot, LikelySecretDecision, SensitiveMarkers, SizedPayload,
-        CAPTURE_STATE_LISTENING, CAPTURE_STATE_RESTARTING, CAPTURE_STATE_STOPPED,
-        CLIPBOARD_CLEAR_FORGET_WINDOW, IGNORE_HASH,
+        release_ignore_for_dropped_events, rgba_to_cf_dib, set_ignore_hash,
+        should_forget_recent_capture, should_relay_capture, should_skip_sensitive_capture,
+        CapturedContent, CapturedFormat, ClipboardListenerEvent, ClipboardSnapshot,
+        LikelySecretDecision, SensitiveMarkers, SizedPayload, CAPTURE_STATE_LISTENING,
+        CAPTURE_STATE_RESTARTING, CAPTURE_STATE_STOPPED, CLIPBOARD_CLEAR_FORGET_WINDOW,
+        IGNORE_HASH, IGNORE_HASH_TTL,
     };
+    use super::{ignore_hash, snapshot_channel, snapshot_queue};
     use std::time::{Duration, Instant};
+
+    fn text_snapshot(
+        sequence: u32,
+        text: &[u8],
+        ignore: Option<ignore_hash::QueuedIgnore>,
+    ) -> ClipboardSnapshot {
+        ClipboardSnapshot {
+            sequence,
+            source_app_identity: None,
+            content: CapturedContent::Text {
+                content: text.to_vec(),
+                preview: String::from_utf8_lossy(text).into_owned(),
+                hash: "unused".into(),
+            },
+            formats: Vec::new(),
+            materialize_ms: 0,
+            sensitive: SensitiveMarkers::default(),
+            ignore,
+        }
+    }
+
+    fn text_event(
+        sequence: u32,
+        text: &[u8],
+        ignore: Option<ignore_hash::QueuedIgnore>,
+    ) -> ClipboardListenerEvent {
+        ClipboardListenerEvent::Content(text_snapshot(sequence, text, ignore))
+    }
 
     /// SBS-1032: the queue's RAM budget must count the PNG/HTML/RTF bytes
     /// that used to sit on the unbounded channel, not just a slot count.
@@ -3473,6 +3556,181 @@ mod tests {
             ClipboardListenerEvent::Cleared { sequence: 2 }.payload_bytes(),
             0
         );
+    }
+
+    #[test]
+    fn captured_clip_hash_matches_process_time_identity() {
+        let text = CapturedContent::Text {
+            content: b"hello".to_vec(),
+            preview: "hello".into(),
+            hash: "unused".into(),
+        };
+        let formats = [CapturedFormat {
+            name: "html",
+            content: b"<p>hello</p>".to_vec(),
+        }];
+        assert_eq!(
+            captured_clip_hash(&text, &formats),
+            calculate_hash(&build_clip_hash_material(
+                "text",
+                b"hello",
+                [("html", b"<p>hello</p>".as_slice())],
+            ))
+        );
+
+        let png = vec![0_u8; 16];
+        let image = CapturedContent::Image {
+            png_bytes: png.clone(),
+            width: 2,
+            height: 2,
+            hash: "unused".into(),
+            decode_ms: 0,
+            source_type: "png",
+        };
+        assert_eq!(
+            captured_clip_hash(&image, &formats),
+            calculate_hash(&build_clip_hash_material("image", &png, std::iter::empty()))
+        );
+    }
+
+    /// SBS-1039: flood-drop a bound self-paste echo. Without
+    /// [`release_ignore_for_dropped_events`], IGNORE_HASH stays live and the
+    /// next real copy of the same content is swallowed.
+    #[test]
+    fn dropping_a_bound_echo_releases_ignore_hash_so_the_next_real_copy_is_captured() {
+        *IGNORE_HASH.lock() = ignore_hash::IgnoreState::default();
+        let clip_hash = captured_clip_hash(
+            &CapturedContent::Text {
+                content: b"echo".to_vec(),
+                preview: "echo".into(),
+                hash: "unused".into(),
+            },
+            &[],
+        );
+        set_ignore_hash(clip_hash.clone());
+        let ignore = bind_ignore_hash_for_queued_work(
+            IGNORE_HASH.lock().marker.as_ref(),
+            Instant::now(),
+            IGNORE_HASH_TTL,
+        );
+        assert!(ignore.is_some());
+
+        release_ignore_for_dropped_events(&[text_event(1, b"echo", ignore)]);
+
+        assert!(
+            IGNORE_HASH.lock().marker.is_none(),
+            "fail-without-fix: dropped echo left the live IGNORE_HASH marker"
+        );
+        let recopy = bind_ignore_hash_for_queued_work(
+            IGNORE_HASH.lock().marker.as_ref(),
+            Instant::now(),
+            IGNORE_HASH_TTL,
+        );
+        assert!(
+            !IGNORE_HASH.lock().ignore_and_consume_self_paste(
+                recopy.as_ref(),
+                clip_hash.as_str(),
+                Instant::now(),
+                IGNORE_HASH_TTL,
+            ),
+            "fail-without-fix: dropped echo left IGNORE_HASH swallowing the next real copy"
+        );
+        *IGNORE_HASH.lock() = ignore_hash::IgnoreState::default();
+    }
+
+    #[test]
+    fn dropping_unrelated_or_cleared_events_does_not_release_ignore_hash() {
+        *IGNORE_HASH.lock() = ignore_hash::IgnoreState::default();
+        let echo_hash = captured_clip_hash(
+            &CapturedContent::Text {
+                content: b"echo".to_vec(),
+                preview: "echo".into(),
+                hash: "unused".into(),
+            },
+            &[],
+        );
+        set_ignore_hash(echo_hash.clone());
+        let generation = IGNORE_HASH
+            .lock()
+            .marker
+            .as_ref()
+            .expect("just set")
+            .generation;
+        let passenger = bind_ignore_hash_for_queued_work(
+            IGNORE_HASH.lock().marker.as_ref(),
+            Instant::now(),
+            IGNORE_HASH_TTL,
+        );
+
+        release_ignore_for_dropped_events(&[
+            text_event(1, b"other", passenger),
+            ClipboardListenerEvent::Cleared { sequence: 2 },
+        ]);
+
+        assert_eq!(
+            IGNORE_HASH
+                .lock()
+                .marker
+                .as_ref()
+                .map(|marked| marked.generation),
+            Some(generation),
+            "fail-without-fix: dropping B or a clear spent A's ignore"
+        );
+        assert_eq!(IGNORE_HASH.lock().consumed_generation, None);
+        *IGNORE_HASH.lock() = ignore_hash::IgnoreState::default();
+    }
+
+    /// Whole path: bind at enqueue, flood-evict via the production channel,
+    /// consume on drop, then a later real copy of the same content is not
+    /// ignored (SBS-1039).
+    #[test]
+    fn enqueue_listener_event_releases_ignore_hash_when_a_bound_echo_is_flood_dropped() {
+        *IGNORE_HASH.lock() = ignore_hash::IgnoreState::default();
+        let clip_hash = captured_clip_hash(
+            &CapturedContent::Text {
+                content: b"echo".to_vec(),
+                preview: "echo".into(),
+                hash: "unused".into(),
+            },
+            &[],
+        );
+        set_ignore_hash(clip_hash.clone());
+        let ignore = bind_ignore_hash_for_queued_work(
+            IGNORE_HASH.lock().marker.as_ref(),
+            Instant::now(),
+            IGNORE_HASH_TTL,
+        );
+        let generation = ignore.as_ref().expect("live marker").generation;
+
+        let (tx, rx) = snapshot_channel::channel();
+        enqueue_listener_event(&tx, text_event(1, b"echo", ignore)).expect("receiver is alive");
+        for sequence in 2..=(snapshot_queue::SNAPSHOT_QUEUE_CAPACITY as u32 + 1) {
+            enqueue_listener_event(&tx, text_event(sequence, b"x", None))
+                .expect("receiver is alive");
+        }
+        drop(rx);
+
+        assert!(
+            IGNORE_HASH.lock().marker.is_none(),
+            "fail-without-fix: enqueue_listener_event did not release IGNORE_HASH on flood drop"
+        );
+        assert_eq!(IGNORE_HASH.lock().consumed_generation, Some(generation));
+
+        let recopy = bind_ignore_hash_for_queued_work(
+            IGNORE_HASH.lock().marker.as_ref(),
+            Instant::now(),
+            IGNORE_HASH_TTL,
+        );
+        assert!(
+            !IGNORE_HASH.lock().ignore_and_consume_self_paste(
+                recopy.as_ref(),
+                clip_hash.as_str(),
+                Instant::now(),
+                IGNORE_HASH_TTL,
+            ),
+            "fail-without-fix: dropped echo left IGNORE_HASH swallowing the next real copy"
+        );
+        *IGNORE_HASH.lock() = ignore_hash::IgnoreState::default();
     }
 
     #[cfg(target_os = "windows")]

--- a/src-tauri/src/clipboard/ignore_hash.rs
+++ b/src-tauri/src/clipboard/ignore_hash.rs
@@ -89,6 +89,21 @@ impl IgnoreState {
         );
         true
     }
+
+    /// A flood-dropped snapshot never reaches process time. If it was the
+    /// self-paste echo, consume that generation so the live ignore marker
+    /// cannot keep swallowing later real copies of the same content
+    /// (SBS-1039). A dropped real capture that only carried an unrelated
+    /// binding is left alone.
+    pub(crate) fn release_dropped_queued_work(
+        &mut self,
+        queued: Option<&QueuedIgnore>,
+        clip_hash: &str,
+        now: Instant,
+        ttl: Duration,
+    ) -> bool {
+        self.ignore_and_consume_self_paste(queued, clip_hash, now, ttl)
+    }
 }
 
 /// Whether a self-write marker still applies to `hash`.
@@ -593,5 +608,89 @@ mod tests {
             "fail-without-fix: leftover gen-2 live marker swallows later real copies"
         );
         assert_eq!(state.consumed_generation, Some(2));
+    }
+
+    /// Fail-without-fix for SBS-1039: flood-drop the bound echo and do not
+    /// consume. The live marker (and a later same-generation bind) still
+    /// swallow the next real copy of that content.
+    #[test]
+    fn dropping_a_queued_echo_without_release_swallows_the_next_real_copy() {
+        let now = Instant::now();
+        let paste_a = marker("hash-a", now, 1);
+        let echo = bind_ignore_hash_for_queued_work(Some(&paste_a), now, IGNORE_HASH_TTL);
+        drop(echo);
+
+        let mut state = IgnoreState {
+            marker: Some(paste_a.clone()),
+            consumed_generation: None,
+        };
+        let recopy = bind_ignore_hash_for_queued_work(Some(&paste_a), now, IGNORE_HASH_TTL);
+        assert!(
+            state.ignore_and_consume_self_paste(recopy.as_ref(), "hash-a", now, IGNORE_HASH_TTL),
+            "this is the SBS-1039 leak: leftover IGNORE_HASH still swallows the next real copy"
+        );
+    }
+
+    #[test]
+    fn releasing_a_dropped_echo_lets_the_next_real_copy_through() {
+        // Paste A, queue its echo, flood-drop that work. Consume on drop so
+        // the live marker cannot bind or ignore a later genuine copy of A.
+        let now = Instant::now();
+        let paste_a = marker("hash-a", now, 1);
+        let echo = bind_ignore_hash_for_queued_work(Some(&paste_a), now, IGNORE_HASH_TTL);
+
+        let mut state = IgnoreState {
+            marker: Some(paste_a),
+            consumed_generation: None,
+        };
+        assert!(
+            state.release_dropped_queued_work(echo.as_ref(), "hash-a", now, IGNORE_HASH_TTL),
+            "the dropped work was the self-paste echo and must spend that generation"
+        );
+        assert!(state.marker.is_none());
+        assert_eq!(state.consumed_generation, Some(1));
+
+        let recopy = bind_ignore_hash_for_queued_work(state.marker.as_ref(), now, IGNORE_HASH_TTL);
+        assert!(
+            recopy.is_none(),
+            "fail-without-fix: live IGNORE_HASH still binds new copies after the echo was dropped"
+        );
+        assert!(
+            !state.ignore_and_consume_self_paste(recopy.as_ref(), "hash-a", now, IGNORE_HASH_TTL,),
+            "fail-without-fix: dropped echo left IGNORE_HASH swallowing the next real copy"
+        );
+    }
+
+    #[test]
+    fn dropping_unrelated_bound_work_does_not_release_the_echo_ignore() {
+        // Snapshot bound to paste A, content is B. Evicting B must not spend
+        // A's generation: the echo of A may still be in the queue.
+        let now = Instant::now();
+        let paste_a = marker("hash-a", now, 1);
+        let passenger = bind_ignore_hash_for_queued_work(Some(&paste_a), now, IGNORE_HASH_TTL);
+        let echo = bind_ignore_hash_for_queued_work(Some(&paste_a), now, IGNORE_HASH_TTL);
+
+        let mut state = IgnoreState {
+            marker: Some(paste_a),
+            consumed_generation: None,
+        };
+        assert!(!state.release_dropped_queued_work(
+            passenger.as_ref(),
+            "hash-b",
+            now,
+            IGNORE_HASH_TTL
+        ));
+        assert_eq!(state.consumed_generation, None);
+        assert!(
+            should_ignore_queued_self_paste(
+                echo.as_ref(),
+                state.marker.as_ref(),
+                "hash-a",
+                now,
+                IGNORE_HASH_TTL,
+                state.consumed_generation,
+            ),
+            "fail-without-fix: dropping B spent A's ignore, so the remaining echo would persist"
+        );
     }
 }

--- a/src-tauri/src/clipboard/ignore_hash.rs
+++ b/src-tauri/src/clipboard/ignore_hash.rs
@@ -99,10 +99,23 @@ impl IgnoreState {
         &mut self,
         queued: Option<&QueuedIgnore>,
         clip_hash: &str,
-        now: Instant,
-        ttl: Duration,
     ) -> bool {
-        self.ignore_and_consume_self_paste(queued, clip_hash, now, ttl)
+        let Some(bound) = queued else {
+            return false;
+        };
+        if bound.hash != clip_hash || Some(bound.generation) == self.consumed_generation {
+            return false;
+        }
+
+        self.consumed_generation = Some(bound.generation);
+        if self
+            .marker
+            .as_ref()
+            .is_some_and(|marker| marker.generation == bound.generation)
+        {
+            self.marker.take();
+        }
+        true
     }
 }
 
@@ -644,7 +657,7 @@ mod tests {
             consumed_generation: None,
         };
         assert!(
-            state.release_dropped_queued_work(echo.as_ref(), "hash-a", now, IGNORE_HASH_TTL),
+            state.release_dropped_queued_work(echo.as_ref(), "hash-a"),
             "the dropped work was the self-paste echo and must spend that generation"
         );
         assert!(state.marker.is_none());
@@ -674,12 +687,7 @@ mod tests {
             marker: Some(paste_a),
             consumed_generation: None,
         };
-        assert!(!state.release_dropped_queued_work(
-            passenger.as_ref(),
-            "hash-b",
-            now,
-            IGNORE_HASH_TTL
-        ));
+        assert!(!state.release_dropped_queued_work(passenger.as_ref(), "hash-b"));
         assert_eq!(state.consumed_generation, None);
         assert!(
             should_ignore_queued_self_paste(
@@ -692,5 +700,24 @@ mod tests {
             ),
             "fail-without-fix: dropping B spent A's ignore, so the remaining echo would persist"
         );
+    }
+
+    #[test]
+    fn dropping_unbound_same_hash_work_does_not_spend_the_live_marker() {
+        let now = Instant::now();
+        let paste_a = marker("hash-a", now, 1);
+        let echo = bind_ignore_hash_for_queued_work(Some(&paste_a), now, IGNORE_HASH_TTL);
+        let mut state = IgnoreState {
+            marker: Some(paste_a),
+            consumed_generation: None,
+        };
+
+        assert!(!state.release_dropped_queued_work(None, "hash-a"));
+        assert_eq!(state.consumed_generation, None);
+        assert!(
+            state.marker.is_some(),
+            "the live marker must remain for its bound echo"
+        );
+        assert!(state.ignore_and_consume_self_paste(echo.as_ref(), "hash-a", now, IGNORE_HASH_TTL,));
     }
 }

--- a/src-tauri/src/clipboard/snapshot_channel.rs
+++ b/src-tauri/src/clipboard/snapshot_channel.rs
@@ -70,12 +70,24 @@ pub(super) fn channel<T: SizedPayload>() -> (Sender<T>, Receiver<T>) {
 }
 
 impl<T: SizedPayload> Sender<T> {
-    pub(super) fn send(&self, item: T) -> Result<EnqueueOutcome<T>, ()> {
+    /// Queue an item and handle evictions before the receiver is woken.
+    ///
+    /// The ordering matters for clipboard ignore state: waking first lets the
+    /// consumer process a later same-hash item before an evicted echo releases
+    /// its ignore generation (SBS-1039).
+    pub(super) fn send(
+        &self,
+        item: T,
+        on_evicted: impl FnOnce(&[T]),
+    ) -> Result<EnqueueOutcome<T>, ()> {
         let mut inner = self.shared.inner.lock();
         if inner.receiver_gone {
             return Err(());
         }
         let outcome = inner.push(item);
+        if let EnqueueOutcome::QueuedAfterDrop { evicted, .. } = &outcome {
+            on_evicted(evicted);
+        }
         drop(inner);
         self.shared.notify.notify_one();
         Ok(outcome)
@@ -137,14 +149,14 @@ mod tests {
     fn send_fails_after_the_receiver_is_dropped() {
         let (tx, rx) = channel::<FakeSnapshot>();
         drop(rx);
-        assert_eq!(tx.send(fake(1, 1)), Err(()));
+        assert_eq!(tx.send(fake(1, 1), |_| {}), Err(()));
     }
 
     #[tokio::test]
     async fn recv_delivers_enqueued_items_in_order() {
         let (tx, rx) = channel();
-        assert_eq!(tx.send(fake(1, 4)), Ok(EnqueueOutcome::Queued));
-        assert_eq!(tx.send(fake(2, 4)), Ok(EnqueueOutcome::Queued));
+        assert_eq!(tx.send(fake(1, 4), |_| {}), Ok(EnqueueOutcome::Queued));
+        assert_eq!(tx.send(fake(2, 4), |_| {}), Ok(EnqueueOutcome::Queued));
         assert_eq!(rx.recv().await, Some(fake(1, 4)));
         assert_eq!(rx.recv().await, Some(fake(2, 4)));
     }
@@ -161,7 +173,7 @@ mod tests {
         let (tx, rx) = channel();
         let flood = SNAPSHOT_QUEUE_CAPACITY + 5;
         for id in 0..flood {
-            tx.send(fake(id as u32, 1))
+            tx.send(fake(id as u32, 1), |_| {})
                 .expect("receiver is still alive");
         }
         let first = rx.recv().await.expect("the newest window must remain");
@@ -179,12 +191,15 @@ mod tests {
         let (tx, _rx) = channel();
         for id in 0..SNAPSHOT_QUEUE_CAPACITY {
             assert_eq!(
-                tx.send(fake(id as u32, 1)),
+                tx.send(fake(id as u32, 1), |_| {}),
                 Ok(EnqueueOutcome::Queued),
                 "the first {SNAPSHOT_QUEUE_CAPACITY} items must fit"
             );
         }
-        match tx.send(fake(SNAPSHOT_QUEUE_CAPACITY as u32, 1)) {
+        let mut handled = Vec::new();
+        match tx.send(fake(SNAPSHOT_QUEUE_CAPACITY as u32, 1), |evicted| {
+            handled.extend(evicted.iter().map(|item| item.id));
+        }) {
             Ok(EnqueueOutcome::QueuedAfterDrop {
                 evicted, dropped, ..
             }) => {
@@ -196,5 +211,6 @@ mod tests {
             }
             other => panic!("expected eviction of the oldest item, got {other:?}"),
         }
+        assert_eq!(handled, vec![0]);
     }
 }

--- a/src-tauri/src/clipboard/snapshot_channel.rs
+++ b/src-tauri/src/clipboard/snapshot_channel.rs
@@ -23,7 +23,7 @@ struct Inner<T> {
 impl<T: SizedPayload> Inner<T> {
     // Methods take `&mut self` so we do not split-borrow a MutexGuard
     // (parking_lot's DerefMut is not disjoint-field aware).
-    fn push(&mut self, item: T) -> EnqueueOutcome {
+    fn push(&mut self, item: T) -> EnqueueOutcome<T> {
         enqueue(
             &mut self.items,
             &mut self.bytes,
@@ -70,7 +70,7 @@ pub(super) fn channel<T: SizedPayload>() -> (Sender<T>, Receiver<T>) {
 }
 
 impl<T: SizedPayload> Sender<T> {
-    pub(super) fn send(&self, item: T) -> Result<EnqueueOutcome, ()> {
+    pub(super) fn send(&self, item: T) -> Result<EnqueueOutcome<T>, ()> {
         let mut inner = self.shared.inner.lock();
         if inner.receiver_gone {
             return Err(());
@@ -172,5 +172,29 @@ mod tests {
             last = item;
         }
         assert_eq!(last.id, flood as u32 - 1);
+    }
+
+    #[test]
+    fn send_returns_evicted_items_on_count_flood() {
+        let (tx, _rx) = channel();
+        for id in 0..SNAPSHOT_QUEUE_CAPACITY {
+            assert_eq!(
+                tx.send(fake(id as u32, 1)),
+                Ok(EnqueueOutcome::Queued),
+                "the first {SNAPSHOT_QUEUE_CAPACITY} items must fit"
+            );
+        }
+        match tx.send(fake(SNAPSHOT_QUEUE_CAPACITY as u32, 1)) {
+            Ok(EnqueueOutcome::QueuedAfterDrop {
+                evicted, dropped, ..
+            }) => {
+                assert_eq!(dropped, 1);
+                assert_eq!(
+                    evicted[0].id, 0,
+                    "fail-without-fix: send discarded the evicted item (SBS-1039)"
+                );
+            }
+            other => panic!("expected eviction of the oldest item, got {other:?}"),
+        }
     }
 }

--- a/src-tauri/src/clipboard/snapshot_queue.rs
+++ b/src-tauri/src/clipboard/snapshot_queue.rs
@@ -17,6 +17,8 @@
 //!   unbounded backlog. A later oversized event replaces that capture.
 //! - A 100-copy text burst (the reliability contract) stays under both
 //!   budgets, so capture order is preserved under normal load.
+//! - Evicted items are returned (not dropped in place) so a bound
+//!   self-paste ignore can be released (SBS-1039).
 //!
 //! Kept free of the Windows-only crate graph so
 //! `rustc --test src-tauri/src/clipboard/snapshot_queue.rs` can prove the
@@ -36,12 +38,16 @@ pub(crate) trait SizedPayload {
     fn payload_bytes(&self) -> usize;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum EnqueueOutcome {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EnqueueOutcome<T> {
     Queued,
     QueuedAfterDrop {
         dropped: usize,
         dropped_bytes: usize,
+        /// Evicted work, oldest first. Callers that bound ignore-hash to a
+        /// snapshot must release that binding here (SBS-1039): process time
+        /// never sees these items.
+        evicted: Vec<T>,
     },
 }
 
@@ -53,7 +59,7 @@ pub(crate) fn enqueue<T: SizedPayload>(
     item: T,
     capacity: usize,
     max_bytes: usize,
-) -> EnqueueOutcome {
+) -> EnqueueOutcome<T> {
     debug_assert!(
         capacity >= 1,
         "SBS-1032: the queue must be able to hold the current capture"
@@ -61,6 +67,7 @@ pub(crate) fn enqueue<T: SizedPayload>(
     let item_bytes = item.payload_bytes();
     let mut dropped = 0;
     let mut dropped_bytes = 0;
+    let mut evicted = Vec::new();
 
     if item_bytes > max_bytes {
         // Newest oversized capture wins: refuse an unbounded backlog of
@@ -70,6 +77,7 @@ pub(crate) fn enqueue<T: SizedPayload>(
             *queued_bytes = queued_bytes.saturating_sub(old_bytes);
             dropped += 1;
             dropped_bytes += old_bytes;
+            evicted.push(old);
         }
     } else {
         // Counted bytes skip an already-accepted oversize resident so a
@@ -92,6 +100,7 @@ pub(crate) fn enqueue<T: SizedPayload>(
                 }
                 dropped += 1;
                 dropped_bytes += old_bytes;
+                evicted.push(old);
             } else if let Some(index) = queue
                 .iter()
                 .position(|queued| queued.payload_bytes() <= max_bytes)
@@ -104,6 +113,7 @@ pub(crate) fn enqueue<T: SizedPayload>(
                 counted_bytes = counted_bytes.saturating_sub(old_bytes);
                 dropped += 1;
                 dropped_bytes += old_bytes;
+                evicted.push(old);
             } else {
                 break;
             }
@@ -119,6 +129,7 @@ pub(crate) fn enqueue<T: SizedPayload>(
         EnqueueOutcome::QueuedAfterDrop {
             dropped,
             dropped_bytes,
+            evicted,
         }
     }
 }
@@ -272,7 +283,8 @@ mod tests {
             enqueue(&mut queue, &mut bytes, fake(3, 8), 8, 20),
             EnqueueOutcome::QueuedAfterDrop {
                 dropped: 1,
-                dropped_bytes: 8
+                dropped_bytes: 8,
+                evicted: vec![fake(1, 8)],
             }
         );
         assert_eq!(ids(&queue), vec![2, 3]);
@@ -290,7 +302,8 @@ mod tests {
             outcome,
             EnqueueOutcome::QueuedAfterDrop {
                 dropped: 2,
-                dropped_bytes: 20
+                dropped_bytes: 20,
+                evicted: vec![fake(1, 10), fake(2, 10)],
             }
         );
         assert_eq!(ids(&queue), vec![3]);
@@ -332,7 +345,8 @@ mod tests {
             outcome,
             EnqueueOutcome::QueuedAfterDrop {
                 dropped: 3,
-                dropped_bytes: 51
+                dropped_bytes: 51,
+                evicted: vec![fake(1, 50), fake(2, 0), fake(3, 1)],
             }
         );
         assert_eq!(ids(&queue), vec![4]);
@@ -352,7 +366,8 @@ mod tests {
             outcome,
             EnqueueOutcome::QueuedAfterDrop {
                 dropped: 1,
-                dropped_bytes: 50
+                dropped_bytes: 50,
+                evicted: vec![fake(0, 50)],
             }
         );
         assert_eq!(ids(&queue), vec![1, 2, 3]);
@@ -381,7 +396,8 @@ mod tests {
             outcome,
             EnqueueOutcome::QueuedAfterDrop {
                 dropped: 1,
-                dropped_bytes: 8
+                dropped_bytes: 8,
+                evicted: vec![fake(2, 8)],
             }
         );
         assert_eq!(ids(&queue), vec![1, 3, 4]);
@@ -434,6 +450,26 @@ mod tests {
         assert_eq!(dequeue(&mut queue, &mut bytes).map(|item| item.id), Some(2));
         assert_eq!(bytes, 0);
         assert!(dequeue(&mut queue, &mut bytes).is_none());
+    }
+
+    /// Fail-without-fix for SBS-1039: counting drops is not enough. The
+    /// evicted items themselves must come back so a bound ignore-hash can
+    /// be released. Replacing the return with counts-only makes this fail.
+    #[test]
+    fn enqueue_returns_the_evicted_items() {
+        let mut queue = VecDeque::new();
+        let mut bytes = 0usize;
+        enqueue(&mut queue, &mut bytes, fake(1, 1), 2, 100);
+        enqueue(&mut queue, &mut bytes, fake(2, 1), 2, 100);
+        let outcome = enqueue(&mut queue, &mut bytes, fake(3, 1), 2, 100);
+        match outcome {
+            EnqueueOutcome::QueuedAfterDrop { evicted, .. } => {
+                assert_eq!(evicted, vec![fake(1, 1)]);
+            }
+            EnqueueOutcome::Queued => {
+                panic!("fail-without-fix: enqueue discarded the evicted item")
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Linear [SBS-1039](https://linear.app/southboundsoftware/issue/SBS-1039): after SBS-1032 bounded the snapshot queue, flood eviction dropped oldest pending captures without ever reaching process-time ignore consume. A self-paste echo that had bound `IGNORE_HASH` at enqueue could therefore leave that marker live, and the next real copy of the same content was swallowed.

This does not change the SBS-1022 bind-at-enqueue rule. The echo still carries the generation for as long as it stays queued. The new work is the drop path:

- `snapshot_queue::enqueue` returns the evicted items (not just counts).
- `snapshot_channel::Sender::send` surfaces those items.
- `enqueue_listener_event` consumes a matching self-paste binding via `IgnoreState::release_dropped_queued_work` (same rules as process-time consume).
- A dropped real capture that only carried an unrelated binding, or a `Cleared` event, does not spend the echo's generation.
- `LAST_STABLE_HASH` / `reset_capture_dedup` is unchanged: consecutive-dedup is only written after persist, so a dropped snapshot never stamped it. That helper remains the history-delete path.

## User-visible outcome

Pasting a clip and then flooding the clipboard no longer leaves Cubby ignoring the next genuine copy of that same content.

## Verification

- [x] I kept this pull request focused.
- [ ] I tested the change on Windows 11.
- [x] I added or updated tests where practical.
- [x] I updated documentation for changed behavior.
- [x] I did not include clipboard contents, credentials, signing material, or other secrets.

### Fail without the fix

`release_dropped_queued_work` stubbed to return `false` (no consume):

```
test tests::releasing_a_dropped_echo_lets_the_next_real_copy_through ... FAILED
the dropped work was the self-paste echo and must spend that generation
```

`dropping_a_queued_echo_without_release_swallows_the_next_real_copy` documents the leak: drop the bound echo, leave the live marker, and the next same-hash copy is ignored.

`enqueue_returns_the_evicted_items` fails if `enqueue` only counts drops and discards the values.

### Local (Linux, this agent)

```
rustc --edition 2021 --test src-tauri/src/clipboard/ignore_hash.rs
# 19 passed (includes drop-then-real-copy)

rustc --edition 2021 --test src-tauri/src/clipboard/snapshot_queue.rs
# 13 passed (includes evicted-item return)

cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
pnpm run format:check
pnpm run release:check
pnpm run test                          # 15 files, 168 tests
node --test …                          # 122 passed
node .github/scripts/check-site.mjs
node .github/scripts/check-privileged-action-pins.mjs
node .github/scripts/check-shipped-windows-ci.mjs
```

### Windows CI on `cbee7e0`

Passed: `test` (includes `cargo test --all-targets` and `cargo clippy --all-targets -- -D warnings`), `shipped-windows`, all four `Check <arch> <features>` legs, CodeQL (no new alerts).

`github-advanced-security` / "Code scanning AI findings" failed with `You are not licensed to use Copilot` before any review of this diff. The same check failed on PRs #283–#285 in the same window. That is a license/auth error, not a finding in this change.

Cite: SBS-1039. Do not merge from this agent.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a51a871-bb30-446f-8ee0-be0298e65719?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a51a871-bb30-446f-8ee0-be0298e65719&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release ignore-hash when a queued self-paste echo is flood-dropped
> - When the clipboard event queue evicts items under flood, `enqueue_listener_event` now invokes `release_ignore_for_dropped_events` to consume the matching self-paste ignore marker for dropped content events, so a later real copy is not swallowed
> - `EnqueueOutcome` is made generic over `T` and `QueuedAfterDrop` now carries the evicted items; `snapshot_channel::Sender::send` accepts an `on_evicted` callback that receives them synchronously at send time
> - `IgnoreState::release_dropped_queued_work` consumes the bound self-paste generation (and clears the live marker) only when the dropped work matches the bound echo by hash and generation
> - `captured_clip_hash` computes the clipboard identity hash at enqueue time; a `debug_assert_eq` in `process_clipboard_snapshot` guards parity with the process-time hash
> - Risk: `Sender::send` and `enqueue_listener_event` signatures changed (new callback parameter, `EnqueueOutcome` now generic); all in-tree call sites are updated but out-of-tree callers will break. Debug builds panic on hash mismatch between enqueue and process time
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eafcb63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->