### PR TITLE
Fix tagged release draft uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -372,14 +372,16 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ needs.create-release.outputs.tag }}
+          RELEASE_ID: ${{ needs.create-release.outputs.release_id }}
         run: |
           Copy-Item "${{ steps.installer.outputs.path }}" "${{ steps.installer.outputs.name }}"
           Copy-Item "${{ steps.store-installer.outputs.path }}" "${{ steps.store-installer.outputs.name }}"
-          gh release upload "$env:TAG" `
-            "${{ steps.installer.outputs.name }}" `
-            "${{ steps.store-installer.outputs.name }}" `
-            --clobber
+          ./scripts/upload-release-asset.ps1 `
+            -ReleaseId $env:RELEASE_ID `
+            -AssetPath @(
+              "${{ steps.installer.outputs.name }}",
+              "${{ steps.store-installer.outputs.name }}"
+            )
 
       - name: Re-sign the installer for the updater (over the signed bytes)
         shell: pwsh
@@ -397,9 +399,11 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ needs.create-release.outputs.tag }}
+          RELEASE_ID: ${{ needs.create-release.outputs.release_id }}
         run: |
-          gh release upload "$env:TAG" "${{ steps.installer.outputs.name }}.sig" --clobber
+          ./scripts/upload-release-asset.ps1 `
+            -ReleaseId $env:RELEASE_ID `
+            -AssetPath "${{ steps.installer.outputs.name }}.sig"
 
       - name: Publish Microsoft Store installer to Cloudflare R2
         if: github.event_name != 'workflow_dispatch'
@@ -490,12 +494,12 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ needs.create-release.outputs.tag }}
+          RELEASE_ID: ${{ needs.create-release.outputs.release_id }}
           VERSION: ${{ needs.create-release.outputs.version }}
         run: |
           $zip = "Cubby-Clipboard-Portable-$($env:VERSION)-x64.zip"
           Compress-Archive -Path "portable/*" -DestinationPath $zip -Force
-          gh release upload "$env:TAG" $zip --clobber
+          ./scripts/upload-release-asset.ps1 -ReleaseId $env:RELEASE_ID -AssetPath $zip
 
   updater-manifest:
     name: Assemble updater manifest
@@ -512,6 +516,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.create-release.outputs.release_id }}
           TAG: ${{ needs.create-release.outputs.tag }}
           VERSION: ${{ needs.create-release.outputs.version }}
         run: |
@@ -519,7 +524,24 @@ jobs:
           NAME_X64="Cubby.Clipboard_${VERSION}_x64-setup.exe"
           NAME_ARM="Cubby.Clipboard_${VERSION}_arm64-setup.exe"
           BASE="https://github.com/${REPO}/releases/download/${TAG}"
-          gh release download "$TAG" -R "$REPO" -p "${NAME_X64}.sig" -p "${NAME_ARM}.sig" -D sigs
+
+          download_asset() {
+            local name="$1"
+            local destination="$2"
+            local asset_id
+            asset_id=$(gh api "repos/${REPO}/releases/${RELEASE_ID}/assets?per_page=100" \
+              --jq ".[] | select(.name == \"${name}\") | .id")
+            if [ -z "$asset_id" ] || [[ "$asset_id" == *$'\n'* ]]; then
+              echo "Expected exactly one release asset named ${name}"
+              exit 1
+            fi
+            gh api "repos/${REPO}/releases/assets/${asset_id}" \
+              -H "Accept: application/octet-stream" > "$destination"
+          }
+
+          mkdir -p sigs
+          download_asset "${NAME_X64}.sig" "sigs/${NAME_X64}.sig"
+          download_asset "${NAME_ARM}.sig" "sigs/${NAME_ARM}.sig"
           SIG_X64=$(cat "sigs/${NAME_X64}.sig")
           SIG_ARM=$(cat "sigs/${NAME_ARM}.sig")
           PUB_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -529,7 +551,21 @@ jobs:
             --arg sa "$SIG_ARM" --arg ua "${BASE}/${NAME_ARM}" \
             '{version:$v, pub_date:$d, platforms:{"windows-x86_64":{signature:$sx,url:$ux},"windows-aarch64":{signature:$sa,url:$ua}}}' \
             > latest.json
-          gh release upload "$TAG" latest.json --clobber
+
+          existing_id=$(gh api "repos/${REPO}/releases/${RELEASE_ID}/assets?per_page=100" \
+            --jq '.[] | select(.name == "latest.json") | .id')
+          if [ -n "$existing_id" ]; then
+            gh api "repos/${REPO}/releases/assets/${existing_id}" --method DELETE --silent
+          fi
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            --header "Content-Type: application/octet-stream" \
+            --data-binary @latest.json \
+            "https://uploads.github.com/repos/${REPO}/releases/${RELEASE_ID}/assets?name=latest.json" \
+            > /dev/null
 
   submit-store:
     name: Submit Microsoft Store update
@@ -640,6 +676,9 @@ jobs:
       - name: Publish release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ needs.create-release.outputs.tag }}
-        # -R is required: this job has no checkout, so gh has no git context.
-        run: gh release edit "$RELEASE_TAG" -R ${{ github.repository }} --draft=false
+          RELEASE_ID: ${{ needs.create-release.outputs.release_id }}
+        run: |
+          gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}" \
+            --method PATCH \
+            -F draft=false \
+            --silent

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -50,6 +50,7 @@ const [
   verifyInstallerSignature,
   libSource,
   logTargetsSource,
+  releaseAssetUploader,
 ] = await Promise.all([
   read('package.json'),
   read('src-tauri/tauri.conf.json'),
@@ -75,6 +76,7 @@ const [
   read('scripts/verify-installer-signature.ps1'),
   read('src-tauri/src/lib.rs'),
   read('src-tauri/src/log_targets.rs'),
+  read('scripts/upload-release-asset.ps1'),
 ]);
 
 const packageVersion = JSON.parse(packageText).version;
@@ -155,6 +157,25 @@ if (jobNeeds(createReleaseJob, 'validate')) {
   throw new Error(
     'create-release must stay independent of validate so the draft release can be created in parallel'
   );
+}
+
+// A real release draft uses the same name as its existing Git tag. GitHub's
+// tag-based release commands cannot resolve that private draft, so every asset
+// operation and the final publish must use create-release's numeric ID.
+if (/\bgh release (?:upload|download|edit)\b/.test(releaseWorkflow)) {
+  throw new Error('Release workflow must address private drafts by release ID, not tag');
+}
+if (!releaseWorkflow.includes('needs.create-release.outputs.release_id')) {
+  throw new Error('Release workflow must pass create-release release_id to draft consumers');
+}
+for (const requiredUploadGate of [
+  'https://uploads.github.com/repos/',
+  '/releases/$ReleaseId/assets?name=',
+  'application/octet-stream',
+]) {
+  if (!releaseAssetUploader.includes(requiredUploadGate)) {
+    throw new Error(`Release asset uploader is missing: ${requiredUploadGate}`);
+  }
 }
 
 // SBS-777: a signed outer Store installer is not enough. Publication and

--- a/scripts/upload-release-asset.ps1
+++ b/scripts/upload-release-asset.ps1
@@ -1,0 +1,45 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [long]$ReleaseId,
+
+    [Parameter(Mandatory = $true)]
+    [string[]]$AssetPath
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+if ([string]::IsNullOrWhiteSpace($env:GITHUB_REPOSITORY)) {
+    throw "GITHUB_REPOSITORY is required."
+}
+if ([string]::IsNullOrWhiteSpace($env:GH_TOKEN)) {
+    throw "GH_TOKEN is required."
+}
+
+$apiHeaders = @{
+    Accept                 = "application/vnd.github+json"
+    Authorization          = "Bearer $env:GH_TOKEN"
+    "X-GitHub-Api-Version" = "2022-11-28"
+}
+$assetListUri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/$ReleaseId/assets?per_page=100"
+
+foreach ($pathValue in $AssetPath) {
+    $file = Get-Item -LiteralPath $pathValue
+    $assets = @(Invoke-RestMethod -Uri $assetListUri -Headers $apiHeaders)
+
+    foreach ($asset in $assets | Where-Object { $_.name -eq $file.Name }) {
+        $deleteUri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/assets/$($asset.id)"
+        Invoke-RestMethod -Uri $deleteUri -Method Delete -Headers $apiHeaders | Out-Null
+    }
+
+    $encodedName = [Uri]::EscapeDataString($file.Name)
+    $uploadUri = "https://uploads.github.com/repos/$env:GITHUB_REPOSITORY/releases/$ReleaseId/assets?name=$encodedName"
+    Invoke-RestMethod `
+        -Uri $uploadUri `
+        -Method Post `
+        -Headers $apiHeaders `
+        -ContentType "application/octet-stream" `
+        -InFile $file.FullName | Out-Null
+
+    Write-Host "Uploaded $($file.Name) to release $ReleaseId."
+}


