### PR TITLE
Handle an empty release asset list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Embedded installer signature rules
         shell: pwsh
         run: ./scripts/test-verify-installer-signature.ps1
+      - name: Release asset upload rules
+        shell: pwsh
+        run: ./scripts/test-upload-release-asset.ps1
       # Compiling cargo-audit from source took 5m55s of a 9m17s job, to then run
       # for 7 seconds. Cache the built binary instead. The key pins the exact
       # version, so the only way to get a stale tool is to change the pin, which

--- a/scripts/test-upload-release-asset.ps1
+++ b/scripts/test-upload-release-asset.ps1
@@ -1,0 +1,62 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$previousRepository = $env:GITHUB_REPOSITORY
+$previousToken = $env:GH_TOKEN
+$assetFile = New-TemporaryFile
+$script:requests = [System.Collections.Generic.List[object]]::new()
+
+function Invoke-RestMethod {
+    param(
+        [Parameter(Mandatory = $true)]
+        [Uri]$Uri,
+
+        [string]$Method,
+        [hashtable]$Headers,
+        [string]$ContentType,
+        [string]$InFile
+    )
+
+    $script:requests.Add([pscustomobject]@{
+        Uri         = $Uri
+        Method      = $Method
+        ContentType = $ContentType
+        InFile      = $InFile
+    })
+
+    if ($Uri.Host -eq "api.github.com") {
+        return @()
+    }
+    if ($Uri.Host -eq "uploads.github.com") {
+        return [pscustomobject]@{ id = 123 }
+    }
+
+    throw "Unexpected request to $Uri"
+}
+
+try {
+    Set-Content -LiteralPath $assetFile -Value "x" -NoNewline
+    $env:GITHUB_REPOSITORY = "tsouth89/cubby-clipboard"
+    $env:GH_TOKEN = "test-token"
+
+    ./scripts/upload-release-asset.ps1 -ReleaseId 42 -AssetPath $assetFile
+
+    if ($script:requests.Count -ne 2) {
+        throw "Expected an empty asset-list request followed by one upload, got $($script:requests.Count) requests."
+    }
+    if ($script:requests[0].Uri.AbsoluteUri -ne "https://api.github.com/repos/tsouth89/cubby-clipboard/releases/42/assets?per_page=100") {
+        throw "The helper did not list assets by release ID."
+    }
+    if ($script:requests[1].Uri.Host -ne "uploads.github.com") {
+        throw "The helper did not use GitHub's release upload host."
+    }
+    if ($script:requests[1].ContentType -ne "application/octet-stream") {
+        throw "The helper did not upload the asset as binary data."
+    }
+
+    Write-Host "Release asset upload handles a new draft with no existing assets."
+} finally {
+    $env:GITHUB_REPOSITORY = $previousRepository
+    $env:GH_TOKEN = $previousToken
+    Remove-Item -LiteralPath $assetFile -Force
+}

--- a/scripts/test-upload-release-asset.ps1
+++ b/scripts/test-upload-release-asset.ps1
@@ -4,7 +4,7 @@ Set-StrictMode -Version Latest
 $previousRepository = $env:GITHUB_REPOSITORY
 $previousToken = $env:GH_TOKEN
 $assetFile = New-TemporaryFile
-$script:requests = [System.Collections.Generic.List[object]]::new()
+$global:uploadRequests = [System.Collections.Generic.List[object]]::new()
 
 function Invoke-RestMethod {
     param(
@@ -17,7 +17,7 @@ function Invoke-RestMethod {
         [string]$InFile
     )
 
-    $script:requests.Add([pscustomobject]@{
+    $global:uploadRequests.Add([pscustomobject]@{
         Uri         = $Uri
         Method      = $Method
         ContentType = $ContentType
@@ -41,16 +41,16 @@ try {
 
     ./scripts/upload-release-asset.ps1 -ReleaseId 42 -AssetPath $assetFile
 
-    if ($script:requests.Count -ne 2) {
-        throw "Expected an empty asset-list request followed by one upload, got $($script:requests.Count) requests."
+    if ($global:uploadRequests.Count -ne 2) {
+        throw "Expected an empty asset-list request followed by one upload, got $($global:uploadRequests.Count) requests."
     }
-    if ($script:requests[0].Uri.AbsoluteUri -ne "https://api.github.com/repos/tsouth89/cubby-clipboard/releases/42/assets?per_page=100") {
+    if ($global:uploadRequests[0].Uri.AbsoluteUri -ne "https://api.github.com/repos/tsouth89/cubby-clipboard/releases/42/assets?per_page=100") {
         throw "The helper did not list assets by release ID."
     }
-    if ($script:requests[1].Uri.Host -ne "uploads.github.com") {
+    if ($global:uploadRequests[1].Uri.Host -ne "uploads.github.com") {
         throw "The helper did not use GitHub's release upload host."
     }
-    if ($script:requests[1].ContentType -ne "application/octet-stream") {
+    if ($global:uploadRequests[1].ContentType -ne "application/octet-stream") {
         throw "The helper did not upload the asset as binary data."
     }
 
@@ -58,5 +58,6 @@ try {
 } finally {
     $env:GITHUB_REPOSITORY = $previousRepository
     $env:GH_TOKEN = $previousToken
+    Remove-Variable -Name uploadRequests -Scope Global -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath $assetFile -Force
 }

--- a/scripts/upload-release-asset.ps1
+++ b/scripts/upload-release-asset.ps1
@@ -25,7 +25,7 @@ $assetListUri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/$R
 
 foreach ($pathValue in $AssetPath) {
     $file = Get-Item -LiteralPath $pathValue
-    $assets = @(Invoke-RestMethod -Uri $assetListUri -Headers $apiHeaders)
+    $assets = @(Invoke-RestMethod -Uri $assetListUri -Headers $apiHeaders | Where-Object { $null -ne $_ })
 
     foreach ($asset in $assets | Where-Object { $_.name -eq $file.Name }) {
         $deleteUri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/assets/$($asset.id)"


### PR DESCRIPTION
The first release-ID upload failed because a brand-new draft returns an empty asset list. Filter the null PowerShell result before checking asset names.

Add a mocked Windows test for the exact first-upload case. Local release checks, YAML parsing, and all 181 frontend tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release-asset upload helper used in production release workflows. The change is a small null-filter plus a mocked test, so blast radius is limited but a regression would break installer uploads.
> 
> **Overview**
> Fixes first-time GitHub release uploads when a new draft has no assets. PowerShell was treating a null API result as a real item, then failing when it tried to read `.name`.
> 
> `upload-release-asset.ps1` now drops null entries from the asset list before matching names. A mocked Windows test covers that empty-list path (list then binary upload) and is wired into CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 264c27fc26c853ae0e950b86bb6f546a32ac5a83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle empty release asset list in `upload-release-asset.ps1`
> - Filters null entries from the asset listing result in [upload-release-asset.ps1](https://github.com/tsouth89/cubby-clipboard/pull/309/files#diff-58afd6191f9fcfb2596c1a47dded0ceec9f11ef7dfaface0c197d3ac74ef1b89) so an empty or partially-null response no longer breaks the upload flow
> - Adds [test-upload-release-asset.ps1](https://github.com/tsouth89/cubby-clipboard/pull/309/files#diff-a9d06bb8ace5771e1b7584d71095f8dd42aef4331767fcaa26d7f7650ca35498), which stubs `Invoke-RestMethod` to verify the list-then-upload sequence uses the correct hosts and content type
> - Runs the new test script in the CI test job via a PowerShell step in [ci.yml](https://github.com/tsouth89/cubby-clipboard/pull/309/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 264c27f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->