### PR TITLE
Make the backup passphrase prompt modal

### DIFF
--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -19,8 +19,9 @@ import {
   AlertTriangle,
   FlaskConical,
 } from 'lucide-react';
-import { useState, useEffect, useRef, type ReactNode } from 'react';
+import { useState, useEffect, useId, useRef, type ReactNode } from 'react';
 import { useTheme } from '../hooks/useTheme';
+import { useModalDialog } from '../hooks/useModalDialog';
 import { useTranslation } from 'react-i18next';
 import { invoke } from '@tauri-apps/api/core';
 import { emit } from '@tauri-apps/api/event';
@@ -336,6 +337,8 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
   const [backupPrompt, setBackupPrompt] = useState<'export' | 'import' | null>(null);
   const [backupPassphrase, setBackupPassphrase] = useState('');
   const [backupPassphraseConfirm, setBackupPassphraseConfirm] = useState('');
+  const backupPromptTitleId = useId();
+  const backupPromptDescriptionId = useId();
   const [ocrStatus, setOcrStatus] = useState<OcrQueueStatus | null>(null);
   const [ocrActionBusy, setOcrActionBusy] = useState(false);
   const [storageUsage, setStorageUsage] = useState<StorageUsage | null>(null);
@@ -583,6 +586,7 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
     setBackupPassphrase('');
     setBackupPassphraseConfirm('');
   };
+  const backupPromptRef = useModalDialog<HTMLFormElement>(closeBackupPrompt, backupPrompt !== null);
 
   const handleExportBackup = async (passphrase: string) => {
     let path: string;
@@ -867,6 +871,12 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
       {backupPrompt && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6">
           <form
+            ref={backupPromptRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={backupPromptTitleId}
+            aria-describedby={backupPromptDescriptionId}
+            tabIndex={-1}
             className="w-full max-w-sm rounded-lg border border-border bg-card p-4 shadow-xl"
             onSubmit={(event) => {
               event.preventDefault();
@@ -877,10 +887,13 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
               else void handleImportBackup(passphrase);
             }}
           >
-            <h2 className="text-sm font-semibold">
+            <h2 id={backupPromptTitleId} className="text-sm font-semibold">
               {backupPrompt === 'export' ? 'Choose a passphrase' : 'Enter the passphrase'}
             </h2>
-            <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            <p
+              id={backupPromptDescriptionId}
+              className="mt-1 text-xs leading-5 text-muted-foreground"
+            >
               {backupPrompt === 'export'
                 ? 'This passphrase encrypts the backup file. Cubby does not store it — if you lose it, the backup cannot be opened by anyone, including you.'
                 : 'The passphrase this backup was created with.'}

--- a/frontend/src/hooks/useModalDialog.test.tsx
+++ b/frontend/src/hooks/useModalDialog.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useModalDialog } from './useModalDialog';
+
+function Harness({ onEscape = vi.fn() }: { onEscape?: () => void }) {
+  const [open, setOpen] = useState(false);
+  const close = () => {
+    onEscape();
+    setOpen(false);
+  };
+  const ref = useModalDialog<HTMLDivElement>(close, open);
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open</button>
+      <button>Background</button>
+      {open && (
+        <div ref={ref} role="dialog" tabIndex={-1}>
+          <input aria-label="Passphrase" autoFocus />
+          <button onClick={close}>Cancel</button>
+        </div>
+      )}
+    </>
+  );
+}
+
+describe('useModalDialog', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLElement.prototype, 'offsetParent', 'get').mockReturnValue(document.body);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('moves focus inside, traps Tab, and restores the opener', () => {
+    render(<Harness />);
+    const opener = screen.getByRole('button', { name: 'Open' });
+
+    opener.focus();
+    fireEvent.click(opener);
+    const input = screen.getByRole('textbox', { name: 'Passphrase' });
+    const cancel = screen.getByRole('button', { name: 'Cancel' });
+    expect(input).toHaveFocus();
+
+    cancel.focus();
+    fireEvent.keyDown(cancel, { key: 'Tab' });
+    expect(input).toHaveFocus();
+
+    fireEvent.click(cancel);
+    expect(opener).toHaveFocus();
+  });
+
+  it('calls the escape handler and restores focus', () => {
+    const onEscape = vi.fn();
+    render(<Harness onEscape={onEscape} />);
+    const opener = screen.getByRole('button', { name: 'Open' });
+
+    opener.focus();
+    fireEvent.click(opener);
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+
+    expect(onEscape).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(opener).toHaveFocus();
+  });
+});

