### PR TITLE
Give History an accessible list focus model

### DIFF
--- a/frontend/src/components/ClipList.test.tsx
+++ b/frontend/src/components/ClipList.test.tsx
@@ -1,0 +1,132 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { ClipboardItem } from '../types';
+import { ClipList } from './ClipList';
+
+const clips: ClipboardItem[] = [
+  {
+    id: 'first',
+    clip_type: 'text',
+    content: 'First clip',
+    preview: 'First clip',
+    folder_id: null,
+    is_pinned: false,
+    created_at: '2026-08-23T12:00:00Z',
+    source_app: 'Notepad',
+    source_icon: null,
+    metadata: null,
+    ocr_match: null,
+  },
+  {
+    id: 'second',
+    clip_type: 'text',
+    content: 'Second clip',
+    preview: 'Second clip',
+    folder_id: null,
+    is_pinned: false,
+    created_at: '2026-08-23T12:01:00Z',
+    source_app: 'Notepad',
+    source_icon: null,
+    metadata: null,
+    ocr_match: null,
+  },
+];
+
+beforeAll(() => {
+  HTMLElement.prototype.scrollTo = vi.fn();
+  HTMLElement.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(cleanup);
+
+function listProps(overrides: Partial<ComponentProps<typeof ClipList>> = {}) {
+  return {
+    clips,
+    isLoading: false,
+    hasMore: false,
+    resetToken: 0,
+    density: 'comfortable' as const,
+    selectedClipId: 'first',
+    loadError: false,
+    emptyTitle: 'No clips',
+    emptyDescription: 'Copy something.',
+    onSelectClip: vi.fn(),
+    onPaste: vi.fn(),
+    onCopy: vi.fn(),
+    onTogglePin: vi.fn(),
+    onLoadMore: vi.fn(),
+    onRetry: vi.fn(),
+    keyboardNavigation: true,
+    ...overrides,
+  };
+}
+
+describe('ClipList History focus model', () => {
+  it('owns focus and exposes the selected option as its active descendant', () => {
+    const props = listProps();
+    const { rerender } = render(<ClipList {...props} />);
+    const listbox = screen.getByRole('listbox', { name: 'Clipboard history' });
+
+    expect(listbox).toHaveAttribute('tabindex', '0');
+    expect(listbox).toHaveAttribute('aria-activedescendant', 'clip-option-first');
+    expect(screen.getAllByRole('option')[0]).toHaveAttribute('aria-posinset', '1');
+
+    listbox.focus();
+    rerender(
+      <ClipList
+        {...props}
+        clips={[...clips, { ...clips[1], id: 'third', content: 'Third clip' }]}
+        selectedClipId="second"
+        hasMore
+      />
+    );
+
+    expect(document.activeElement).toBe(listbox);
+    expect(listbox).toHaveAttribute('aria-activedescendant', 'clip-option-second');
+
+    rerender(<ClipList {...props} clips={[clips[1]]} selectedClipId="second" resetToken={1} />);
+    expect(document.activeElement).toBe(listbox);
+    expect(listbox).toHaveAttribute('aria-activedescendant', 'clip-option-second');
+  });
+
+  it('moves selection with arrows only while the listbox owns the key', () => {
+    const onSelectClip = vi.fn();
+    render(
+      <ClipList {...listProps({ onSelectClip, selectable: true, checkedIds: new Set<string>() })} />
+    );
+    const listbox = screen.getByRole('listbox');
+
+    fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+    expect(onSelectClip).toHaveBeenCalledWith('second');
+
+    onSelectClip.mockClear();
+    fireEvent.keyDown(screen.getAllByRole('checkbox')[0], { key: 'ArrowDown' });
+    expect(onSelectClip).not.toHaveBeenCalled();
+  });
+
+  it('keeps mouse and modifier multi-select gestures unchanged', () => {
+    const onPaste = vi.fn();
+    const onToggleSelect = vi.fn();
+    render(
+      <ClipList
+        {...listProps({
+          onPaste,
+          selectable: true,
+          checkedIds: new Set<string>(),
+          onToggleSelect,
+        })}
+      />
+    );
+    const listbox = screen.getByRole('listbox');
+    const firstOption = screen.getAllByRole('option')[0];
+
+    fireEvent.mouseDown(firstOption);
+    fireEvent.click(firstOption);
+    expect(document.activeElement).toBe(listbox);
+    expect(onPaste).toHaveBeenCalledOnce();
+
+    fireEvent.click(firstOption, { ctrlKey: true });
+    expect(onToggleSelect).toHaveBeenCalledWith('first', 0, expect.anything());
+  });
+});

--- a/frontend/src/components/ClipList.tsx
+++ b/frontend/src/components/ClipList.tsx
@@ -36,6 +36,9 @@ interface ClipListProps {
   checkedIds?: ReadonlySet<string>;
   /** Toggle multi-selection for a row, given its index for shift-extend. */
   onToggleSelect?: (clipId: string, index: number, event: React.MouseEvent) => void;
+  /** Makes the listbox the History window's keyboard focus owner. The flyout
+   *  keeps focus in its search field and therefore leaves this off. */
+  keyboardNavigation?: boolean;
 }
 
 export function ClipList({
@@ -61,6 +64,7 @@ export function ClipList({
   selectable = false,
   checkedIds,
   onToggleSelect,
+  keyboardNavigation = false,
 }: ClipListProps) {
   const listRef = useRef<HTMLDivElement>(null);
   // Arrow-key navigation can scroll a card under a stationary cursor and fire
@@ -79,6 +83,25 @@ export function ClipList({
       ?.querySelector<HTMLElement>(`[data-clip-id="${CSS.escape(selectedClipId)}"]`)
       ?.scrollIntoView({ block: 'nearest' });
   }, [selectedClipId]);
+
+  const handleListKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    // Interactive descendants keep their native key handling. Only the
+    // listbox itself owns History's Up/Down selection model.
+    if (!keyboardNavigation || event.target !== event.currentTarget) return;
+    if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return;
+
+    event.preventDefault();
+    const selectedIndex = clips.findIndex((clip) => clip.id === selectedClipId);
+    const nextIndex =
+      selectedIndex < 0
+        ? 0
+        : Math.min(
+            Math.max(selectedIndex + (event.key === 'ArrowDown' ? 1 : -1), 0),
+            clips.length - 1
+          );
+    const nextClip = clips[nextIndex];
+    if (nextClip) onSelectClip(nextClip.id);
+  };
 
   if (isLoading && clips.length === 0) {
     return (
@@ -128,7 +151,25 @@ export function ClipList({
       id="clip-listbox"
       role="listbox"
       aria-label="Clipboard history"
-      className={`no-scrollbar overflow-y-auto px-2 pb-2 ${errorSurface === 'banner' ? 'min-h-0 flex-1' : 'h-full'}`}
+      // History keeps DOM focus here while aria-activedescendant moves through
+      // the options. That lets Narrator announce the selected clip and its
+      // aria-posinset position without moving focus away from the list.
+      tabIndex={keyboardNavigation ? 0 : undefined}
+      aria-activedescendant={
+        keyboardNavigation && selectedClipId && clips.some((clip) => clip.id === selectedClipId)
+          ? `clip-option-${selectedClipId}`
+          : undefined
+      }
+      onKeyDown={handleListKeyDown}
+      onMouseDown={(event) => {
+        if (!keyboardNavigation) return;
+        const target = event.target as Element;
+        if (target.closest('button, input, select, textarea, a, [contenteditable="true"]')) return;
+        // A mouse-selected option and the next arrow press must use the same
+        // composite widget. Keep nested controls focusable in their own right.
+        event.currentTarget.focus({ preventScroll: true });
+      }}
+      className={`no-scrollbar overflow-y-auto px-2 pb-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/70 ${errorSurface === 'banner' ? 'min-h-0 flex-1' : 'h-full'}`}
       onScroll={(event) => {
         if (!hasMore || isLoading) return;
         const element = event.currentTarget;

--- a/frontend/src/windows/HistoryWindow.tsx
+++ b/frontend/src/windows/HistoryWindow.tsx
@@ -757,6 +757,8 @@ export function HistoryWindow() {
         event.target,
         '[data-el="history-search-input"]'
       );
+      const isClipListFocusOwner =
+        event.target instanceof Element && event.target.matches('[data-el="clip-list"]');
 
       if (event.key === 'Escape') {
         // Search is an INPUT, so isEditing is true there; Escape still clears
@@ -775,22 +777,10 @@ export function HistoryWindow() {
         document.querySelector<HTMLInputElement>('[data-el="history-search-input"]')?.focus();
         return;
       }
-      // Arrow keys move the list selection, but not while the caret is in the
-      // search box — there they belong to the input, or typing becomes
-      // unworkable without a mouse.
-      if ((event.key === 'ArrowUp' || event.key === 'ArrowDown') && !isInteractive) {
-        const list = clipsRef.current;
-        if (list.length === 0) return;
-        event.preventDefault();
-        const index = list.findIndex((clip) => clip.id === selectedClipId);
-        const nextIndex =
-          index < 0
-            ? 0
-            : Math.min(Math.max(index + (event.key === 'ArrowDown' ? 1 : -1), 0), list.length - 1);
-        setSelectedClipId(list[nextIndex].id);
-        return;
-      }
-      if (isInteractive) return;
+      // The listbox is intentionally interactive, but its active descendant
+      // still uses History's Enter and Delete actions. Nested controls remain
+      // excluded because only the listbox element itself qualifies here.
+      if (isInteractive && !isClipListFocusOwner) return;
       if (event.key === 'Enter' && selectedClipId) {
         event.preventDefault();
         handleCopy(selectedClipId, event.shiftKey);
@@ -1074,6 +1064,7 @@ export function HistoryWindow() {
             // somewhere else.
             selectOnHover={false}
             selectable
+            keyboardNavigation
             checkedIds={selection.ids}
             onToggleSelect={handleToggleSelect}
             onSelectClip={setSelectedClipId}
@@ -1112,6 +1103,9 @@ export function HistoryWindow() {
       <footer className="flex h-9 shrink-0 items-center border-t border-border px-4 text-[10px] text-muted-foreground">
         <span>{totalClipCount.toLocaleString()} items</span>
         <div className="ml-auto flex items-center gap-3">
+          <span>
+            <kbd>↑↓</kbd> Select
+          </span>
           <span>
             <kbd>Enter</kbd> Copy
           </span>


### PR DESCRIPTION
Closes #187

Makes the History listbox own keyboard focus and expose its selected option through `aria-activedescendant`. Arrow keys now belong to that owner, while nested controls keep their native key handling. Mouse and multi-select behavior are covered too.

Checked with 181 frontend tests, lint, build, formatting, and release checks. A Windows Narrator smoke test is still needed before release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Keyboard and focus routing in History is easy to get wrong for screen readers and nested controls, but the flyout path is unchanged and behavior is covered by new tests.
> 
> **Overview**
> History now treats the clip list as a real composite listbox: it owns keyboard focus and points screen readers at the selected option via `aria-activedescendant`.
> 
> Arrow Up/Down move selection only when the listbox itself has the key. Nested controls keep native handling. Clicking a row focuses the list so the next arrow continues from that selection. Enter and Delete still copy/delete the active clip.
> 
> The flyout is unchanged (`keyboardNavigation` stays off so search keeps focus). Tests cover focus ownership, arrow routing, and mouse/multi-select.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98a0e9f29bd739e23e83419944ab2c1b494a4079. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add accessible focus model with `keyboardNavigation` prop to `ClipList`
> - Adds the `keyboardNavigation` prop to `ClipList` to let the listbox own DOM focus in the History window.
> - When enabled, the list container gets `tabIndex=0`, uses `aria-activedescendant` for the active option, and handles `ArrowUp`/`ArrowDown` selection internally.
> - Updates `HistoryWindow` to enable this mode, dropping its global arrow key handler and allowing `Enter`/`Delete` shortcuts to fire when the listbox has focus.
> - Risk: `HistoryWindow` removes window-level `ArrowUp`/`ArrowDown` handling; arrow navigation now requires the listbox element to have focus.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 98a0e9f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->