### PR TITLE
Refuse restaging over a dest-gone image leave-temp (SBS-1073)

### DIFF
--- a/src-tauri/src/image_persist.rs
+++ b/src-tauri/src/image_persist.rs
@@ -68,9 +68,10 @@ impl Drop for StagedImageFile {
 }
 
 /// Encrypt and write the new original to a sibling temp file without touching
-/// the live `{uuid}.cubby`. `std::fs::write` truncates on open, so writing the
-/// live name in place would destroy the previous good file if the write failed
-/// mid-stream.
+/// the live `{uuid}.cubby`. The temp is created with `create_new` so a dest-gone
+/// leave-temp (the only remaining original after SBS-1030) cannot be truncated
+/// by same-uuid restaging (SBS-1073). Writing the live name in place would
+/// destroy the previous good file if the write failed mid-stream.
 pub(crate) fn stage_full_image_file(
     crypto: &CryptoManager,
     image_dir: &Path,
@@ -81,7 +82,7 @@ pub(crate) fn stage_full_image_file(
     let final_path = image_dir.join(format!("{}.cubby", clip_uuid));
     let temp_path = image_dir.join(format!("{}.cubby.tmp", clip_uuid));
     let encrypted = crypto.encrypt(png_bytes)?;
-    std::fs::write(&temp_path, encrypted).map_err(|e| e.to_string())?;
+    crate::image_stage::write_staged_image_temp(&temp_path, &encrypted)?;
     Ok(StagedImageFile {
         temp_path,
         final_path,
@@ -355,6 +356,86 @@ mod tests {
         assert!(
             !temp_path.exists(),
             "recovery consumes the temp so Drop has nothing to delete"
+        );
+
+        let _ = std::fs::remove_dir_all(&image_dir);
+    }
+
+    /// SBS-1073: a dest-gone leave-temp is the only remaining original. Same-uuid
+    /// restaging used `fs::write`, which truncates that file on open. The retry
+    /// must fail the create instead of destroying those bytes.
+    #[test]
+    fn restaging_does_not_overwrite_a_dest_gone_leave_temp() {
+        let crypto = CryptoManager::ephemeral();
+        let image_dir = std::env::temp_dir().join(format!(
+            "cubby-image-restage-leave-temp-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&image_dir).unwrap();
+        let uuid = "dest-gone-restage";
+        let live_path = image_dir.join(format!("{uuid}.cubby"));
+        let temp_path = image_dir.join(format!("{uuid}.cubby.tmp"));
+        let leave_temp_bytes = crypto.encrypt(b"only-remaining-original").unwrap();
+        std::fs::write(&temp_path, &leave_temp_bytes).unwrap();
+        assert!(
+            !live_path.exists(),
+            "this is the dest-gone leave-temp case: no live original"
+        );
+
+        let staged = stage_full_image_file(&crypto, &image_dir, uuid, b"retry-full-res");
+        assert!(
+            staged.is_err(),
+            "restaging must refuse to open the existing leave-temp: {staged:?}"
+        );
+        let error = staged.unwrap_err();
+        assert!(
+            error.contains("refusing to overwrite"),
+            "the error should describe the staging-file conflict: {}",
+            error
+        );
+        assert_eq!(
+            std::fs::read(&temp_path).expect("leave-temp must still exist"),
+            leave_temp_bytes,
+            "restaging must not truncate the dest-gone leave-temp"
+        );
+        assert_eq!(
+            read_original(&crypto, &temp_path.to_string_lossy()),
+            b"only-remaining-original"
+        );
+        assert!(
+            !live_path.exists(),
+            "a refused restage must not invent a live original"
+        );
+
+        let _ = std::fs::remove_dir_all(&image_dir);
+    }
+
+    /// A leftover temp beside a live dest is not the only copy, but restaging
+    /// still must not truncate it. `create_new` treats that the same as dest-gone.
+    #[test]
+    fn restaging_does_not_overwrite_an_existing_temp_beside_a_live_original() {
+        let crypto = CryptoManager::ephemeral();
+        let image_dir = std::env::temp_dir().join(format!(
+            "cubby-image-restage-beside-live-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let uuid = "restage-beside-live";
+        let live_path =
+            persist_full_image_file(&crypto, &image_dir, uuid, b"previous-full-res").unwrap();
+        let temp_path = image_dir.join(format!("{uuid}.cubby.tmp"));
+        let leftover_bytes = crypto.encrypt(b"leftover-staging-bytes").unwrap();
+        std::fs::write(&temp_path, &leftover_bytes).unwrap();
+
+        let staged = stage_full_image_file(&crypto, &image_dir, uuid, b"retry-full-res");
+        assert!(
+            staged.is_err(),
+            "restaging must refuse to open an existing staging file: {staged:?}"
+        );
+        assert_eq!(read_original(&crypto, &live_path), b"previous-full-res");
+        assert_eq!(
+            std::fs::read(&temp_path).expect("leftover temp must still exist"),
+            leftover_bytes,
+            "restaging must not truncate a leftover staging file"
         );
 
         let _ = std::fs::remove_dir_all(&image_dir);
@@ -998,6 +1079,80 @@ mod tests {
         assert!(
             !image_dir.join(format!("{uuid}.cubby.tmp")).exists(),
             "a committed staged file must leave no temp file behind"
+        );
+
+        let _ = std::fs::remove_dir_all(&image_dir);
+    }
+
+    /// SBS-1073 on the expired-revival Capture retry: dest is already gone
+    /// (retention), and a prior dest-gone commit left `{uuid}.cubby.tmp` as the
+    /// only remaining original. Restaging that uuid must fail the recapture
+    /// without truncating those bytes, and the row must stay expired.
+    #[tokio::test]
+    async fn restaging_an_expired_revive_does_not_overwrite_the_leave_temp() {
+        let pool = recapture_pool().await;
+        let crypto = CryptoManager::ephemeral();
+        let image_dir = std::env::temp_dir().join(format!(
+            "cubby-recapture-restage-leave-temp-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&image_dir).unwrap();
+        let uuid = "expired-image-restage";
+        let (old_content, old_preview) = seed_expired_image_clip(&pool, &crypto, uuid).await;
+
+        let temp_path = image_dir.join(format!("{uuid}.cubby.tmp"));
+        let leave_temp_bytes = crypto.encrypt(b"only-remaining-original").unwrap();
+        std::fs::write(&temp_path, &leave_temp_bytes).unwrap();
+
+        let staged = stage_full_image_file(&crypto, &image_dir, uuid, b"retry-full-res");
+        assert!(
+            staged.is_err(),
+            "expired-revival restaging must refuse to overwrite the leave-temp"
+        );
+
+        let recapture = apply_existing_image_recapture(
+            &pool,
+            uuid,
+            staged,
+            b"retry-full-res".len() as i64,
+            new_fields(b"new-thumbnail", "new-preview"),
+        )
+        .await;
+        assert!(
+            recapture.is_err(),
+            "a refused restage must fail the recapture, not continue as success"
+        );
+
+        let row = load_recapture_row(&pool, uuid).await;
+        assert_eq!(row.0, old_content, "thumbnail must stay the expired one");
+        assert_eq!(
+            row.1.as_deref(),
+            Some(old_preview.as_str()),
+            "preview must stay the expired one"
+        );
+        assert_eq!(
+            row.3, 1,
+            "a refused revive must keep full_image_expired so Paste still says expired"
+        );
+
+        let indexed: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM clip_images WHERE clip_uuid = ?")
+                .bind(uuid)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            indexed, 0,
+            "no clip_images row may name an original that is not on disk"
+        );
+        assert_eq!(
+            std::fs::read(&temp_path).expect("leave-temp must still exist"),
+            leave_temp_bytes,
+            "the dest-gone leave-temp must stay byte-identical through the retry"
+        );
+        assert!(
+            !image_dir.join(format!("{uuid}.cubby")).exists(),
+            "a refused restage must not invent a live original"
         );
 
         let _ = std::fs::remove_dir_all(&image_dir);

--- a/src-tauri/src/image_persist.rs
+++ b/src-tauri/src/image_persist.rs
@@ -383,15 +383,13 @@ mod tests {
         );
 
         let staged = stage_full_image_file(&crypto, &image_dir, uuid, b"retry-full-res");
-        assert!(
-            staged.is_err(),
-            "restaging must refuse to open the existing leave-temp: {staged:?}"
-        );
-        let error = staged.unwrap_err();
+        let error = match staged {
+            Ok(_) => panic!("restaging must refuse to open the existing leave-temp"),
+            Err(error) => error,
+        };
         assert!(
             error.contains("refusing to overwrite"),
-            "the error should describe the staging-file conflict: {}",
-            error
+            "the error should describe the staging-file conflict: {error}"
         );
         assert_eq!(
             std::fs::read(&temp_path).expect("leave-temp must still exist"),
@@ -429,7 +427,7 @@ mod tests {
         let staged = stage_full_image_file(&crypto, &image_dir, uuid, b"retry-full-res");
         assert!(
             staged.is_err(),
-            "restaging must refuse to open an existing staging file: {staged:?}"
+            "restaging must refuse to open an existing staging file"
         );
         assert_eq!(read_original(&crypto, &live_path), b"previous-full-res");
         assert_eq!(

--- a/src-tauri/src/image_stage.rs
+++ b/src-tauri/src/image_stage.rs
@@ -1,0 +1,148 @@
+//! Exclusive write for `{uuid}.cubby.tmp`.
+//!
+//! `std::fs::write` truncates on open. After a dest-gone leave-temp (SBS-1030)
+//! that file can be the only remaining original, and same-uuid restaging —
+//! expired revival retries Capture — must not destroy it (SBS-1073). Backup
+//! already uses `create_new` for this class of hazard.
+//!
+//! No crate dependencies so `rustc --test src-tauri/src/image_stage.rs` can
+//! prove the overwrite refusal on Linux. Windows CI runs the same tests via
+//! `cargo test --all-targets`.
+
+use std::io::Write;
+use std::path::Path;
+
+/// Write `bytes` only if `path` does not already exist. An existing dest-gone
+/// leave-temp is left byte-identical; the caller sees a conflict error.
+pub(crate) fn write_staged_image_temp(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| {
+            if error.kind() == std::io::ErrorKind::AlreadyExists {
+                format!(
+                    "refusing to overwrite existing staging file {}",
+                    path.display()
+                )
+            } else {
+                error.to_string()
+            }
+        })?;
+    if let Err(error) = file.write_all(bytes).and_then(|_| file.sync_all()) {
+        drop(file);
+        let _ = std::fs::remove_file(path);
+        return Err(error.to_string());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_staged_image_temp;
+    use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    fn test_dir() -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "cubby-sbs-1073-{}-{}",
+            std::process::id(),
+            TEST_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// SBS-1073: dest-gone leave-temp is the only remaining original. Restaging
+    /// the same uuid must fail instead of truncating those bytes.
+    #[test]
+    fn restaging_does_not_overwrite_a_dest_gone_leave_temp() {
+        let dir = test_dir();
+        let dest = dir.join("abc.cubby");
+        let tmp = dir.join("abc.cubby.tmp");
+        fs::write(&tmp, b"only-remaining-original").unwrap();
+        assert!(!dest.exists());
+
+        let staged = write_staged_image_temp(&tmp, b"retry-full-res");
+        assert!(
+            staged.is_err(),
+            "restaging must refuse to open the existing leave-temp: {:?}",
+            staged
+        );
+        let error = staged.unwrap_err();
+        assert!(
+            error.contains("refusing to overwrite"),
+            "the error should describe the staging-file conflict: {}",
+            error
+        );
+        assert_eq!(
+            fs::read(&tmp).expect("leave-temp must still exist"),
+            b"only-remaining-original",
+            "restaging must not truncate the dest-gone leave-temp"
+        );
+        assert!(
+            !dest.exists(),
+            "a refused restage must not invent a live original"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// A leftover temp beside a live dest is not the only copy, but restaging
+    /// still must not truncate it. `create_new` treats that the same as dest-gone.
+    #[test]
+    fn restaging_does_not_overwrite_an_existing_temp_beside_a_live_original() {
+        let dir = test_dir();
+        let dest = dir.join("abc.cubby");
+        let tmp = dir.join("abc.cubby.tmp");
+        fs::write(&dest, b"previous-full-res").unwrap();
+        fs::write(&tmp, b"leftover-staging-bytes").unwrap();
+
+        let staged = write_staged_image_temp(&tmp, b"retry-full-res");
+        assert!(
+            staged.is_err(),
+            "restaging must refuse to open an existing staging file: {:?}",
+            staged
+        );
+        assert_eq!(fs::read(&dest).unwrap(), b"previous-full-res");
+        assert_eq!(
+            fs::read(&tmp).expect("leftover temp must still exist"),
+            b"leftover-staging-bytes",
+            "restaging must not truncate a leftover staging file"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn staging_writes_when_the_temp_name_is_free() {
+        let dir = test_dir();
+        let tmp = dir.join("abc.cubby.tmp");
+
+        write_staged_image_temp(&tmp, b"new-full-res").expect("a free staging name must succeed");
+        assert_eq!(fs::read(&tmp).unwrap(), b"new-full-res");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Occupying the staging name with a directory must fail without inventing
+    /// a live original. Same collision class as the persist-path test.
+    #[test]
+    fn staging_fails_when_the_temp_name_is_a_directory() {
+        let dir = test_dir();
+        let dest = dir.join("abc.cubby");
+        let tmp = dir.join("abc.cubby.tmp");
+        fs::write(&dest, b"previous-full-res").unwrap();
+        fs::create_dir(&tmp).unwrap();
+
+        let staged = write_staged_image_temp(&tmp, b"new-full-res");
+        assert!(
+            staged.is_err(),
+            "a directory on the staging name must fail the write: {:?}",
+            staged
+        );
+        assert_eq!(fs::read(&dest).unwrap(), b"previous-full-res");
+        assert!(tmp.is_dir(), "the colliding directory must be left alone");
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,6 +39,7 @@ mod crypto;
 mod database;
 mod ditto_import;
 mod image_persist;
+mod image_stage;
 mod log_targets;
 mod managed_image;
 mod models;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Fixes [SBS-1073](https://linear.app/southforge/issue/SBS-1073): same-uuid `stage_full_image_file` used `fs::write` on the fixed `{uuid}.cubby.tmp` name. After an SBS-1030 dest-gone mid-replace, that temp is the only remaining original (expired revival retries Capture). `fs::write` truncates on open, so the retry destroyed those bytes before a durable new copy existed.

Backup already refuses this class of hazard with `create_new`. Image staging uses a **fixed** temp name (dest-gone sweep computes dest as `name.strip_suffix(".tmp")` ΓåÆ `{uuid}.cubby`), so unique names / rename-aside would break SBS-1030 promotion. The matching safe pattern is `create_new` + conflict failure: restaging leaves the leave-temp byte-identical and fails the recapture. Next launch still promotes the leftover via `sweep_stale_image_temps`.

`write_staged_image_temp` lives in `image_stage.rs` so `rustc --test src-tauri/src/image_stage.rs` can pin the I/O contract on Linux. `stage_full_image_file` and the expired-revive recapture path call it.

## Sibling overwrite sweep

Production write-then-replace temps:

| Path | Temp name | Write | Verdict |
| --- | --- | --- | --- |
| `image_persist::stage_full_image_file` | fixed `{uuid}.cubby.tmp` | was `fs::write` | **this bug** ΓÇö now `create_new` |
| `backup::write_backup_temp` | unique `.{pid}.{uuid}.tmp` | `create_new` | already safe |
| `database` rolling backup | unique `*.bak.{pid}.{uuid}.tmp` | `fs::copy` to a unique name | collision improbable |
| `crypto` storage key | unique `storage.key.{pid}.{uuid}.tmp` | `fs::write` to a unique name | collision improbable |
| `settings_manager::save` | fixed `settings.json.tmp` | `fs::write` | **same class**: dest-gone leftover + a later save truncates the only remaining preferences. Not changed here (SBS-935 family). |

No other writer targets `{uuid}.cubby.tmp`.

## Verification

- [x] I kept this pull request focused.
- [x] Windows 11 coverage is the GitHub `windows-latest` `test` job (same flags as `.github/workflows/ci.yml`).
- [x] I added or updated tests where practical.
- [x] I updated documentation for changed behavior.
- [x] I did not include clipboard contents, credentials, signing material, or other secrets.

### Fail-without-fix

`write_staged_image_temp` temporarily implemented as `fs::write`. `rustc --test src-tauri/src/image_stage.rs`:

```
running 4 tests
test tests::restaging_does_not_overwrite_a_dest_gone_leave_temp ... FAILED
test tests::restaging_does_not_overwrite_an_existing_temp_beside_a_live_original ... FAILED
test tests::staging_fails_when_the_temp_name_is_a_directory ... ok
test tests::staging_writes_when_the_temp_name_is_free ... ok

failures:
    tests::restaging_does_not_overwrite_a_dest_gone_leave_temp
    tests::restaging_does_not_overwrite_an_existing_temp_beside_a_live_original

test result: FAILED. 2 passed; 2 failed
```

The dest-gone case panicked at `restaging must refuse to open the existing leave-temp` ΓÇö `fs::write` returned `Ok` and had already truncated the leave-temp.

### After `create_new` (Linux, `rustc --test`)

```
$ rustc --test src-tauri/src/image_stage.rs -D warnings -o /tmp/image_stage_test && /tmp/image_stage_test
running 4 tests
test tests::staging_fails_when_the_temp_name_is_a_directory ... ok
test tests::restaging_does_not_overwrite_a_dest_gone_leave_temp ... ok
test tests::restaging_does_not_overwrite_an_existing_temp_beside_a_live_original ... ok
test tests::staging_writes_when_the_temp_name_is_free ... ok
test result: ok. 4 passed; 0 failed
```

Crate-level tests in `image_persist.rs` go through `stage_full_image_file` (encrypted bytes) and `apply_existing_image_recapture` on an expired revive so a revert to `fs::write` there still fails.

Related dest-gone contracts still pass:

```
$ rustc --test src-tauri/src/settings_load.rs && ./settings_load dest_gone
test tests::image_persist_dest_gone_recovers_instead_of_deleting_the_only_copy ... ok
test tests::dest_gone_rename_does_not_touch_an_existing_destination ... ok
test tests::dest_gone_rename_puts_temp_in_place ... ok
test tests::rolling_backup_dest_gone_recovers_instead_of_deleting_the_only_copy ... ok
```

### CI gate (GitHub `windows-latest`, run [32670607424](https://github.com/tsouth89/cubby-clipboard/actions/runs/32670607424), commit `a64f6df`)

Same commands as `.github/workflows/ci.yml`:

```
$ cargo fmt --manifest-path src-tauri/Cargo.toml --check
# exit 0 (test job, 2026-08-23T22:30:15Z)

$ cargo test --manifest-path src-tauri/Cargo.toml --all-targets
# Finished `test` profile in 42.43s
# running 526 tests
test image_persist::tests::restaging_an_expired_revive_does_not_overwrite_the_leave_temp ... ok
test image_persist::tests::restaging_does_not_overwrite_a_dest_gone_leave_temp ... ok
test image_persist::tests::restaging_does_not_overwrite_an_existing_temp_beside_a_live_original ... ok
test image_stage::tests::restaging_does_not_overwrite_a_dest_gone_leave_temp ... ok
test image_stage::tests::restaging_does_not_overwrite_an_existing_temp_beside_a_live_original ... ok
test image_stage::tests::staging_fails_when_the_temp_name_is_a_directory ... ok
test image_stage::tests::staging_writes_when_the_temp_name_is_free ... ok
test result: ok. 524 passed; 0 failed; 2 ignored
test result: ok. 13 passed; 0 failed

$ cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
# Finished `dev` profile in 12.08s
```

All 12 checks on the PR head passed (`test`, `shipped-windows`, four `Check <arch> <features>` legs, CodeQL).


<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9327f6fa-38c6-4ad6-b46c-e78f59620e03?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9327f6fa-38c6-4ad6-b46c-e78f59620e03&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse restaging over a dest-gone image leave-temp in `stage_full_image_file`
> - Adds `write_staged_image_temp` helper in [image_stage.rs](https://github.com/tsouth89/cubby-clipboard/pull/300/files#diff-2c3b0b6c82e79839c99d51257e474bbb25a446b517959c74d384326e980c9294) that opens staging paths with exclusive creation, maps existing-path collisions to an explicit refusal error, and removes partial files on write/sync failure
> - Changes `stage_full_image_file` in [image_persist.rs](https://github.com/tsouth89/cubby-clipboard/pull/300/files#diff-aca32a5e129a1566b01ef4d4ef0468598aa604fca59c8d800e16610bb12a84df) to delegate temp-file creation to this helper instead of truncating the destination directly
> - Adds regression tests covering dest-gone leave-temp preservation, existing-temp-beside-live-original collisions, expired-revive recapture refusal, and directory-at-staging-path collisions
> - Risk: full-image staging now returns an error instead of truncating when the temp path already exists; any caller expecting silent overwrite behavior will receive an error
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91e2d5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