--- a/frontend/src/hooks/useModalDialog.ts
+++ b/frontend/src/hooks/useModalDialog.ts
@@ -21,6 +21,14 @@ import { useEffect, useRef } from 'react';
  */
 export function useModalDialog<T extends HTMLElement>(onEscape?: () => void, enabled = true) {
   const containerRef = useRef<T>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+  const wasEnabledRef = useRef(false);
+  if (enabled && !wasEnabledRef.current) {
+    // Capture during render, before React applies autoFocus while committing the
+    // dialog. Waiting for the effect would remember the dialog input instead.
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+  }
+  wasEnabledRef.current = enabled;
   // Read through a ref so changing the handler between renders does not tear
   // down and re-run the focus effect, which would steal focus back on every
   // parent render.
@@ -31,8 +39,6 @@ export function useModalDialog<T extends HTMLElement>(onEscape?: () => void, ena
     if (!enabled) return;
     const container = containerRef.current;
     if (!container) return;
-
-    const previouslyFocused = document.activeElement as HTMLElement | null;
 
     const focusable = () =>
       Array.from(
@@ -93,8 +99,8 @@ export function useModalDialog<T extends HTMLElement>(onEscape?: () => void, ena
       document.removeEventListener('keydown', handleKeyDown, true);
       // The invoking control can be gone by now (deleted clip, closed panel);
       // isConnected keeps that from throwing focus somewhere arbitrary.
-      if (previouslyFocused?.isConnected) {
-        previouslyFocused.focus();
+      if (previouslyFocusedRef.current?.isConnected) {
+        previouslyFocusedRef.current.focus();
       }
     };
   }, [enabled]);


### PR DESCRIPTION
Fixes #183.\n\nThe backup passphrase prompt now has dialog semantics, trapped focus, Escape cancellation, and focus restoration. The shared modal hook now captures the opener before React applies autoFocus.\n\nVerified with 174 frontend tests, the production build, and Prettier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Accessibility and focus-management only; backup crypto and file I/O are unchanged. The render-time activeElement capture is a small timing change that also affects other dialogs using the hook.
> 
> **Overview**
> Turns the backup passphrase prompt into an accessible modal: dialog semantics, focus trap, Escape to cancel, and focus restored to the opener.
> 
> Wires `useModalDialog` into the settings backup form and labels it with `role="dialog"`, `aria-modal`, and `useId` title/description IDs.
> 
> Fixes the shared hook so it records the previously focused element during render, before React applies `autoFocus`—otherwise close would restore focus to the passphrase field. Adds tests for trap, Escape, and restore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c3e298feef37747570f64a8b056e6df743e6b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make backup passphrase prompt an accessible modal dialog
> - Integrates the `useModalDialog` hook into `SettingsPanel` so the backup passphrase prompt traps focus, handles Escape, and restores focus to the opener on close
> - Adds `role="dialog"`, `aria-modal="true"`, and `aria-labelledby`/`aria-describedby` using stable IDs from `useId` for screen reader semantics
> - Fixes `useModalDialog` to capture the previously focused element during render (via `previouslyFocusedRef`) instead of at effect time, avoiding restoring focus to an auto-focused dialog control
> - Adds a test suite for `useModalDialog` covering focus movement, Tab trapping, Escape handling, and focus restoration
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c3e298.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->