### PR TITLE
Thank v1.3.3 contributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ All notable Cubby Clipboard changes are documented here. PastePaw entries below 
 - Settings and support copy no longer overstate remote hotkey behavior, remote relay privacy gates, copied-file retention, or encrypted-backup contents (SBS-776, SBS-832, SBS-1028, SBS-1049, SBS-1071)
 - Release checks now verify every Settings web link against the opener allowlist and keep generated capabilities in sync (SBS-1016)
 
+### Thanks
+- Thanks to [Harshvardhan Agrawal](https://github.com/harshvardhan60792) for expanding Settings and Win+V replacement test coverage (#270)
+
 ## v1.3.2
 
 ### Security


### PR DESCRIPTION
Adds the missing v1.3.3 acknowledgement for Harshvardhan Agrawal’s test contribution in #270.

Checked with `pnpm run release:check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only documentation change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Adds a **Thanks** note under v1.3.3 for Harshvardhan Agrawal’s Settings and Win+V replacement test coverage in #270. No code or behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28da4727d035eb6f282e92e41875bc45f92da39d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add contributor thanks entry to `CHANGELOG.md` for v1.3.3
> Adds a 'Thanks' subsection under the v1.3.3 release notes in [CHANGELOG.md](https://github.com/tsouth89/cubby-clipboard/pull/307/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) crediting Harshvardhan Agrawal for expanding Settings and Win+V replacement test coverage, referencing PR #270.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28da472.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->