### PR TITLE
Preserve focused control keyboard behavior

### DIFF
--- a/frontend/src/hooks/useKeyboard.test.tsx
+++ b/frontend/src/hooks/useKeyboard.test.tsx
@@ -72,6 +72,23 @@ describe('useKeyboard', () => {
     expect(handlers.onNavigateDown).toHaveBeenCalledOnce();
   });
 
+  it('leaves clip shortcuts to focused buttons and selects', () => {
+    const handlers = callbacks();
+    renderHook(() => useKeyboard(handlers));
+    const button = document.createElement('button');
+    const select = document.createElement('select');
+    document.body.append(button, select);
+
+    fireEvent.keyDown(button, { key: 'Enter' });
+    fireEvent.keyDown(button, { key: 'Delete' });
+    fireEvent.keyDown(select, { key: 'ArrowDown' });
+    fireEvent.keyDown(select, { key: 'Home' });
+
+    expect(handlers.onPaste).not.toHaveBeenCalled();
+    expect(handlers.onDelete).not.toHaveBeenCalled();
+    expect(handlers.onNavigateDown).not.toHaveBeenCalled();
+  });
+
   it('ignores composition and non-arrow repeats', () => {
     const handlers = callbacks();
     renderHook(() => useKeyboard(handlers));

--- a/frontend/src/hooks/useKeyboard.ts
+++ b/frontend/src/hooks/useKeyboard.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { classifyKeyboardTarget } from '../utils/keyboardTarget';
 
 interface KeyboardOptions {
   disabled?: boolean;
@@ -26,11 +27,11 @@ export function useKeyboard(options: KeyboardOptions) {
 
       const current = optionsRef.current;
       if (current.disabled) return;
-      const target = e.target as HTMLElement | null;
-      const isEditing =
-        target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || target?.isContentEditable;
-      const isSearchInput = target?.matches('[data-el="search-input"]') ?? false;
-      const canNavigateHistory = !isEditing || isSearchInput;
+      const { isInteractive, isSearch } = classifyKeyboardTarget(
+        e.target,
+        '[data-el="search-input"]'
+      );
+      const canNavigateHistory = !isInteractive || isSearch;
       const isRepeatableAction = e.key === 'ArrowUp' || e.key === 'ArrowDown';
 
       if (e.repeat && !isRepeatableAction) return;
@@ -47,7 +48,7 @@ export function useKeyboard(options: KeyboardOptions) {
         return;
       }
 
-      if (!isEditing && e.key === 'Delete' && current.onDelete) {
+      if (!isInteractive && e.key === 'Delete' && current.onDelete) {
         e.preventDefault();
         current.onDelete();
         return;

--- a/frontend/src/utils/keyboardTarget.test.ts
+++ b/frontend/src/utils/keyboardTarget.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { classifyKeyboardTarget } from './keyboardTarget';
+
+describe('classifyKeyboardTarget', () => {
+  it('recognizes native controls and descendants of buttons and links', () => {
+    const host = document.createElement('div');
+    host.innerHTML = '<button><span>Save</span></button><select></select><a href="#">Help</a>';
+
+    for (const target of host.querySelectorAll('span, select, a')) {
+      expect(classifyKeyboardTarget(target, '[data-el="search-input"]').isInteractive).toBe(true);
+    }
+  });
+
+  it('recognizes applicable ARIA widgets', () => {
+    for (const role of ['button', 'combobox', 'listbox', 'menuitem', 'option', 'switch', 'tab']) {
+      const target = document.createElement('div');
+      target.setAttribute('role', role);
+      expect(classifyKeyboardTarget(target, '[data-el="search-input"]').isInteractive).toBe(true);
+    }
+  });
+
+  it('keeps search inputs identifiable while treating them as editing controls', () => {
+    const search = document.createElement('input');
+    search.dataset.el = 'search-input';
+    expect(classifyKeyboardTarget(search, '[data-el="search-input"]')).toEqual({
+      isEditing: true,
+      isInteractive: true,
+      isSearch: true,
+    });
+  });
+});

--- a/frontend/src/utils/keyboardTarget.ts
+++ b/frontend/src/utils/keyboardTarget.ts
@@ -1,0 +1,40 @@
+const INTERACTIVE_SELECTOR = [
+  'button',
+  'select',
+  'a[href]',
+  '[contenteditable="true"]',
+  '[role="button"]',
+  '[role="checkbox"]',
+  '[role="combobox"]',
+  '[role="listbox"]',
+  '[role="menuitem"]',
+  '[role="option"]',
+  '[role="radio"]',
+  '[role="slider"]',
+  '[role="switch"]',
+  '[role="tab"]',
+  '[role="textbox"]',
+].join(',');
+
+export interface KeyboardTargetState {
+  isEditing: boolean;
+  isInteractive: boolean;
+  isSearch: boolean;
+}
+
+export function classifyKeyboardTarget(
+  target: EventTarget | null,
+  searchSelector: string
+): KeyboardTargetState {
+  if (!(target instanceof Element)) {
+    return { isEditing: false, isInteractive: false, isSearch: false };
+  }
+
+  const isEditing =
+    target.closest('input, textarea, [contenteditable="true"], [role="textbox"]') !== null;
+  return {
+    isEditing,
+    isInteractive: isEditing || target.closest(INTERACTIVE_SELECTOR) !== null,
+    isSearch: target.matches(searchSelector),
+  };
+}

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -19,6 +19,7 @@ import { shortcutsSuspended } from '../utils/flyoutSearch';
 import { ClipDetails } from '../utils/clipPreviewState';
 import { customRange, DATE_PRESET_LABELS, DatePreset, presetRange } from '../utils/dateRange';
 import { folderSelectionAfterReload } from '../utils/folderSelection';
+import { classifyKeyboardTarget } from '../utils/keyboardTarget';
 import { clipListPageArgs, nextPageCursor } from '../utils/clipListPage';
 import {
   clipLoadAnnouncesSuccess,
@@ -756,15 +757,15 @@ export function HistoryWindow() {
       // buttons. App.tsx stands down the same way with useKeyboard's disabled
       // flag.
       if (shortcutsSuspended(event, bulkDeleteOpen)) return;
-      const target = event.target as HTMLElement | null;
-      const isEditing =
-        target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || target?.isContentEditable;
+      const { isEditing, isInteractive, isSearch } = classifyKeyboardTarget(
+        event.target,
+        '[data-el="history-search-input"]'
+      );
 
       if (event.key === 'Escape') {
         // Search is an INPUT, so isEditing is true there; Escape still clears
         // the query / closes. Notes and other fields must not close the window
         // even if they forget to stopPropagation (SBS-1008).
-        const isSearch = target?.getAttribute('data-el') === 'history-search-input';
         if (isEditing && !isSearch) return;
         if (searchQuery) {
           setSearchQuery('');
@@ -781,7 +782,7 @@ export function HistoryWindow() {
       // Arrow keys move the list selection, but not while the caret is in the
       // search box — there they belong to the input, or typing becomes
       // unworkable without a mouse.
-      if ((event.key === 'ArrowUp' || event.key === 'ArrowDown') && !isEditing) {
+      if ((event.key === 'ArrowUp' || event.key === 'ArrowDown') && !isInteractive) {
         const list = clipsRef.current;
         if (list.length === 0) return;
         event.preventDefault();
@@ -793,7 +794,7 @@ export function HistoryWindow() {
         setSelectedClipId(list[nextIndex].id);
         return;
       }
-      if (isEditing) return;
+      if (isInteractive) return;
       if (event.key === 'Enter' && selectedClipId) {
         event.preventDefault();
         handleCopy(selectedClipId, event.shiftKey);


### PR DESCRIPTION
Fixes #185.\n\nFlyout and History shortcuts now stand down for focused buttons, links, selects, contenteditable regions, and ARIA widgets while keeping search navigation intact.\n\nVerified with 176 frontend tests, the production build, and Prettier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Keyboard-shortcut gating only; no auth, data, or backend changes. Risk is limited to missed or extra shortcut suppression on some focus targets.
> 
> **Overview**
> Flyout and History keyboard shortcuts no longer steal keys from focused buttons, links, selects, contenteditable regions, or ARIA widgets. Search still allows Escape and (in the flyout) list navigation.
> 
> Adds shared `classifyKeyboardTarget` and switches both `useKeyboard` and History from a tag-name `isEditing` check to `isInteractive`, so native control behavior (Enter on a button, arrows in a select) is preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14a0f0f25a4123ff70669485f0e2d7729bc6bb4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix keyboard shortcuts firing inside focused interactive controls
> - Introduces `classifyKeyboardTarget` in [keyboardTarget.ts](https://github.com/tsouth89/cubby-clipboard/pull/291/files#diff-3252aae457b27bf53e4c2170efe4af4374e37a29e2537f4227649b955faf20f9) to detect if a key event target is editing, interactive, or search based on DOM structure and ARIA roles
> - Updates [useKeyboard.ts](https://github.com/tsouth89/cubby-clipboard/pull/291/files#diff-42aef17dbb9e7b9534bb61b90841868e530d2e80540c68d55aaa543a596563dd) and [HistoryWindow.tsx](https://github.com/tsouth89/cubby-clipboard/pull/291/files#diff-66e4a504891e766358388fbcc59de24cd17efafbabffdf4380b98891366560f2) to replace ad-hoc `isEditing` checks with the new helper. Global shortcuts (Delete, arrow keys, history navigation) now check `!isInteractive` instead of `!isEditing`
> - Behavioral Change: Global shortcuts no longer trigger when focus is inside buttons, selects, or ARIA widgets. The designated search input remains navigable for history navigation and Escape handling
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14a0f0f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->