### PR TITLE
Guard History bulk deletes

### DIFF
--- a/frontend/src/components/ConfirmDialog.test.tsx
+++ b/frontend/src/components/ConfirmDialog.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConfirmDialog } from './ConfirmDialog';
+
+function renderDialog(overrides: Partial<ComponentProps<typeof ConfirmDialog>> = {}) {
+  const onConfirm = vi.fn();
+  const onCancel = vi.fn();
+  render(
+    <ConfirmDialog
+      isOpen
+      title="Delete 2 clips?"
+      message="Deleted clips cannot be recovered."
+      confirmText="Delete 2 clips"
+      cancelText="Cancel"
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+      {...overrides}
+    />
+  );
+  return { onConfirm, onCancel };
+}
+
+afterEach(cleanup);
+
+describe('ConfirmDialog', () => {
+  it('reports the exact action and supports cancel and confirm', () => {
+    const { onConfirm, onCancel } = renderDialog();
+
+    expect(screen.getByRole('dialog')).toHaveAccessibleName('Delete 2 clips?');
+    expect(screen.getByRole('dialog')).toHaveAccessibleDescription(
+      'Deleted clips cannot be recovered.'
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete 2 clips' }));
+
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('blocks repeated actions while busy', () => {
+    const { onConfirm, onCancel } = renderDialog({ isBusy: true });
+    const confirm = screen.getByRole('button', { name: 'Delete 2 clips' });
+    const cancel = screen.getByRole('button', { name: 'Cancel' });
+
+    expect(confirm).toBeDisabled();
+    expect(cancel).toBeDisabled();
+    fireEvent.click(confirm);
+    fireEvent.click(cancel);
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -74,6 +74,8 @@ export function HistoryWindow() {
   const [hasMore, setHasMore] = useState(true);
   const [totalClipCount, setTotalClipCount] = useState(0);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+  const [bulkDeleteBusy, setBulkDeleteBusy] = useState(false);
+  const bulkDeleteInFlightRef = useRef(false);
   const [settings, setSettings] = useState<Settings | null>(null);
   const [sourceApps, setSourceApps] = useState<SourceAppCount[]>([]);
   const [sourceApp, setSourceApp] = useState<string | null>(null);
@@ -406,7 +408,9 @@ export function HistoryWindow() {
   );
 
   const handleBulkDelete = useCallback(async () => {
-    if (selectionCount === 0) return;
+    if (selectionCount === 0 || bulkDeleteInFlightRef.current) return;
+    bulkDeleteInFlightRef.current = true;
+    setBulkDeleteBusy(true);
     try {
       // Same contract as single-clip delete: Cubby has no trash, so the payload
       // goes immediately rather than leaving a hidden soft-delete.
@@ -414,6 +418,7 @@ export function HistoryWindow() {
         ids: selectedIds,
         hardDelete: true,
       });
+      setBulkDeleteOpen(false);
       selectedIds.forEach((id) => forgetRevealed(id));
       // A failed reload already speaks: ClipList shows the error panel once
       // these rows are dropped. A superseded reload belongs to a newer load.
@@ -423,6 +428,9 @@ export function HistoryWindow() {
     } catch (error) {
       console.error('Failed to delete clips:', error);
       toast.error('Failed to delete clips');
+    } finally {
+      bulkDeleteInFlightRef.current = false;
+      setBulkDeleteBusy(false);
     }
   }, [afterBulkChange, forgetRevealed, selectedIds, selectionCount]);
 
@@ -1125,10 +1133,8 @@ export function HistoryWindow() {
         title={selectionCount === 1 ? 'Delete this clip?' : `Delete ${selectionCount} clips?`}
         message="Cubby has no trash. Deleted clips cannot be recovered."
         confirmText={selectionCount === 1 ? 'Delete clip' : `Delete ${selectionCount} clips`}
-        onConfirm={() => {
-          setBulkDeleteOpen(false);
-          void handleBulkDelete();
-        }}
+        isBusy={bulkDeleteBusy}
+        onConfirm={() => void handleBulkDelete()}
         onCancel={() => setBulkDeleteOpen(false)}
       />
     </div>


### PR DESCRIPTION
Fixes #184.

The confirmation now stays open and disables every dismissal and submit path while deletion runs. A synchronous in-flight guard blocks rapid repeat submissions, success closes the dialog, and failure keeps the selection available for retry.

Verified with 178 frontend tests, the production build, and Prettier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches irreversible hard-delete of selected clips and request in-flight handling. Scope is small and frontend-only, but a guard bug could still double-delete or leave the dialog stuck.
> 
> **Overview**
> Stops History bulk delete from firing twice and from dismissing the confirm dialog before the IPC call finishes.
> 
> Confirm now stays open with `isBusy` while `handleBulkDelete` runs. A ref plus busy state blocks overlapping submits. The dialog closes only after a successful `delete_clips`; failure leaves it open so the selection can be retried.
> 
> Adds `ConfirmDialog` tests for accessible name/description, confirm/cancel, and disabled buttons when busy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d6f4d077f4846bc2bb471e3aaf45c9e426b5187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard concurrent bulk deletes in `HistoryWindow`
> - Adds `bulkDeleteBusy` state and `bulkDeleteInFlightRef` to [HistoryWindow.tsx](https://github.com/tsouth89/cubby-clipboard/pull/295/files#diff-66e4a504891e766358388fbcc59de24cd17efafbabffdf4380b98891366560f2) to prevent concurrent bulk delete requests.
> - Passes `isBusy` to `ConfirmDialog`, keeping the dialog open with disabled buttons during the operation. The dialog closes only after a successful delete.
> - Adds tests for `ConfirmDialog` covering accessibility, callbacks, and disabled states when `isBusy` is true.
> - Behavioral Change: Clicking confirm on the bulk delete dialog no longer closes it immediately; it stays open and disabled until the delete completes successfully, remaining open on failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d6f4d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->