### PR TITLE
Use accessible native Settings selects

### DIFF
--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -1032,6 +1032,7 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
                         control={
                           <div className="w-40">
                             <Select
+                              ariaLabel={t('settings.language')}
                               value={settings.language || 'en'}
                               onChange={handleLanguageChange}
                               options={[
@@ -1346,6 +1347,7 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
                         control={
                           <div className="w-40">
                             <Select
+                              ariaLabel={t('settings.keepHistoryFor')}
                               value={String(settings.auto_delete_days ?? 30)}
                               onChange={handleRetentionChange}
                               options={[

--- a/frontend/src/components/ui/Select.test.tsx
+++ b/frontend/src/components/ui/Select.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Select } from './Select';
+
+const options = [
+  { label: 'English', value: 'en' },
+  { label: 'Spanish', value: 'es' },
+];
+
+afterEach(cleanup);
+
+describe('Select', () => {
+  it('uses native select semantics and reports changes', () => {
+    const onChange = vi.fn();
+    render(<Select ariaLabel="Language" value="en" onChange={onChange} options={options} />);
+    const select = screen.getByRole('combobox', { name: 'Language' });
+
+    expect(select).toHaveValue('en');
+    expect(screen.getByRole('option', { name: 'English' })).toHaveProperty('selected', true);
+    fireEvent.change(select, { target: { value: 'es' } });
+
+    expect(onChange).toHaveBeenCalledWith('es');
+  });
+
+  it('shows a disabled placeholder when no value is selected', () => {
+    render(
+      <Select
+        ariaLabel="Language"
+        value=""
+        onChange={vi.fn()}
+        options={options}
+        placeholder="Language"
+      />
+    );
+
+    expect(screen.getByRole('combobox')).toHaveValue('');
+    expect(screen.getByRole('option', { name: 'Language' })).toBeDisabled();
+  });
+
+  it('honors the disabled state', () => {
+    render(
+      <Select ariaLabel="Language" value="en" onChange={vi.fn()} options={options} disabled />
+    );
+
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+});

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -1,6 +1,4 @@
-import { useState, useRef, useEffect, useLayoutEffect, type CSSProperties } from 'react';
-import { createPortal } from 'react-dom';
-import { ChevronDown, Check } from 'lucide-react';
+import { ChevronDown } from 'lucide-react';
 import { clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
@@ -10,6 +8,7 @@ export interface SelectOption {
 }
 
 interface SelectProps {
+  ariaLabel: string;
   value: string;
   onChange: (value: string) => void;
   options: SelectOption[];
@@ -19,6 +18,7 @@ interface SelectProps {
 }
 
 export function Select({
+  ariaLabel,
   value,
   onChange,
   options,
@@ -26,124 +26,37 @@ export function Select({
   className,
   disabled,
 }: SelectProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [menuStyle, setMenuStyle] = useState<CSSProperties>({});
-  const containerRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  const selectedOption = options.find((opt) => opt.value === value);
-
-  // Position the menu against the trigger in viewport coordinates. The menu is
-  // portaled to <body>, so it is never clipped by an ancestor's overflow (the
-  // settings cards use overflow-hidden and the panel is a scroll container).
-  const updatePosition = () => {
-    const trigger = triggerRef.current;
-    if (!trigger) return;
-    const rect = trigger.getBoundingClientRect();
-    setMenuStyle({
-      position: 'fixed',
-      left: rect.left,
-      top: rect.bottom + 4,
-      width: rect.width,
-    });
-  };
-
-  useLayoutEffect(() => {
-    if (isOpen) updatePosition();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (containerRef.current?.contains(target)) return;
-      if (menuRef.current?.contains(target)) return;
-      setIsOpen(false);
-    };
-    // The menu is fixed-positioned, so close it if an ancestor or the page
-    // scrolls (it would otherwise detach from the trigger). Ignore scrolls that
-    // originate inside the menu's own option list so it stays open while paging
-    // through long lists.
-    const handleScroll = (event: Event) => {
-      if (menuRef.current?.contains(event.target as Node)) return;
-      setIsOpen(false);
-    };
-    const close = () => setIsOpen(false);
-
-    document.addEventListener('mousedown', handleClickOutside);
-    window.addEventListener('scroll', handleScroll, true);
-    window.addEventListener('resize', close);
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      window.removeEventListener('scroll', handleScroll, true);
-      window.removeEventListener('resize', close);
-    };
-  }, [isOpen]);
-
-  const handleSelect = (newValue: string) => {
-    onChange(newValue);
-    setIsOpen(false);
-  };
+  const hasSelectedOption = options.some((option) => option.value === value);
 
   return (
-    <div className={twMerge('relative w-full', className)} ref={containerRef}>
-      <button
-        ref={triggerRef}
-        type="button"
-        onClick={() => !disabled && setIsOpen(!isOpen)}
+    <div className={twMerge('relative w-full', className)}>
+      <select
+        aria-label={ariaLabel}
+        value={hasSelectedOption ? value : ''}
+        onChange={(event) => onChange(event.target.value)}
         disabled={disabled}
         className={clsx(
-          'flex w-full items-center justify-between rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ring',
+          'w-full appearance-none rounded-lg border border-border bg-input px-3 py-2 pr-9 text-sm text-foreground transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ring',
           disabled && 'cursor-not-allowed opacity-50',
-          isOpen && 'border-ring ring-2 ring-ring'
+          !hasSelectedOption && 'text-muted-foreground'
         )}
       >
-        <span className={clsx(!selectedOption && 'text-muted-foreground')}>
-          {selectedOption ? selectedOption.label : placeholder || 'Select...'}
-        </span>
-        <ChevronDown
-          size={16}
-          className={clsx(
-            'text-muted-foreground transition-transform duration-200',
-            isOpen && 'rotate-180'
-          )}
-        />
-      </button>
-
-      {isOpen &&
-        createPortal(
-          <div
-            ref={menuRef}
-            style={menuStyle}
-            className="animate-in fade-in-0 zoom-in-95 z-[100] overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-md duration-100"
-          >
-            <div className="max-h-60 overflow-y-auto py-1">
-              {options.map((option) => (
-                <button
-                  key={option.value}
-                  type="button"
-                  onClick={() => handleSelect(option.value)}
-                  className={clsx(
-                    'relative flex w-full cursor-default select-none items-center py-1.5 pl-3 pr-8 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground',
-                    option.value === value && 'bg-accent/50 font-medium text-accent-foreground'
-                  )}
-                >
-                  <span className="truncate">{option.label}</span>
-                  {option.value === value && (
-                    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
-                      <Check size={14} className="text-primary" />
-                    </span>
-                  )}
-                </button>
-              ))}
-            </div>
-          </div>,
-          document.body
+        {!hasSelectedOption && (
+          <option value="" disabled>
+            {placeholder || 'Select...'}
+          </option>
         )}
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      <ChevronDown
+        aria-hidden="true"
+        size={16}
+        className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+      />
     </div>
   );
 }


### PR DESCRIPTION
Fixes #182.\n\nReplaces the custom popup with a styled native select and adds accessible names at both Settings call sites. Windows now owns the conventional keyboard, type-ahead, focus, and screen-reader behavior.\n\nVerified with 175 frontend tests, the production build, and Prettier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only accessibility refactor of a shared select; no auth, data, or backend changes. Native OS dropdowns will look different from the old custom menu.
> 
> **Overview**
> Replaces the custom portaled dropdown in `Select` with a styled native `<select>` so language and history-retention settings get OS keyboard, type-ahead, and screen-reader behavior.
> 
> Adds a required `ariaLabel` and wires localized names at both Settings call sites. Drops open/close state, positioning, and click-outside handling. Adds unit tests for combobox naming, change events, placeholder, and disabled state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0d1bdc084d22a2f5c9fce252958844c4455b734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace custom `Select` with native `<select>` for accessibility
> - Rewrites `Select` to render a native `<select>` element instead of a custom popover menu, removing local state for positioning and outside-click handling.
> - Adds a required `ariaLabel` prop and updates `SettingsPanel` to pass translated labels for the language and history retention selectors.
> - Introduces a disabled placeholder `<option>` when the current value is missing from the provided options, coercing the select value to `''`.
> - Risk: Replacing the custom popover in [Select.tsx](https://github.com/tsouth89/cubby-clipboard/pull/293/files#diff-5f14fcc361c060c6bc80d0c66446a24095689a8164b106a654e3773fbb8da5c7) removes custom portals and positioning, which may alter visual styling and interaction behavior for existing consumers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0d1bdc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->