### PR TITLE
SBS-1071: Privacy and Settings must say skip gates block remote relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - Flood-dropping a queued self-paste echo no longer leaves the ignore hash swallowing the next real copy of that content (SBS-1039)
 - Recover a dest-gone rolling `cubby.db.bak` replace on FAT/exFAT instead of deleting the only remaining copy (SBS-1051)
 - Settings and the support FAQ no longer say the configured hotkey opens Cubby in remote sessions unless Replace Windows clipboard shortcut is on (SBS-1049)
+- Privacy and Settings no longer say skip-sensitive and skip-likely-secrets leave remote-session relay running (SBS-1071)
 - CI now publishes a stable `shipped-windows` check that fails when any SBS-779 `Check <arch> <features>` cargo-check fails. Branch protection on main still requires only `test` until a repo admin adds that name; the docs no longer claim the matrix legs already block merge (SBS-1025)
 
 ## v1.3.3

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -1226,7 +1226,7 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
                       <Row
                         title={'Sync clipboard between remote sessions'}
                         desc={
-                          'Re-announce anything copied inside a remote session so your other remote sessions pick it up. Copy in one session, Ctrl+V in another.'
+                          'Re-announce a copy from a remote session so your other remote sessions pick it up. Copies skipped as sensitive or as likely secrets are not relayed. Copy in one session, Ctrl+V in another.'
                         }
                         control={
                           <Toggle
@@ -1274,7 +1274,7 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
                       <Row
                         title={'Skip passwords and sensitive copies'}
                         desc={
-                          "When an app such as a password manager marks a copy as sensitive, Cubby won't save it (Windows' own clipboard history does the same). Turn this off to capture everything, including passwords."
+                          "When an app such as a password manager marks a copy as sensitive, Cubby won't save it (Windows' own clipboard history does the same) and won't relay it between remote sessions. Turn this off to capture everything, including passwords."
                         }
                         control={
                           <Toggle
@@ -1289,7 +1289,7 @@ export function SettingsPanel({ settings: initialSettings, onClose }: SettingsPa
                       <Row
                         title={'Skip likely secrets in text'}
                         desc={
-                          "Don't save text that looks like API tokens, private keys, or payment card numbers. Off by default. Turn it on if you'd rather keep these out of your history (the matching is conservative, but it can skip a clip you meant to keep). Large pastes are still checked: Cubby scans the first 8 KB, which is enough to catch those markers at the start of a log or key."
+                          "Don't save text that looks like API tokens, private keys, or payment card numbers, and don't relay those clips between remote sessions. Off by default. Turn it on if you'd rather keep these out of your history (the matching is conservative, but it can skip a clip you meant to keep). Large pastes are still checked: Cubby scans the first 8 KB, which is enough to catch those markers at the start of a log or key."
                         }
                         control={
                           <Toggle

--- a/product_pages/privacy.html
+++ b/product_pages/privacy.html
@@ -41,7 +41,7 @@
       <p class="eyebrow">Privacy</p>
       <h1>Your clipboard stays yours.</h1>
       <p>Cubby is built to keep clipboard history useful without turning it into a cloud service.</p>
-      <div class="legal-meta">Last updated August 22, 2026</div>
+      <div class="legal-meta">Last updated August 23, 2026</div>
     </header>
     <article class="legal-content">
       <div class="legal-callout"><p><strong>The short version:</strong> Cubby stores clipboard history locally on your Windows PC. The desktop app does not include analytics, advertising, cloud sync, or network-backed AI features. This website collects limited, privacy-preserving visit counts.</p></div>
@@ -54,7 +54,7 @@
       <p>You can export your clip history to a single encrypted file you choose on this PC, and import that file later here or on another machine. The archive holds each clip’s text, HTML and RTF copies, your notes, image thumbnails, any live full-resolution original, text recognized in images, and the source app, folder, pin state, and hidden state. Export refuses to write the file if a live original or format cannot be read, rather than writing an incomplete backup. An image whose full-resolution original has already been dropped by retention stays thumbnail-only, matching the live history. You choose the passphrase. Cubby does not store it, cannot recover it, and does not upload the file. Export decrypts your local history in memory and re-encrypts it into that portable archive. There is no cloud backup.</p>
 
       <h2>Remote-session clipboard</h2>
-      <p>When you copy inside a supported remote-control session, Cubby can rewrite that remote-owned clipboard onto the local clipboard so your other remote viewer sessions pick it up. Cubby only writes to the clipboard on this PC; the remote-control app you are using can then carry that content on to its other sessions and to the remote hosts they connect to. Cubby itself is not a cloud clipboard. The relay is on by default and skips a copy only when the remote viewer process itself (mstsc.exe and similar) is on the ignored list, not the application running on the remote host. The sensitive-content and skip-likely-secrets settings do not stop it. Turn it off in Settings under “Sync clipboard between remote sessions.”</p>
+      <p>When you copy inside a supported remote-control session, Cubby can rewrite that remote-owned clipboard onto the local clipboard so your other remote viewer sessions pick it up. Cubby only writes to the clipboard on this PC; the remote-control app you are using can then carry that content on to its other sessions and to the remote hosts they connect to. Cubby itself is not a cloud clipboard. The relay is on by default. It skips a copy when the remote viewer process itself (mstsc.exe and similar) is on the ignored list, not the application running on the remote host, and when Skip passwords and sensitive copies or Skip likely secrets in text would refuse the clip. Turn it off in Settings under “Sync clipboard between remote sessions.”</p>
 
       <h2>What Cubby does not collect</h2>
       <ul>

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -6,6 +6,7 @@ import { checkPrivilegedActionPins } from '../.github/scripts/check-privileged-a
 import {
   findFileListHistoryClaims,
   findStaleBackupOmissionClaims,
+  findStaleRemoteRelayPrivacyBypassClaims,
   findUnqualifiedRemoteHotkeyClaims,
   findWeakerFileRetentionClaim,
 } from './product-page-claims.mjs';
@@ -298,6 +299,18 @@ for (const [docName, doc] of userFacingHistoryDocs) {
   }
 }
 
+// SBS-1071: skip_sensitive and skip_likely_secrets return before
+// relay_remote_capture. Privacy and Settings once said those gates do
+// not stop remote relay, and that the relay re-announces "anything."
+for (const [docName, doc] of userFacingHistoryDocs) {
+  const [claim] = findStaleRemoteRelayPrivacyBypassClaims(doc);
+  if (claim) {
+    throw new Error(
+      `${docName} still claims skip-sensitive or skip-likely-secrets leave remote relay running: ${claim}`
+    );
+  }
+}
+
 // The hint is only true while replacement is on. An unconditional render
 // next to Remote session paste restated the Settings lie when the toggle
 // was off.
@@ -325,6 +338,36 @@ if (!/\bHTML\b/.test(backupSection) || !/\bRTF\b/.test(backupSection)) {
 if (!/\bfull[\s-]*resolution\b/i.test(backupSection)) {
   throw new Error(
     'product_pages/privacy.html must say encrypted backups include live full-resolution originals'
+  );
+}
+
+// SBS-1071: the remote-session section must keep saying the skip
+// gates stop relay, not only that ignored viewer processes do.
+const remoteSection = privacyPageDoc.match(
+  /<h2>Remote-session clipboard<\/h2>\s*<p>([\s\S]*?)<\/p>/
+)?.[1];
+if (!remoteSection) {
+  throw new Error('product_pages/privacy.html must keep a Remote-session clipboard section');
+}
+if (
+  !/\bsensitive\b/i.test(remoteSection) ||
+  !/\blikely[\s-]secrets?\b/i.test(remoteSection)
+) {
+  throw new Error(
+    'product_pages/privacy.html must say skip-sensitive and skip-likely-secrets stop remote relay'
+  );
+}
+const relayDesc = settingsPanelSource.match(
+  /Re-announce[\s\S]*?Ctrl\+V in another\./
+)?.[0];
+if (!relayDesc) {
+  throw new Error(
+    'Could not read the remote clipboard relay description in SettingsPanel.tsx'
+  );
+}
+if (!/\bsensitive\b/i.test(relayDesc) || !/\blikely secrets\b/i.test(relayDesc)) {
+  throw new Error(
+    'SettingsPanel remote clipboard relay description must say sensitive and likely-secret skips block relay'
   );
 }
 

--- a/scripts/product-page-claims.mjs
+++ b/scripts/product-page-claims.mjs
@@ -247,7 +247,7 @@ const RELAY_OR_REANNOUNCE = /\b(?:relay(?:s|ed|ing)?|re-?announce(?:s|d)?)\b/i;
 const SENSITIVE_OR_SECRETS =
   /\b(?:sensitive(?:[\s-]content)?|skip[\s-]likely[\s-]secrets|likely[\s-]secrets?)\b/i;
 const DO_NOT_STOP =
-  /\b(?:do\s+not|does\s+not|don[’']t|doesn[’']t|never)\s+stop\b/i;
+  /\b(?:do\s+not|does\s+not|don[’']t|doesn[’']t|never)\s+stops?\b/i;
 const ANYTHING_COPIED = /\banything\s+copied\b/i;
 const ONLY_WHEN_IGNORED =
   /\bskips?\s+a\s+copy\s+only\s+when\b/i;

--- a/scripts/product-page-claims.mjs
+++ b/scripts/product-page-claims.mjs
@@ -233,6 +233,56 @@ export function findUnqualifiedRemoteHotkeyClaims(source) {
 }
 
 /**
+ * SBS-1071: skip_sensitive and skip_likely_secrets return before
+ * relay_remote_capture (SBS-1001). Privacy and Settings once said those
+ * gates do not stop remote relay, that the relay re-announces "anything,"
+ * and that it skips a copy only for ignored viewer processes.
+ *
+ * A sentence is a claim when it is about remote-session relay and either
+ * says the skip-sensitive / skip-likely-secrets settings do not stop it,
+ * re-announces "anything copied," or skips a copy only for the ignored list.
+ * Accurate copy that says those settings also stop the relay is not a claim.
+ */
+const RELAY_OR_REANNOUNCE = /\b(?:relay(?:s|ed|ing)?|re-?announce(?:s|d)?)\b/i;
+const SENSITIVE_OR_SECRETS =
+  /\b(?:sensitive(?:[\s-]content)?|skip[\s-]likely[\s-]secrets|likely[\s-]secrets?)\b/i;
+const DO_NOT_STOP =
+  /\b(?:do\s+not|does\s+not|don[’']t|doesn[’']t|never)\s+stop\b/i;
+const ANYTHING_COPIED = /\banything\s+copied\b/i;
+const ONLY_WHEN_IGNORED =
+  /\bskips?\s+a\s+copy\s+only\s+when\b/i;
+
+export function findStaleRemoteRelayPrivacyBypassClaims(source) {
+  const claims = [];
+  const pieces = segments(source);
+  for (let i = 0; i < pieces.length; i++) {
+    const segment = pieces[i];
+    const previous = i > 0 ? pieces[i - 1] : '';
+    // The original privacy lie used "do not stop it" after a relay sentence.
+    const aboutRelay =
+      REMOTE_SESSION.test(segment) ||
+      RELAY_OR_REANNOUNCE.test(segment) ||
+      REMOTE_SESSION.test(previous) ||
+      RELAY_OR_REANNOUNCE.test(previous);
+    if (!aboutRelay) {
+      continue;
+    }
+    if (SENSITIVE_OR_SECRETS.test(segment) && DO_NOT_STOP.test(segment)) {
+      claims.push(segment);
+      continue;
+    }
+    if (ANYTHING_COPIED.test(segment) && RELAY_OR_REANNOUNCE.test(segment)) {
+      claims.push(segment);
+      continue;
+    }
+    if (ONLY_WHEN_IGNORED.test(segment) && /\bignored\s+list\b/i.test(segment)) {
+      claims.push(segment);
+    }
+  }
+  return claims;
+}
+
+/**
  * Weaker scan used by the release check: a sentence that says files are
  * retained or supported without also negating that. Broader than
  * `findFileListHistoryClaims` so "Cubby stores files" still fails even when

--- a/scripts/product-page-claims.test.mjs
+++ b/scripts/product-page-claims.test.mjs
@@ -8,6 +8,7 @@ import {
   claimSegments,
   findFileListHistoryClaims,
   findStaleBackupOmissionClaims,
+  findStaleRemoteRelayPrivacyBypassClaims,
   findUnqualifiedRemoteHotkeyClaims,
   findWeakerFileRetentionClaim,
 } from './product-page-claims.mjs';
@@ -422,5 +423,87 @@ test('live Settings and support copy name the Win+V replacement dependency', asy
   ]) {
     const source = await readFile(path.join(root, relative), 'utf8');
     assert.deepEqual(findUnqualifiedRemoteHotkeyClaims(source), [], relative);
+  }
+});
+
+// SBS-1071: after SBS-1001, skip_sensitive and skip_likely_secrets return
+// before relay_remote_capture. Privacy said those settings do not stop
+// the relay; Settings said it re-announces "anything."
+
+test('the original privacy.html relay-bypass sentence is a claim', () => {
+  const source =
+    'The relay is on by default. The sensitive-content and skip-likely-secrets settings do not stop it.';
+  const claims = findStaleRemoteRelayPrivacyBypassClaims(source);
+  assert.equal(claims.length, 1);
+  assert.match(claims[0], /do not stop it/);
+});
+
+test('the original privacy.html ignored-list-only sentence is a claim', () => {
+  const sentence =
+    'The relay is on by default and skips a copy only when the remote viewer process itself (mstsc.exe and similar) is on the ignored list, not the application running on the remote host.';
+  const claims = findStaleRemoteRelayPrivacyBypassClaims(sentence);
+  assert.equal(claims.length, 1);
+  assert.match(claims[0], /skips a copy only when/);
+});
+
+test('the original Settings anything-copied sentence is a claim', () => {
+  const sentence =
+    'Re-announce anything copied inside a remote session so your other remote sessions pick it up.';
+  const claims = findStaleRemoteRelayPrivacyBypassClaims(sentence);
+  assert.equal(claims.length, 1);
+  assert.match(claims[0], /anything copied/);
+});
+
+test('a restated relay-bypass claim is reported', () => {
+  assert.equal(
+    findStaleRemoteRelayPrivacyBypassClaims(
+      'Skip likely secrets does not stop remote-session relay.'
+    ).length,
+    1
+  );
+  assert.equal(
+    findStaleRemoteRelayPrivacyBypassClaims(
+      'The sensitive-content setting never stops the relay.'
+    ).length,
+    1
+  );
+});
+
+test('accurate relay copy is not reported', () => {
+  for (const sentence of [
+    'The skip-sensitive and skip-likely-secrets settings also stop it.',
+    'It skips a copy when the remote viewer process itself is on the ignored list, and when Skip passwords and sensitive copies or Skip likely secrets in text would refuse the clip.',
+    'Re-announce a copy from a remote session so your other remote sessions pick it up.',
+    'Copies skipped as sensitive or as likely secrets are not relayed.',
+  ]) {
+    assert.deepEqual(
+      findStaleRemoteRelayPrivacyBypassClaims(sentence),
+      [],
+      sentence
+    );
+  }
+});
+
+test('an unrelated do-not-stop sentence is not reported', () => {
+  assert.deepEqual(
+    findStaleRemoteRelayPrivacyBypassClaims(
+      'Cubby does not stop you from deleting a clip.'
+    ),
+    []
+  );
+});
+
+test('live privacy.html and Settings copy do not claim relay bypasses skip gates', async () => {
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  for (const relative of [
+    'product_pages/privacy.html',
+    'frontend/src/components/SettingsPanel.tsx',
+  ]) {
+    const source = await readFile(path.join(root, relative), 'utf8');
+    assert.deepEqual(
+      findStaleRemoteRelayPrivacyBypassClaims(source),
+      [],
+      relative
+    );
   }
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

After SBS-1001, `clipboard.rs` returns from skip-sensitive and skip-likely-secrets **before** `relay_remote_capture`. Privacy and Settings still said the opposite: ignored viewer processes were the only stop, and the relay re-announced “anything.”

This updates:

- `product_pages/privacy.html` — skip-sensitive and skip-likely-secrets now stop remote-session relay, along with an ignored viewer process
- Settings copy in `frontend/src/components/SettingsPanel.tsx` (post-#296; no i18n catalogs) — those gates block relay; the description no longer says “anything”
- The public-docs claim guard (same pattern as SBS-1028 / SBS-1049) so the old lie fails `release:check`. Live-source checks read `SettingsPanel.tsx`, not `en.json`.

No capture or relay behavior change.

Rebased onto `main` after #296.

Closes SBS-1071.

## Verification

- [x] I kept this pull request focused.
- [ ] I tested the change on Windows 11.
- [x] I added or updated tests where practical.
- [x] I updated documentation for changed behavior.
- [x] I did not include clipboard contents, credentials, signing material, or other secrets.

Local gates after rebase:

- `node --test scripts/product-page-claims.test.mjs` — 49 passed
- `pnpm run release:check` — Cubby Clipboard v1.3.3 release metadata is consistent

This is a docs/copy change. No Windows 11 UI run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c511496-8065-4f86-8597-e3fc7a98eb4d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c511496-8065-4f86-8597-e3fc7a98eb4d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix copy claiming skip gates don't block remote-session relay
> - Corrects the Privacy page and `SettingsPanel` relay descriptions to state that copies skipped as sensitive or likely secrets are not relayed, and that relay also skips when the viewer is on the ignored list.
> - Adds `findStaleRemoteRelayPrivacyBypassClaims` in [product-page-claims.mjs](https://github.com/tsouth89/cubby-clipboard/pull/298/files#diff-4971434621030568f03454596f791852ca2d50bf85d07a35065be9ffb776a524) with unit tests, and wires it into [check-release.mjs](https://github.com/tsouth89/cubby-clipboard/pull/298/files#diff-14ac66f5d0a1f9e003460f1b27bce6e68f7665390d99e23d897038130d21cdca) to scan user-facing docs for stale bypass claims and enforce required wording.
> - Behavioral Change: the release check now fails if any doc claims remote-session relay ignores skip-sensitive/skip-likely-secrets, if [privacy.html](https://github.com/tsouth89/cubby-clipboard/pull/298/files#diff-c9d4b5077587a9c3753be84f19d211791e5993b7643fa2747aa2123ab4cb3726) omits those gates in the remote-session section, or if the `SettingsPanel` relay description omits 'sensitive' and 'likely secrets'.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6dda945.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->