### PR TITLE
Handle GitHub's empty draft asset shape

### DIFF
--- a/scripts/test-upload-release-asset.ps1
+++ b/scripts/test-upload-release-asset.ps1
@@ -25,7 +25,9 @@ function Invoke-RestMethod {
     })
 
     if ($Uri.Host -eq "api.github.com") {
-        return @()
+        # PowerShell can preserve an empty JSON array as an object with no
+        # `name` property instead of returning $null.
+        return [pscustomobject]@{}
     }
     if ($Uri.Host -eq "uploads.github.com") {
         return [pscustomobject]@{ id = 123 }

--- a/scripts/upload-release-asset.ps1
+++ b/scripts/upload-release-asset.ps1
@@ -25,9 +25,16 @@ $assetListUri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/$R
 
 foreach ($pathValue in $AssetPath) {
     $file = Get-Item -LiteralPath $pathValue
-    $assets = @(Invoke-RestMethod -Uri $assetListUri -Headers $apiHeaders | Where-Object { $null -ne $_ })
+    $assets = @(Invoke-RestMethod -Uri $assetListUri -Headers $apiHeaders)
 
-    foreach ($asset in $assets | Where-Object { $_.name -eq $file.Name }) {
+    foreach ($asset in $assets) {
+        if ($null -eq $asset) {
+            continue
+        }
+        $nameProperty = $asset.PSObject.Properties["name"]
+        if ($null -eq $nameProperty -or $nameProperty.Value -ne $file.Name) {
+            continue
+        }
         $deleteUri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/assets/$($asset.id)"
         Invoke-RestMethod -Uri $deleteUri -Method Delete -Headers $apiHeaders | Out-Null
     }


### PR DESCRIPTION
GitHub returns a nameless empty-array object for a new draft’s asset list. Ignore nameless entries before matching existing asset names.

Verified with the Windows regression test and a live PowerShell upload to the private v1.3.3 draft. The 25 KB probe uploaded successfully and was deleted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small PowerShell parsing fix in the release upload helper; no auth or payload changes, only how empty GitHub asset lists are skipped.
> 
> **Overview**
> Fixes release asset upload on new GitHub drafts, where PowerShell can turn an empty asset list into a nameless object instead of `$null`.
> 
> `upload-release-asset.ps1` now skips null and nameless entries before matching by `name` and deleting a prior asset. The Windows regression test mocks that empty-object shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fe5afab3ab64f344e958da8664feab3456fb1be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix asset deletion to handle GitHub's empty draft asset shape
> - Updates the mocked `Invoke-RestMethod` in [test-upload-release-asset.ps1](https://github.com/tsouth89/cubby-clipboard/pull/310/files#diff-a9d06bb8ace5771e1b7584d71095f8dd42aef4331767fcaa26d7f7650ca35498) to return an empty `PSCustomObject` instead of an empty array, matching how PowerShell may represent an empty JSON array from `api.github.com`
> - Rewrites the asset enumeration loop in [upload-release-asset.ps1](https://github.com/tsouth89/cubby-clipboard/pull/310/files#diff-58afd6191f9fcfb2596c1a47dded0ceec9f11ef7dfaface0c197d3ac74ef1b89) to skip null entries and only delete assets whose `name` property exists and matches the target file name
> - Risk: the deletion loop now relies on `$asset.PSObject.Properties["name"]` checks; any asset object type that does not expose `PSObject.Properties` could be silently skipped
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2fe5afa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->