### PR TITLE
Clarify draft updater manifest behavior

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -54,7 +54,7 @@ Pick deliberately. They are not the same thing.
 | Tag | `draft-<sha>` | `v<version>`, must match all four version files |
 | GitHub release | draft prerelease, stays draft | published automatically at the end |
 | Release notes | a fixed "test build" line | awk-extracted from the `## v<version>` CHANGELOG section, which fails the build if missing |
-| `latest.json` | not assembled | assembled, so installed users auto-update |
+| `latest.json` | attached to the private draft for verification only | assembled and published, so installed users auto-update |
 | Microsoft Store | skipped | submitted **and** published when the flag is on |
 | Cleanup | deletes previous test-build drafts on the next dispatch | none; a leftover test draft has to be deleted by hand |
 


### PR DESCRIPTION
The release dispatch attaches latest.json to its private draft for verification. It does not publish that manifest to installed users.

Checks:
- pnpm run release:check
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change in the release checklist; no workflow or updater behavior is modified.
> 
> **Overview**
> Clarifies the release checklist: `workflow_dispatch` still attaches `latest.json` to the private draft for verification, but that path does not publish the updater manifest to installed users. Tag releases remain the path that publishes auto-updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5d0ef6be7ca50c9db7d63fc9f6e0da89c9b8fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify draft updater manifest behavior in `RELEASE_CHECKLIST.md`
> Updates the `latest.json` row of the release process comparison table in [RELEASE_CHECKLIST.md](https://github.com/tsouth89/cubby-clipboard/pull/306/files#diff-01a313e7e929db25ac2e0b129ffdc941def6ada896f29c12dfc1f38fee77a321). For test builds, changes the description from 'not assembled' to 'attached to the private draft for verification only'. For tagged releases, clarifies that the manifest is 'assembled and published'.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5d0ef6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->