### PR DESCRIPTION
The v1.3.3 tag build produced and signed both installers, then failed because tag-based GitHub CLI commands could not resolve the private draft.

Use the draft release ID for asset upload, signature download, and publication. Add a release gate so the tag-based commands cannot return.

Verified with `release:check`, workflow checks, all 181 frontend tests, and live upload/download probes against private drafts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production release pipeline (asset upload, updater signatures, undraft). A bug here can fail or mis-publish GitHub releases, but it does not change app or auth code.
> 
> **Overview**
> Fixes tagged GitHub releases failing after signing because `gh release upload/download/edit` cannot resolve a **private draft that shares its Git tag**.
> 
> Asset upload, updater `.sig` download, `latest.json` replace, and undraft now use `create-release`'s numeric `release_id` via the GitHub API. A new `upload-release-asset.ps1` deletes any same-named asset then POSTs to `uploads.github.com`. `release:check` forbids tag-based `gh release` commands in the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a09aa34dfa6ae1b7450cfe0e98d2de097242d6cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix tagged release draft uploads by switching to numeric release ID API calls
> - All release asset upload, download, and publish steps in [.github/workflows/release.yml](https://github.com/tsouth89/cubby-clipboard/pull/308/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34) now address the draft release by its numeric `RELEASE_ID` instead of the git tag, replacing `gh release upload/download/edit` with direct `gh api` calls
> - Adds [scripts/upload-release-asset.ps1](https://github.com/tsouth89/cubby-clipboard/pull/308/files#diff-58afd6191f9fcfb2596c1a47dded0ceec9f11ef7dfaface0c197d3ac74ef1b89), a PowerShell uploader that deletes existing same-name assets then uploads via the GitHub uploads API with `application/octet-stream`
> - Extends [scripts/check-release.mjs](https://github.com/tsouth89/cubby-clipboard/pull/308/files#diff-14ac66f5d0a1f9e003460f1b27bce6e68f7665390d99e23d897038130d21cdca) to fail if the workflow still uses tag-based `gh release` commands or omits the `release_id` output
> - Risk: the updater manifest step now downloads assets by name via ID lookup and deletes/re-creates `latest.json` through the API; if the asset name query returns multiple matches, the download could target the wrong asset
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a09aa34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->