### PR TITLE
Preserve a lone settings recovery temp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 ### Fixed
 - Auto-paste now re-checks that the remembered target still has focus after the settle delay, and leaves the clip on the clipboard instead of synthesizing Ctrl+V if focus moved (SBS-1066)
 - Release `submit-store` now waits for `validate` before `msstore submission publish`, matching the GitHub undraft gate so a red or still-running cargo test / clippy / `release:check` cannot reach Partner Center (SBS-1068)
+- A Settings change no longer overwrites the only recoverable preferences file when an interrupted write could not be promoted (#303)
 - History bulk Copy now includes recognized text from selected images, including images whose full-resolution original has expired
 - Encrypted backup exports now flush a complete sibling temp file before replacing an existing backup, preserving the prior file on write or install failure (#189)
 - Flood-dropping a queued self-paste echo no longer leaves the ignore hash swallowing the next real copy of that content (SBS-1039)

--- a/src-tauri/src/settings_load.rs
+++ b/src-tauri/src/settings_load.rs
@@ -15,11 +15,43 @@
 //! on a Linux box that cannot compile the Windows crate.
 
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 /// Same sibling name `SettingsManager::save` writes before replace.
 pub fn settings_tmp_path(canonical: &Path) -> PathBuf {
     canonical.with_extension("json.tmp")
+}
+
+/// Write the next settings file without overwriting a lone recovery temp.
+/// When the canonical file exists it remains the fallback, so a stale temp is
+/// safe to replace. Without that file, an existing temp is the only disk copy
+/// of the user's preferences and must stay untouched.
+pub fn write_settings_temp(canonical: &Path, tmp: &Path, bytes: &[u8]) -> Result<(), String> {
+    if canonical.is_file() {
+        return fs::write(tmp, bytes).map_err(|error| error.to_string());
+    }
+
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(tmp)
+        .map_err(|error| {
+            if error.kind() == std::io::ErrorKind::AlreadyExists {
+                format!(
+                    "refusing to overwrite settings recovery temp {}",
+                    tmp.display()
+                )
+            } else {
+                error.to_string()
+            }
+        })?;
+    if let Err(error) = file.write_all(bytes) {
+        drop(file);
+        let _ = fs::remove_file(tmp);
+        return Err(error.to_string());
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -154,6 +186,38 @@ mod tests {
         let source = resolve_settings_disk_source(&canonical);
         assert_eq!(source, SettingsDiskSource::Missing);
         assert!(may_persist_first_run_defaults(source));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn later_save_does_not_overwrite_a_lone_recovery_temp() {
+        let dir = test_dir();
+        let canonical = dir.join("settings.json");
+        let tmp = settings_tmp_path(&canonical);
+        let recovered = b"{\"auto_delete_days\":0}";
+        fs::write(&tmp, recovered).unwrap();
+
+        let error = write_settings_temp(&canonical, &tmp, b"{\"auto_delete_days\":30}")
+            .expect_err("a lone recovery temp must not be overwritten");
+
+        assert!(error.contains("refusing to overwrite"));
+        assert_eq!(fs::read(&tmp).unwrap(), recovered);
+        assert!(!canonical.exists());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn stale_temp_can_be_rewritten_when_canonical_settings_exist() {
+        let dir = test_dir();
+        let canonical = dir.join("settings.json");
+        let tmp = settings_tmp_path(&canonical);
+        fs::write(&canonical, b"last-good-settings").unwrap();
+        fs::write(&tmp, b"stale-temp").unwrap();
+
+        write_settings_temp(&canonical, &tmp, b"next-settings").unwrap();
+
+        assert_eq!(fs::read(&canonical).unwrap(), b"last-good-settings");
+        assert_eq!(fs::read(&tmp).unwrap(), b"next-settings");
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/src-tauri/src/settings_manager.rs
+++ b/src-tauri/src/settings_manager.rs
@@ -2,7 +2,7 @@ use crate::database::Database;
 use crate::models::AppSettings;
 use crate::settings_load::{
     may_persist_first_run_defaults, promote_interrupted_tmp, recover_dest_gone_replace,
-    resolve_settings_disk_source, settings_tmp_path, SettingsDiskSource,
+    resolve_settings_disk_source, settings_tmp_path, write_settings_temp, SettingsDiskSource,
 };
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -380,7 +380,7 @@ impl SettingsManager {
         // every preference on the next launch).
         let mut lock = self.settings.write().unwrap();
         let tmp_path = settings_tmp_path(&self.file_path);
-        fs::write(&tmp_path, json).map_err(|e| e.to_string())?;
+        write_settings_temp(&self.file_path, &tmp_path, json.as_bytes())?;
         if let Err(error) = replace_file_atomically(&tmp_path, &self.file_path) {
             // On exFAT/FAT, replace is delete-the-target-then-rename. A failure
             // after the destination entry is gone leaves the temp holding the
@@ -715,6 +715,36 @@ mod tests {
             !path.exists(),
             "nothing may be written while the temp still holds the only copy"
         );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn save_after_failed_promote_leaves_the_only_copy_untouched() {
+        let dir =
+            std::env::temp_dir().join(format!("cubby-settings-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+        let tmp = settings_tmp_path(&path);
+        let recovered = AppSettings {
+            auto_delete_days: 0,
+            ..AppSettings::default()
+        };
+        let recovered_bytes = serde_json::to_string_pretty(&recovered).unwrap();
+        fs::write(&tmp, &recovered_bytes).unwrap();
+
+        let manager = manager_at(&path, recovered.clone());
+        let changed = AppSettings {
+            auto_delete_days: 30,
+            ..recovered.clone()
+        };
+        let error = manager
+            .save(changed)
+            .expect_err("save must refuse to overwrite the recovery temp");
+
+        assert!(error.contains("refusing to overwrite"));
+        assert_eq!(fs::read_to_string(&tmp).unwrap(), recovered_bytes);
+        assert!(!path.exists());
+        assert_eq!(manager.get().auto_delete_days, recovered.auto_delete_days);
         let _ = fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
Closes #303.

A later Settings save now refuses to overwrite `settings.json.tmp` when the canonical file is absent or not a file. A stale temp can still be rewritten when `settings.json` exists as the last-good copy.

Verified with Rust formatting, the 9 isolated settings recovery tests, and `pnpm run release:check`. Windows CI remains the authoritative full Rust check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistence of user preferences: a failed save now preserves the recovery temp instead of writing new settings, which is the intended data-loss fix but changes save behavior in that edge case.
> 
> **Overview**
> Stops a later Settings save from destroying the only remaining copy of user preferences when `settings.json` is missing and `settings.json.tmp` still holds a recovered write (#303).
> 
> `save` now goes through `write_settings_temp`: if the canonical file exists, a stale temp can still be rewritten; if it does not, the temp is opened with `create_new` so an existing recovery file is left untouched and a failed new write is deleted. The in-memory settings stay on the recovered values when that save errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8d35df44cdeec9ee7ac7325a5213e79c3f014ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve lone settings recovery temp by refusing overwrite in `write_settings_temp`
> Fixes a data-loss edge case where `SettingsManager.save` could overwrite the only remaining copy of user preferences — a lone temp file left behind after a failed atomic promote.
>
> - Adds `write_settings_temp` helper in [settings_load.rs](https://github.com/tsouth89/cubby-clipboard/pull/304/files#diff-208a2c2fe40666cd2616f2700d4f952813643d5e5214c181ce7c842173b320d8): if the canonical settings file exists, it writes the tmp normally (allowing stale tmp rewrite); if canonical is missing, it uses `create_new` so an existing tmp is left untouched and a newly created tmp is deleted on write failure.
> - `SettingsManager.save` in [settings_manager.rs](https://github.com/tsouth89/cubby-clipboard/pull/304/files#diff-0fe1d380aef3c89c137c8ece1edecc8544480537a8f82d52d8807d56ae9fbf3e) now calls `write_settings_temp` instead of a direct `fs::write` to the tmp path; the subsequent `replace_file_atomically` logic is unchanged.
> - Returns an error containing `refusing to overwrite settings recovery temp` when a lone tmp already exists.
> - Behavioral Change: when canonical settings are missing, `save` now errors instead of overwriting the lone tmp, preserving the only recoverable copy on disk and the in-memory recovered settings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8d35df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->